### PR TITLE
Fix missing vote value

### DIFF
--- a/2013/20131121__tn__special__general__precinct.csv
+++ b/2013/20131121__tn__special__general__precinct.csv
@@ -20,7 +20,7 @@ shelby,Memphis47,State House,91,D,James "Jim" Tomasik,6
 shelby,Memphis48,State House,91,D,Raumesh A. Akbari,111
 shelby,Memphis48,State House,91,D,James "Jim" Tomasik,7
 shelby,Memphis49,State House,91,D,Raumesh A. Akbari,292
-shelby,Memphis49,State House,91,D,James "Jim" Tomasik1-
+shelby,Memphis49,State House,91,D,James "Jim" Tomasik,10
 shelby,Memphis50-2,State House,91,D,Raumesh A. Akbari,0
 shelby,Memphis50-2,State House,91,D,James "Jim" Tomasik,0
 shelby,Memphis58-4,State House,91,D,Raumesh A. Akbari,77


### PR DESCRIPTION
According to the [file](https://www.shelbyvote.com/sites/default/files/documents/elections/2013/Special%20State%20General%20and%20Municipal%20Referendum%2011.21.13/2013%20Nov%2021%20GEMS%20SOVC%20REPORT.pdf) on the [Shelby County Election Commission site](https://www.shelbyvote.com/elections/special-state-general-and-municipal-referendum-11212013), James "Jim" Tomasik received 10 votes in the Memphis49 precinct.

![image](https://user-images.githubusercontent.com/17345532/122442404-65acf100-cf53-11eb-934a-2bbd5658f6eb.png)
