### PR TITLE
Bump data tests to version 1.1.0

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -29,11 +29,11 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-data-tests
-        ref: v1.0.0
+        ref: v1.1.0
         path: data_tests
 
     - name: Run data tests
-      run: python3 ${{ github.workspace }}/data_tests/run_tests.py --log-file=${{ env.LOG_FILE }} ${{ matrix.test }} ${{ github.workspace }}/data
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py --group-failures --log-file=${{ env.LOG_FILE }} ${{ matrix.test }} ${{ github.workspace }}/data
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2.2.4


### PR DESCRIPTION
This bumps the data tests to [version 1.1.0](https://github.com/openelections/openelections-data-tests/releases/tag/v1.1.0).