### PR TITLE
Add 2025 TN U.S. House District 7 special primary & general results

### DIFF
--- a/2025/20251007__tn__special__primary__county.csv
+++ b/2025/20251007__tn__special__primary__county.csv
@@ -1,0 +1,211 @@
+county,office,district,party,candidate,votes
+Benton,U.S. House,7,Democratic,Aftyn Behn,36
+Benton,U.S. House,7,Democratic,Bo Mitchell,65
+Benton,U.S. House,7,Democratic,Darden Hunter Copeland,68
+Benton,U.S. House,7,Democratic,Vincent Dixie,2
+Benton,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Benton,U.S. House,7,Republican,Gino Bulso,123
+Benton,U.S. House,7,Republican,Jason D. Knight,1
+Benton,U.S. House,7,Republican,Jody Barrett,132
+Benton,U.S. House,7,Republican,Joe Leurs,0
+Benton,U.S. House,7,Republican,Lee Reeves,17
+Benton,U.S. House,7,Republican,Mason Foley,11
+Benton,U.S. House,7,Republican,Matt Van Epps,336
+Benton,U.S. House,7,Republican,Stewart Parks,25
+Benton,U.S. House,7,Republican,Stuart Cooper,4
+Benton,U.S. House,7,Republican,Tres Wittum,2
+Cheatham,U.S. House,7,Democratic,Aftyn Behn,397
+Cheatham,U.S. House,7,Democratic,Bo Mitchell,601
+Cheatham,U.S. House,7,Democratic,Darden Hunter Copeland,512
+Cheatham,U.S. House,7,Democratic,Vincent Dixie,98
+Cheatham,U.S. House,7,Republican,Adolph Agbéko Dagan,7
+Cheatham,U.S. House,7,Republican,Gino Bulso,234
+Cheatham,U.S. House,7,Republican,Jason D. Knight,26
+Cheatham,U.S. House,7,Republican,Jody Barrett,681
+Cheatham,U.S. House,7,Republican,Joe Leurs,17
+Cheatham,U.S. House,7,Republican,Lee Reeves,116
+Cheatham,U.S. House,7,Republican,Mason Foley,90
+Cheatham,U.S. House,7,Republican,Matt Van Epps,1695
+Cheatham,U.S. House,7,Republican,Stewart Parks,42
+Cheatham,U.S. House,7,Republican,Stuart Cooper,14
+Cheatham,U.S. House,7,Republican,Tres Wittum,13
+Davidson,U.S. House,7,Democratic,Aftyn Behn,3919
+Davidson,U.S. House,7,Democratic,Bo Mitchell,2920
+Davidson,U.S. House,7,Democratic,Darden Hunter Copeland,1856
+Davidson,U.S. House,7,Democratic,Vincent Dixie,5110
+Davidson,U.S. House,7,Republican,Adolph Agbéko Dagan,20
+Davidson,U.S. House,7,Republican,Gino Bulso,318
+Davidson,U.S. House,7,Republican,Jason D. Knight,34
+Davidson,U.S. House,7,Republican,Jody Barrett,474
+Davidson,U.S. House,7,Republican,Joe Leurs,14
+Davidson,U.S. House,7,Republican,Lee Reeves,158
+Davidson,U.S. House,7,Republican,Mason Foley,130
+Davidson,U.S. House,7,Republican,Matt Van Epps,1359
+Davidson,U.S. House,7,Republican,Stewart Parks,52
+Davidson,U.S. House,7,Republican,Stuart Cooper,25
+Davidson,U.S. House,7,Republican,Tres Wittum,24
+Decatur,U.S. House,7,Democratic,Aftyn Behn,19
+Decatur,U.S. House,7,Democratic,Bo Mitchell,118
+Decatur,U.S. House,7,Democratic,Darden Hunter Copeland,75
+Decatur,U.S. House,7,Democratic,Vincent Dixie,3
+Decatur,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Decatur,U.S. House,7,Republican,Gino Bulso,72
+Decatur,U.S. House,7,Republican,Jason D. Knight,10
+Decatur,U.S. House,7,Republican,Jody Barrett,120
+Decatur,U.S. House,7,Republican,Joe Leurs,1
+Decatur,U.S. House,7,Republican,Lee Reeves,27
+Decatur,U.S. House,7,Republican,Mason Foley,6
+Decatur,U.S. House,7,Republican,Matt Van Epps,427
+Decatur,U.S. House,7,Republican,Stewart Parks,58
+Decatur,U.S. House,7,Republican,Stuart Cooper,7
+Decatur,U.S. House,7,Republican,Tres Wittum,4
+Dickson,U.S. House,7,Democratic,Aftyn Behn,376
+Dickson,U.S. House,7,Democratic,Bo Mitchell,684
+Dickson,U.S. House,7,Democratic,Darden Hunter Copeland,400
+Dickson,U.S. House,7,Democratic,Vincent Dixie,53
+Dickson,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Dickson,U.S. House,7,Republican,Gino Bulso,256
+Dickson,U.S. House,7,Republican,Jason D. Knight,6
+Dickson,U.S. House,7,Republican,Jody Barrett,2201
+Dickson,U.S. House,7,Republican,Joe Leurs,7
+Dickson,U.S. House,7,Republican,Lee Reeves,124
+Dickson,U.S. House,7,Republican,Mason Foley,32
+Dickson,U.S. House,7,Republican,Matt Van Epps,1504
+Dickson,U.S. House,7,Republican,Stewart Parks,29
+Dickson,U.S. House,7,Republican,Stuart Cooper,11
+Dickson,U.S. House,7,Republican,Tres Wittum,5
+Hickman,U.S. House,7,Democratic,Aftyn Behn,57
+Hickman,U.S. House,7,Democratic,Bo Mitchell,190
+Hickman,U.S. House,7,Democratic,Darden Hunter Copeland,164
+Hickman,U.S. House,7,Democratic,Vincent Dixie,16
+Hickman,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Hickman,U.S. House,7,Republican,Gino Bulso,199
+Hickman,U.S. House,7,Republican,Jason D. Knight,8
+Hickman,U.S. House,7,Republican,Jody Barrett,1041
+Hickman,U.S. House,7,Republican,Joe Leurs,4
+Hickman,U.S. House,7,Republican,Lee Reeves,59
+Hickman,U.S. House,7,Republican,Mason Foley,26
+Hickman,U.S. House,7,Republican,Matt Van Epps,567
+Hickman,U.S. House,7,Republican,Stewart Parks,54
+Hickman,U.S. House,7,Republican,Stuart Cooper,10
+Hickman,U.S. House,7,Republican,Tres Wittum,4
+Houston,U.S. House,7,Democratic,Aftyn Behn,56
+Houston,U.S. House,7,Democratic,Bo Mitchell,59
+Houston,U.S. House,7,Democratic,Darden Hunter Copeland,81
+Houston,U.S. House,7,Democratic,Vincent Dixie,6
+Houston,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Houston,U.S. House,7,Republican,Gino Bulso,214
+Houston,U.S. House,7,Republican,Jason D. Knight,3
+Houston,U.S. House,7,Republican,Jody Barrett,165
+Houston,U.S. House,7,Republican,Joe Leurs,2
+Houston,U.S. House,7,Republican,Lee Reeves,15
+Houston,U.S. House,7,Republican,Mason Foley,4
+Houston,U.S. House,7,Republican,Matt Van Epps,232
+Houston,U.S. House,7,Republican,Stewart Parks,23
+Houston,U.S. House,7,Republican,Stuart Cooper,9
+Houston,U.S. House,7,Republican,Tres Wittum,2
+Humphreys,U.S. House,7,Democratic,Aftyn Behn,81
+Humphreys,U.S. House,7,Democratic,Bo Mitchell,247
+Humphreys,U.S. House,7,Democratic,Darden Hunter Copeland,189
+Humphreys,U.S. House,7,Democratic,Vincent Dixie,18
+Humphreys,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Humphreys,U.S. House,7,Republican,Gino Bulso,146
+Humphreys,U.S. House,7,Republican,Jason D. Knight,6
+Humphreys,U.S. House,7,Republican,Jody Barrett,368
+Humphreys,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,U.S. House,7,Republican,Lee Reeves,48
+Humphreys,U.S. House,7,Republican,Mason Foley,31
+Humphreys,U.S. House,7,Republican,Matt Van Epps,568
+Humphreys,U.S. House,7,Republican,Stewart Parks,12
+Humphreys,U.S. House,7,Republican,Stuart Cooper,11
+Humphreys,U.S. House,7,Republican,Tres Wittum,2
+Montgomery,U.S. House,7,Democratic,Aftyn Behn,1931
+Montgomery,U.S. House,7,Democratic,Bo Mitchell,1216
+Montgomery,U.S. House,7,Democratic,Darden Hunter Copeland,2146
+Montgomery,U.S. House,7,Democratic,Vincent Dixie,1419
+Montgomery,U.S. House,7,Republican,Adolph Agbéko Dagan,24
+Montgomery,U.S. House,7,Republican,Gino Bulso,915
+Montgomery,U.S. House,7,Republican,Jason D. Knight,215
+Montgomery,U.S. House,7,Republican,Jody Barrett,1148
+Montgomery,U.S. House,7,Republican,Joe Leurs,50
+Montgomery,U.S. House,7,Republican,Lee Reeves,307
+Montgomery,U.S. House,7,Republican,Mason Foley,108
+Montgomery,U.S. House,7,Republican,Matt Van Epps,5837
+Montgomery,U.S. House,7,Republican,Stewart Parks,51
+Montgomery,U.S. House,7,Republican,Stuart Cooper,41
+Montgomery,U.S. House,7,Republican,Tres Wittum,33
+Perry,U.S. House,7,Democratic,Aftyn Behn,15
+Perry,U.S. House,7,Democratic,Bo Mitchell,106
+Perry,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Perry,U.S. House,7,Democratic,Vincent Dixie,2
+Perry,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Perry,U.S. House,7,Republican,Gino Bulso,61
+Perry,U.S. House,7,Republican,Jason D. Knight,4
+Perry,U.S. House,7,Republican,Jody Barrett,167
+Perry,U.S. House,7,Republican,Joe Leurs,0
+Perry,U.S. House,7,Republican,Lee Reeves,13
+Perry,U.S. House,7,Republican,Mason Foley,2
+Perry,U.S. House,7,Republican,Matt Van Epps,230
+Perry,U.S. House,7,Republican,Stewart Parks,18
+Perry,U.S. House,7,Republican,Stuart Cooper,3
+Perry,U.S. House,7,Republican,Tres Wittum,1
+Robertson,U.S. House,7,Democratic,Aftyn Behn,372
+Robertson,U.S. House,7,Democratic,Bo Mitchell,417
+Robertson,U.S. House,7,Democratic,Darden Hunter Copeland,678
+Robertson,U.S. House,7,Democratic,Vincent Dixie,140
+Robertson,U.S. House,7,Republican,Adolph Agbéko Dagan,8
+Robertson,U.S. House,7,Republican,Gino Bulso,503
+Robertson,U.S. House,7,Republican,Jason D. Knight,25
+Robertson,U.S. House,7,Republican,Jody Barrett,628
+Robertson,U.S. House,7,Republican,Joe Leurs,7
+Robertson,U.S. House,7,Republican,Lee Reeves,153
+Robertson,U.S. House,7,Republican,Mason Foley,141
+Robertson,U.S. House,7,Republican,Matt Van Epps,2810
+Robertson,U.S. House,7,Republican,Stewart Parks,69
+Robertson,U.S. House,7,Republican,Stuart Cooper,21
+Robertson,U.S. House,7,Republican,Tres Wittum,13
+Stewart,U.S. House,7,Democratic,Aftyn Behn,56
+Stewart,U.S. House,7,Democratic,Bo Mitchell,80
+Stewart,U.S. House,7,Democratic,Darden Hunter Copeland,174
+Stewart,U.S. House,7,Democratic,Vincent Dixie,14
+Stewart,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Stewart,U.S. House,7,Republican,Gino Bulso,164
+Stewart,U.S. House,7,Republican,Jason D. Knight,16
+Stewart,U.S. House,7,Republican,Jody Barrett,147
+Stewart,U.S. House,7,Republican,Joe Leurs,4
+Stewart,U.S. House,7,Republican,Lee Reeves,34
+Stewart,U.S. House,7,Republican,Mason Foley,6
+Stewart,U.S. House,7,Republican,Matt Van Epps,590
+Stewart,U.S. House,7,Republican,Stewart Parks,40
+Stewart,U.S. House,7,Republican,Stuart Cooper,2
+Stewart,U.S. House,7,Republican,Tres Wittum,2
+Wayne,U.S. House,7,Democratic,Aftyn Behn,15
+Wayne,U.S. House,7,Democratic,Bo Mitchell,56
+Wayne,U.S. House,7,Democratic,Darden Hunter Copeland,76
+Wayne,U.S. House,7,Democratic,Vincent Dixie,7
+Wayne,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,U.S. House,7,Republican,Gino Bulso,69
+Wayne,U.S. House,7,Republican,Jason D. Knight,2
+Wayne,U.S. House,7,Republican,Jody Barrett,268
+Wayne,U.S. House,7,Republican,Joe Leurs,0
+Wayne,U.S. House,7,Republican,Lee Reeves,30
+Wayne,U.S. House,7,Republican,Mason Foley,27
+Wayne,U.S. House,7,Republican,Matt Van Epps,457
+Wayne,U.S. House,7,Republican,Stewart Parks,40
+Wayne,U.S. House,7,Republican,Stuart Cooper,5
+Wayne,U.S. House,7,Republican,Tres Wittum,0
+Williamson,U.S. House,7,Democratic,Aftyn Behn,1323
+Williamson,U.S. House,7,Democratic,Bo Mitchell,739
+Williamson,U.S. House,7,Democratic,Darden Hunter Copeland,1264
+Williamson,U.S. House,7,Democratic,Vincent Dixie,265
+Williamson,U.S. House,7,Republican,Adolph Agbéko Dagan,23
+Williamson,U.S. House,7,Republican,Gino Bulso,731
+Williamson,U.S. House,7,Republican,Jason D. Knight,25
+Williamson,U.S. House,7,Republican,Jody Barrett,1797
+Williamson,U.S. House,7,Republican,Joe Leurs,16
+Williamson,U.S. House,7,Republican,Lee Reeves,828
+Williamson,U.S. House,7,Republican,Mason Foley,408
+Williamson,U.S. House,7,Republican,Matt Van Epps,2394
+Williamson,U.S. House,7,Republican,Stewart Parks,82
+Williamson,U.S. House,7,Republican,Stuart Cooper,76
+Williamson,U.S. House,7,Republican,Tres Wittum,28

--- a/2025/20251007__tn__special__primary__precinct.csv
+++ b/2025/20251007__tn__special__primary__precinct.csv
@@ -1,0 +1,3436 @@
+county,precinct,office,district,party,candidate,votes
+Benton,1 Holladay,U.S. House,7,Democratic,Aftyn Behn,7
+Benton,1 Holladay,U.S. House,7,Democratic,Bo Mitchell,21
+Benton,1 Holladay,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Benton,1 Holladay,U.S. House,7,Democratic,Vincent Dixie,1
+Benton,1 Holladay,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Benton,1 Holladay,U.S. House,7,Republican,Gino Bulso,31
+Benton,1 Holladay,U.S. House,7,Republican,Jason D. Knight,0
+Benton,1 Holladay,U.S. House,7,Republican,Jody Barrett,25
+Benton,1 Holladay,U.S. House,7,Republican,Joe Leurs,0
+Benton,1 Holladay,U.S. House,7,Republican,Lee Reeves,4
+Benton,1 Holladay,U.S. House,7,Republican,Mason Foley,2
+Benton,1 Holladay,U.S. House,7,Republican,Matt Van Epps,105
+Benton,1 Holladay,U.S. House,7,Republican,Stewart Parks,3
+Benton,1 Holladay,U.S. House,7,Republican,Stuart Cooper,1
+Benton,1 Holladay,U.S. House,7,Republican,Tres Wittum,0
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Aftyn Behn,9
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Bo Mitchell,20
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Darden Hunter Copeland,23
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Vincent Dixie,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Gino Bulso,36
+Benton,3 Camden City Hall,U.S. House,7,Republican,Jason D. Knight,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Jody Barrett,33
+Benton,3 Camden City Hall,U.S. House,7,Republican,Joe Leurs,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Lee Reeves,2
+Benton,3 Camden City Hall,U.S. House,7,Republican,Mason Foley,3
+Benton,3 Camden City Hall,U.S. House,7,Republican,Matt Van Epps,45
+Benton,3 Camden City Hall,U.S. House,7,Republican,Stewart Parks,9
+Benton,3 Camden City Hall,U.S. House,7,Republican,Stuart Cooper,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Tres Wittum,2
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Aftyn Behn,8
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Bo Mitchell,18
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Vincent Dixie,0
+Benton,4 Camden Elementary,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Benton,4 Camden Elementary,U.S. House,7,Republican,Gino Bulso,33
+Benton,4 Camden Elementary,U.S. House,7,Republican,Jason D. Knight,0
+Benton,4 Camden Elementary,U.S. House,7,Republican,Jody Barrett,40
+Benton,4 Camden Elementary,U.S. House,7,Republican,Joe Leurs,0
+Benton,4 Camden Elementary,U.S. House,7,Republican,Lee Reeves,4
+Benton,4 Camden Elementary,U.S. House,7,Republican,Mason Foley,4
+Benton,4 Camden Elementary,U.S. House,7,Republican,Matt Van Epps,82
+Benton,4 Camden Elementary,U.S. House,7,Republican,Stewart Parks,11
+Benton,4 Camden Elementary,U.S. House,7,Republican,Stuart Cooper,3
+Benton,4 Camden Elementary,U.S. House,7,Republican,Tres Wittum,0
+Benton,6 Big Sandy,U.S. House,7,Democratic,Aftyn Behn,12
+Benton,6 Big Sandy,U.S. House,7,Democratic,Bo Mitchell,6
+Benton,6 Big Sandy,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Benton,6 Big Sandy,U.S. House,7,Democratic,Vincent Dixie,1
+Benton,6 Big Sandy,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Benton,6 Big Sandy,U.S. House,7,Republican,Gino Bulso,23
+Benton,6 Big Sandy,U.S. House,7,Republican,Jason D. Knight,1
+Benton,6 Big Sandy,U.S. House,7,Republican,Jody Barrett,34
+Benton,6 Big Sandy,U.S. House,7,Republican,Joe Leurs,0
+Benton,6 Big Sandy,U.S. House,7,Republican,Lee Reeves,7
+Benton,6 Big Sandy,U.S. House,7,Republican,Mason Foley,2
+Benton,6 Big Sandy,U.S. House,7,Republican,Matt Van Epps,104
+Benton,6 Big Sandy,U.S. House,7,Republican,Stewart Parks,2
+Benton,6 Big Sandy,U.S. House,7,Republican,Stuart Cooper,0
+Benton,6 Big Sandy,U.S. House,7,Republican,Tres Wittum,0
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Aftyn Behn,78
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Bo Mitchell,81
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Darden Hunter Copeland,69
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Vincent Dixie,29
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Gino Bulso,35
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Jason D. Knight,9
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Jody Barrett,70
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Joe Leurs,1
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Lee Reeves,13
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Mason Foley,15
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Matt Van Epps,191
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Stewart Parks,10
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Stuart Cooper,4
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Aftyn Behn,44
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Bo Mitchell,67
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Darden Hunter Copeland,63
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Vincent Dixie,13
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Gino Bulso,41
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Jason D. Knight,5
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Jody Barrett,109
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Joe Leurs,6
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Lee Reeves,17
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Mason Foley,24
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Matt Van Epps,287
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Stewart Parks,2
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Stuart Cooper,0
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Aftyn Behn,43
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Bo Mitchell,60
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Darden Hunter Copeland,58
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Vincent Dixie,21
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Gino Bulso,48
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Jason D. Knight,6
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Jody Barrett,129
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Joe Leurs,2
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Lee Reeves,20
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Mason Foley,15
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Matt Van Epps,334
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Stewart Parks,15
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Stuart Cooper,3
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Tres Wittum,4
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Aftyn Behn,25
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Bo Mitchell,40
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Vincent Dixie,10
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Gino Bulso,18
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Jason D. Knight,1
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Jody Barrett,86
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Joe Leurs,2
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Lee Reeves,8
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Mason Foley,2
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Matt Van Epps,206
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Stewart Parks,0
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Stuart Cooper,2
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Aftyn Behn,26
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Bo Mitchell,28
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Darden Hunter Copeland,24
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Vincent Dixie,3
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Gino Bulso,17
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Jason D. Knight,0
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Jody Barrett,51
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Joe Leurs,0
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Lee Reeves,12
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Mason Foley,4
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Matt Van Epps,145
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Stewart Parks,6
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Stuart Cooper,0
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Tres Wittum,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Aftyn Behn,26
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Bo Mitchell,46
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Darden Hunter Copeland,28
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Vincent Dixie,10
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Gino Bulso,12
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Jason D. Knight,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Jody Barrett,37
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Joe Leurs,4
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Lee Reeves,7
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Mason Foley,4
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Matt Van Epps,100
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Stewart Parks,3
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Stuart Cooper,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Tres Wittum,0
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Aftyn Behn,44
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Bo Mitchell,101
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Darden Hunter Copeland,84
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Vincent Dixie,4
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Gino Bulso,26
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Jason D. Knight,0
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Jody Barrett,68
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Joe Leurs,0
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Lee Reeves,18
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Mason Foley,11
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Matt Van Epps,206
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Stewart Parks,5
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Stuart Cooper,1
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Aftyn Behn,111
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Bo Mitchell,178
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Darden Hunter Copeland,150
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Vincent Dixie,8
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Gino Bulso,37
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Jason D. Knight,3
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Jody Barrett,131
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Joe Leurs,2
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Lee Reeves,21
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Mason Foley,15
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Matt Van Epps,226
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Stewart Parks,1
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Stuart Cooper,2
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Tres Wittum,3
+Davidson,01-1,U.S. House,7,Democratic,Aftyn Behn,61
+Davidson,01-1,U.S. House,7,Democratic,Bo Mitchell,153
+Davidson,01-1,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Davidson,01-1,U.S. House,7,Democratic,Vincent Dixie,51
+Davidson,01-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-1,U.S. House,7,Republican,Gino Bulso,82
+Davidson,01-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-1,U.S. House,7,Republican,Jody Barrett,33
+Davidson,01-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-1,U.S. House,7,Republican,Lee Reeves,17
+Davidson,01-1,U.S. House,7,Republican,Mason Foley,10
+Davidson,01-1,U.S. House,7,Republican,Matt Van Epps,199
+Davidson,01-1,U.S. House,7,Republican,Stewart Parks,8
+Davidson,01-1,U.S. House,7,Republican,Stuart Cooper,2
+Davidson,01-1,U.S. House,7,Republican,Tres Wittum,4
+Davidson,01-2,U.S. House,7,Democratic,Aftyn Behn,26
+Davidson,01-2,U.S. House,7,Democratic,Bo Mitchell,53
+Davidson,01-2,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Davidson,01-2,U.S. House,7,Democratic,Vincent Dixie,9
+Davidson,01-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-2,U.S. House,7,Republican,Gino Bulso,23
+Davidson,01-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-2,U.S. House,7,Republican,Jody Barrett,18
+Davidson,01-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-2,U.S. House,7,Republican,Lee Reeves,5
+Davidson,01-2,U.S. House,7,Republican,Mason Foley,3
+Davidson,01-2,U.S. House,7,Republican,Matt Van Epps,38
+Davidson,01-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-3,U.S. House,7,Democratic,Aftyn Behn,24
+Davidson,01-3,U.S. House,7,Democratic,Bo Mitchell,31
+Davidson,01-3,U.S. House,7,Democratic,Darden Hunter Copeland,34
+Davidson,01-3,U.S. House,7,Democratic,Vincent Dixie,215
+Davidson,01-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-3,U.S. House,7,Republican,Gino Bulso,8
+Davidson,01-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-3,U.S. House,7,Republican,Jody Barrett,14
+Davidson,01-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-3,U.S. House,7,Republican,Lee Reeves,1
+Davidson,01-3,U.S. House,7,Republican,Mason Foley,2
+Davidson,01-3,U.S. House,7,Republican,Matt Van Epps,30
+Davidson,01-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,01-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-4,U.S. House,7,Democratic,Aftyn Behn,39
+Davidson,01-4,U.S. House,7,Democratic,Bo Mitchell,40
+Davidson,01-4,U.S. House,7,Democratic,Darden Hunter Copeland,32
+Davidson,01-4,U.S. House,7,Democratic,Vincent Dixie,209
+Davidson,01-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-4,U.S. House,7,Republican,Gino Bulso,9
+Davidson,01-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-4,U.S. House,7,Republican,Jody Barrett,8
+Davidson,01-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-4,U.S. House,7,Republican,Lee Reeves,2
+Davidson,01-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,01-4,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,01-4,U.S. House,7,Republican,Stewart Parks,1
+Davidson,01-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-5,U.S. House,7,Democratic,Aftyn Behn,44
+Davidson,01-5,U.S. House,7,Democratic,Bo Mitchell,40
+Davidson,01-5,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Davidson,01-5,U.S. House,7,Democratic,Vincent Dixie,225
+Davidson,01-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-5,U.S. House,7,Republican,Gino Bulso,1
+Davidson,01-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-5,U.S. House,7,Republican,Jody Barrett,3
+Davidson,01-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-5,U.S. House,7,Republican,Lee Reeves,2
+Davidson,01-5,U.S. House,7,Republican,Mason Foley,0
+Davidson,01-5,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,01-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-6,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,01-6,U.S. House,7,Democratic,Bo Mitchell,17
+Davidson,01-6,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Davidson,01-6,U.S. House,7,Democratic,Vincent Dixie,94
+Davidson,01-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-6,U.S. House,7,Republican,Gino Bulso,0
+Davidson,01-6,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-6,U.S. House,7,Republican,Jody Barrett,0
+Davidson,01-6,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-6,U.S. House,7,Republican,Lee Reeves,0
+Davidson,01-6,U.S. House,7,Republican,Mason Foley,0
+Davidson,01-6,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,01-6,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-6,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-6,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-7,U.S. House,7,Democratic,Aftyn Behn,97
+Davidson,01-7,U.S. House,7,Democratic,Bo Mitchell,65
+Davidson,01-7,U.S. House,7,Democratic,Darden Hunter Copeland,85
+Davidson,01-7,U.S. House,7,Democratic,Vincent Dixie,941
+Davidson,01-7,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-7,U.S. House,7,Republican,Gino Bulso,4
+Davidson,01-7,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-7,U.S. House,7,Republican,Jody Barrett,10
+Davidson,01-7,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-7,U.S. House,7,Republican,Lee Reeves,2
+Davidson,01-7,U.S. House,7,Republican,Mason Foley,1
+Davidson,01-7,U.S. House,7,Republican,Matt Van Epps,17
+Davidson,01-7,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-7,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,01-7,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-1,U.S. House,7,Democratic,Aftyn Behn,34
+Davidson,02-1,U.S. House,7,Democratic,Bo Mitchell,17
+Davidson,02-1,U.S. House,7,Democratic,Darden Hunter Copeland,23
+Davidson,02-1,U.S. House,7,Democratic,Vincent Dixie,112
+Davidson,02-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-1,U.S. House,7,Republican,Jody Barrett,2
+Davidson,02-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,02-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,02-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-1,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,02-1,U.S. House,7,Republican,Stewart Parks,2
+Davidson,02-1,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,02-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-2,U.S. House,7,Democratic,Aftyn Behn,46
+Davidson,02-2,U.S. House,7,Democratic,Bo Mitchell,28
+Davidson,02-2,U.S. House,7,Democratic,Darden Hunter Copeland,33
+Davidson,02-2,U.S. House,7,Democratic,Vincent Dixie,174
+Davidson,02-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-2,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-2,U.S. House,7,Republican,Jody Barrett,1
+Davidson,02-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,02-2,U.S. House,7,Republican,Lee Reeves,1
+Davidson,02-2,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-2,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,02-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-2,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,02-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-3,U.S. House,7,Democratic,Aftyn Behn,18
+Davidson,02-3,U.S. House,7,Democratic,Bo Mitchell,19
+Davidson,02-3,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Davidson,02-3,U.S. House,7,Democratic,Vincent Dixie,51
+Davidson,02-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-3,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-3,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,02-3,U.S. House,7,Republican,Jody Barrett,2
+Davidson,02-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,02-3,U.S. House,7,Republican,Lee Reeves,0
+Davidson,02-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-3,U.S. House,7,Republican,Matt Van Epps,1
+Davidson,02-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,02-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-4,U.S. House,7,Democratic,Aftyn Behn,75
+Davidson,02-4,U.S. House,7,Democratic,Bo Mitchell,33
+Davidson,02-4,U.S. House,7,Democratic,Darden Hunter Copeland,39
+Davidson,02-4,U.S. House,7,Democratic,Vincent Dixie,146
+Davidson,02-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-4,U.S. House,7,Republican,Gino Bulso,1
+Davidson,02-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-4,U.S. House,7,Republican,Jody Barrett,5
+Davidson,02-4,U.S. House,7,Republican,Joe Leurs,1
+Davidson,02-4,U.S. House,7,Republican,Lee Reeves,3
+Davidson,02-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-4,U.S. House,7,Republican,Matt Van Epps,6
+Davidson,02-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,02-4,U.S. House,7,Republican,Tres Wittum,1
+Davidson,02-5,U.S. House,7,Democratic,Aftyn Behn,96
+Davidson,02-5,U.S. House,7,Democratic,Bo Mitchell,73
+Davidson,02-5,U.S. House,7,Democratic,Darden Hunter Copeland,73
+Davidson,02-5,U.S. House,7,Democratic,Vincent Dixie,664
+Davidson,02-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-5,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-5,U.S. House,7,Republican,Jody Barrett,1
+Davidson,02-5,U.S. House,7,Republican,Joe Leurs,1
+Davidson,02-5,U.S. House,7,Republican,Lee Reeves,2
+Davidson,02-5,U.S. House,7,Republican,Mason Foley,2
+Davidson,02-5,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,02-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,02-5,U.S. House,7,Republican,Tres Wittum,1
+Davidson,03-1,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,03-1,U.S. House,7,Democratic,Bo Mitchell,0
+Davidson,03-1,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,03-1,U.S. House,7,Democratic,Vincent Dixie,0
+Davidson,03-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,03-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,03-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,03-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,03-1,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,03-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-2,U.S. House,7,Democratic,Aftyn Behn,139
+Davidson,03-2,U.S. House,7,Democratic,Bo Mitchell,62
+Davidson,03-2,U.S. House,7,Democratic,Darden Hunter Copeland,62
+Davidson,03-2,U.S. House,7,Democratic,Vincent Dixie,459
+Davidson,03-2,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,03-2,U.S. House,7,Republican,Gino Bulso,14
+Davidson,03-2,U.S. House,7,Republican,Jason D. Knight,4
+Davidson,03-2,U.S. House,7,Republican,Jody Barrett,21
+Davidson,03-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-2,U.S. House,7,Republican,Lee Reeves,4
+Davidson,03-2,U.S. House,7,Republican,Mason Foley,6
+Davidson,03-2,U.S. House,7,Republican,Matt Van Epps,41
+Davidson,03-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-3,U.S. House,7,Democratic,Aftyn Behn,7
+Davidson,03-3,U.S. House,7,Democratic,Bo Mitchell,9
+Davidson,03-3,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Davidson,03-3,U.S. House,7,Democratic,Vincent Dixie,11
+Davidson,03-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-3,U.S. House,7,Republican,Gino Bulso,1
+Davidson,03-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-3,U.S. House,7,Republican,Jody Barrett,2
+Davidson,03-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-3,U.S. House,7,Republican,Lee Reeves,4
+Davidson,03-3,U.S. House,7,Republican,Mason Foley,5
+Davidson,03-3,U.S. House,7,Republican,Matt Van Epps,8
+Davidson,03-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,03-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-5,U.S. House,7,Democratic,Aftyn Behn,43
+Davidson,03-5,U.S. House,7,Democratic,Bo Mitchell,18
+Davidson,03-5,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Davidson,03-5,U.S. House,7,Democratic,Vincent Dixie,22
+Davidson,03-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-5,U.S. House,7,Republican,Gino Bulso,2
+Davidson,03-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-5,U.S. House,7,Republican,Jody Barrett,8
+Davidson,03-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-5,U.S. House,7,Republican,Lee Reeves,1
+Davidson,03-5,U.S. House,7,Republican,Mason Foley,1
+Davidson,03-5,U.S. House,7,Republican,Matt Van Epps,28
+Davidson,03-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-6,U.S. House,7,Democratic,Aftyn Behn,24
+Davidson,03-6,U.S. House,7,Democratic,Bo Mitchell,19
+Davidson,03-6,U.S. House,7,Democratic,Darden Hunter Copeland,10
+Davidson,03-6,U.S. House,7,Democratic,Vincent Dixie,57
+Davidson,03-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-6,U.S. House,7,Republican,Gino Bulso,4
+Davidson,03-6,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-6,U.S. House,7,Republican,Jody Barrett,7
+Davidson,03-6,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-6,U.S. House,7,Republican,Lee Reeves,4
+Davidson,03-6,U.S. House,7,Republican,Mason Foley,4
+Davidson,03-6,U.S. House,7,Republican,Matt Van Epps,23
+Davidson,03-6,U.S. House,7,Republican,Stewart Parks,1
+Davidson,03-6,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-6,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-8,U.S. House,7,Democratic,Aftyn Behn,96
+Davidson,03-8,U.S. House,7,Democratic,Bo Mitchell,36
+Davidson,03-8,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Davidson,03-8,U.S. House,7,Democratic,Vincent Dixie,419
+Davidson,03-8,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Davidson,03-8,U.S. House,7,Republican,Gino Bulso,5
+Davidson,03-8,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,03-8,U.S. House,7,Republican,Jody Barrett,7
+Davidson,03-8,U.S. House,7,Republican,Joe Leurs,1
+Davidson,03-8,U.S. House,7,Republican,Lee Reeves,1
+Davidson,03-8,U.S. House,7,Republican,Mason Foley,3
+Davidson,03-8,U.S. House,7,Republican,Matt Van Epps,11
+Davidson,03-8,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-8,U.S. House,7,Republican,Stuart Cooper,4
+Davidson,03-8,U.S. House,7,Republican,Tres Wittum,0
+Davidson,05-1,U.S. House,7,Democratic,Aftyn Behn,6
+Davidson,05-1,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,05-1,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Davidson,05-1,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,05-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,05-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,05-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,05-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,05-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,05-1,U.S. House,7,Republican,Lee Reeves,2
+Davidson,05-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,05-1,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,05-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,05-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,05-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-2,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,10-2,U.S. House,7,Democratic,Bo Mitchell,17
+Davidson,10-2,U.S. House,7,Democratic,Darden Hunter Copeland,6
+Davidson,10-2,U.S. House,7,Democratic,Vincent Dixie,3
+Davidson,10-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,10-2,U.S. House,7,Republican,Gino Bulso,9
+Davidson,10-2,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,10-2,U.S. House,7,Republican,Jody Barrett,9
+Davidson,10-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,10-2,U.S. House,7,Republican,Lee Reeves,0
+Davidson,10-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,10-2,U.S. House,7,Republican,Matt Van Epps,30
+Davidson,10-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-2,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,10-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-3,U.S. House,7,Democratic,Aftyn Behn,17
+Davidson,10-3,U.S. House,7,Democratic,Bo Mitchell,46
+Davidson,10-3,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Davidson,10-3,U.S. House,7,Democratic,Vincent Dixie,5
+Davidson,10-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,10-3,U.S. House,7,Republican,Gino Bulso,10
+Davidson,10-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,10-3,U.S. House,7,Republican,Jody Barrett,18
+Davidson,10-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,10-3,U.S. House,7,Republican,Lee Reeves,5
+Davidson,10-3,U.S. House,7,Republican,Mason Foley,1
+Davidson,10-3,U.S. House,7,Republican,Matt Van Epps,64
+Davidson,10-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,10-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-7,U.S. House,7,Democratic,Aftyn Behn,1
+Davidson,10-7,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,10-7,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,10-7,U.S. House,7,Democratic,Vincent Dixie,4
+Davidson,10-7,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,10-7,U.S. House,7,Republican,Gino Bulso,0
+Davidson,10-7,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,10-7,U.S. House,7,Republican,Jody Barrett,0
+Davidson,10-7,U.S. House,7,Republican,Joe Leurs,0
+Davidson,10-7,U.S. House,7,Republican,Lee Reeves,0
+Davidson,10-7,U.S. House,7,Republican,Mason Foley,0
+Davidson,10-7,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,10-7,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-7,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,10-7,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-9,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,10-9,U.S. House,7,Democratic,Bo Mitchell,31
+Davidson,10-9,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Davidson,10-9,U.S. House,7,Democratic,Vincent Dixie,1
+Davidson,10-9,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,10-9,U.S. House,7,Republican,Gino Bulso,12
+Davidson,10-9,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,10-9,U.S. House,7,Republican,Jody Barrett,11
+Davidson,10-9,U.S. House,7,Republican,Joe Leurs,1
+Davidson,10-9,U.S. House,7,Republican,Lee Reeves,4
+Davidson,10-9,U.S. House,7,Republican,Mason Foley,2
+Davidson,10-9,U.S. House,7,Republican,Matt Van Epps,57
+Davidson,10-9,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-9,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,10-9,U.S. House,7,Republican,Tres Wittum,0
+Davidson,15-2,U.S. House,7,Democratic,Aftyn Behn,6
+Davidson,15-2,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,15-2,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Davidson,15-2,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,15-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,15-2,U.S. House,7,Republican,Gino Bulso,0
+Davidson,15-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,15-2,U.S. House,7,Republican,Jody Barrett,2
+Davidson,15-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,15-2,U.S. House,7,Republican,Lee Reeves,0
+Davidson,15-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,15-2,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,15-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,15-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,15-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,16-1,U.S. House,7,Democratic,Aftyn Behn,21
+Davidson,16-1,U.S. House,7,Democratic,Bo Mitchell,6
+Davidson,16-1,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Davidson,16-1,U.S. House,7,Democratic,Vincent Dixie,4
+Davidson,16-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,16-1,U.S. House,7,Republican,Gino Bulso,1
+Davidson,16-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,16-1,U.S. House,7,Republican,Jody Barrett,3
+Davidson,16-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,16-1,U.S. House,7,Republican,Lee Reeves,3
+Davidson,16-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,16-1,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,16-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,16-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,16-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,16-3,U.S. House,7,Democratic,Aftyn Behn,10
+Davidson,16-3,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,16-3,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Davidson,16-3,U.S. House,7,Democratic,Vincent Dixie,0
+Davidson,16-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,16-3,U.S. House,7,Republican,Gino Bulso,0
+Davidson,16-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,16-3,U.S. House,7,Republican,Jody Barrett,0
+Davidson,16-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,16-3,U.S. House,7,Republican,Lee Reeves,0
+Davidson,16-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,16-3,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,16-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,16-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,16-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-1,U.S. House,7,Democratic,Aftyn Behn,67
+Davidson,17-1,U.S. House,7,Democratic,Bo Mitchell,30
+Davidson,17-1,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Davidson,17-1,U.S. House,7,Democratic,Vincent Dixie,32
+Davidson,17-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,17-1,U.S. House,7,Republican,Gino Bulso,3
+Davidson,17-1,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-1,U.S. House,7,Republican,Jody Barrett,12
+Davidson,17-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-1,U.S. House,7,Republican,Lee Reeves,1
+Davidson,17-1,U.S. House,7,Republican,Mason Foley,2
+Davidson,17-1,U.S. House,7,Republican,Matt Van Epps,25
+Davidson,17-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,17-1,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,17-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-2,U.S. House,7,Democratic,Aftyn Behn,48
+Davidson,17-2,U.S. House,7,Democratic,Bo Mitchell,32
+Davidson,17-2,U.S. House,7,Democratic,Darden Hunter Copeland,29
+Davidson,17-2,U.S. House,7,Democratic,Vincent Dixie,32
+Davidson,17-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-2,U.S. House,7,Republican,Gino Bulso,0
+Davidson,17-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,17-2,U.S. House,7,Republican,Jody Barrett,4
+Davidson,17-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-2,U.S. House,7,Republican,Lee Reeves,2
+Davidson,17-2,U.S. House,7,Republican,Mason Foley,5
+Davidson,17-2,U.S. House,7,Republican,Matt Van Epps,5
+Davidson,17-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,17-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-3,U.S. House,7,Democratic,Aftyn Behn,12
+Davidson,17-3,U.S. House,7,Democratic,Bo Mitchell,7
+Davidson,17-3,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Davidson,17-3,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,17-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-3,U.S. House,7,Republican,Gino Bulso,0
+Davidson,17-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,17-3,U.S. House,7,Republican,Jody Barrett,0
+Davidson,17-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-3,U.S. House,7,Republican,Lee Reeves,0
+Davidson,17-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-3,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,17-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,17-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-4,U.S. House,7,Democratic,Aftyn Behn,45
+Davidson,17-4,U.S. House,7,Democratic,Bo Mitchell,16
+Davidson,17-4,U.S. House,7,Democratic,Darden Hunter Copeland,15
+Davidson,17-4,U.S. House,7,Democratic,Vincent Dixie,18
+Davidson,17-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-4,U.S. House,7,Republican,Gino Bulso,1
+Davidson,17-4,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-4,U.S. House,7,Republican,Jody Barrett,0
+Davidson,17-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-4,U.S. House,7,Republican,Lee Reeves,2
+Davidson,17-4,U.S. House,7,Republican,Mason Foley,2
+Davidson,17-4,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,17-4,U.S. House,7,Republican,Stewart Parks,1
+Davidson,17-4,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,17-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-5,U.S. House,7,Democratic,Aftyn Behn,7
+Davidson,17-5,U.S. House,7,Democratic,Bo Mitchell,8
+Davidson,17-5,U.S. House,7,Democratic,Darden Hunter Copeland,20
+Davidson,17-5,U.S. House,7,Democratic,Vincent Dixie,13
+Davidson,17-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-5,U.S. House,7,Republican,Gino Bulso,2
+Davidson,17-5,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-5,U.S. House,7,Republican,Jody Barrett,6
+Davidson,17-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-5,U.S. House,7,Republican,Lee Reeves,1
+Davidson,17-5,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-5,U.S. House,7,Republican,Matt Van Epps,17
+Davidson,17-5,U.S. House,7,Republican,Stewart Parks,2
+Davidson,17-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-6,U.S. House,7,Democratic,Aftyn Behn,10
+Davidson,17-6,U.S. House,7,Democratic,Bo Mitchell,6
+Davidson,17-6,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Davidson,17-6,U.S. House,7,Democratic,Vincent Dixie,20
+Davidson,17-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-6,U.S. House,7,Republican,Gino Bulso,1
+Davidson,17-6,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,17-6,U.S. House,7,Republican,Jody Barrett,1
+Davidson,17-6,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-6,U.S. House,7,Republican,Lee Reeves,0
+Davidson,17-6,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-6,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,17-6,U.S. House,7,Republican,Stewart Parks,1
+Davidson,17-6,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-6,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-7,U.S. House,7,Democratic,Aftyn Behn,213
+Davidson,17-7,U.S. House,7,Democratic,Bo Mitchell,78
+Davidson,17-7,U.S. House,7,Democratic,Darden Hunter Copeland,150
+Davidson,17-7,U.S. House,7,Democratic,Vincent Dixie,68
+Davidson,17-7,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,17-7,U.S. House,7,Republican,Gino Bulso,5
+Davidson,17-7,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-7,U.S. House,7,Republican,Jody Barrett,15
+Davidson,17-7,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-7,U.S. House,7,Republican,Lee Reeves,0
+Davidson,17-7,U.S. House,7,Republican,Mason Foley,4
+Davidson,17-7,U.S. House,7,Republican,Matt Van Epps,43
+Davidson,17-7,U.S. House,7,Republican,Stewart Parks,0
+Davidson,17-7,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-7,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-8,U.S. House,7,Democratic,Aftyn Behn,109
+Davidson,17-8,U.S. House,7,Democratic,Bo Mitchell,31
+Davidson,17-8,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Davidson,17-8,U.S. House,7,Democratic,Vincent Dixie,31
+Davidson,17-8,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-8,U.S. House,7,Republican,Gino Bulso,2
+Davidson,17-8,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-8,U.S. House,7,Republican,Jody Barrett,1
+Davidson,17-8,U.S. House,7,Republican,Joe Leurs,1
+Davidson,17-8,U.S. House,7,Republican,Lee Reeves,2
+Davidson,17-8,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-8,U.S. House,7,Republican,Matt Van Epps,12
+Davidson,17-8,U.S. House,7,Republican,Stewart Parks,4
+Davidson,17-8,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-8,U.S. House,7,Republican,Tres Wittum,1
+Davidson,18-1,U.S. House,7,Democratic,Aftyn Behn,109
+Davidson,18-1,U.S. House,7,Democratic,Bo Mitchell,88
+Davidson,18-1,U.S. House,7,Democratic,Darden Hunter Copeland,49
+Davidson,18-1,U.S. House,7,Democratic,Vincent Dixie,29
+Davidson,18-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,18-1,U.S. House,7,Republican,Gino Bulso,3
+Davidson,18-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,18-1,U.S. House,7,Republican,Jody Barrett,8
+Davidson,18-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,18-1,U.S. House,7,Republican,Lee Reeves,3
+Davidson,18-1,U.S. House,7,Republican,Mason Foley,2
+Davidson,18-1,U.S. House,7,Republican,Matt Van Epps,16
+Davidson,18-1,U.S. House,7,Republican,Stewart Parks,3
+Davidson,18-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,18-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,18-2,U.S. House,7,Democratic,Aftyn Behn,117
+Davidson,18-2,U.S. House,7,Democratic,Bo Mitchell,70
+Davidson,18-2,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Davidson,18-2,U.S. House,7,Democratic,Vincent Dixie,32
+Davidson,18-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,18-2,U.S. House,7,Republican,Gino Bulso,2
+Davidson,18-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,18-2,U.S. House,7,Republican,Jody Barrett,7
+Davidson,18-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,18-2,U.S. House,7,Republican,Lee Reeves,2
+Davidson,18-2,U.S. House,7,Republican,Mason Foley,2
+Davidson,18-2,U.S. House,7,Republican,Matt Van Epps,19
+Davidson,18-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,18-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,18-2,U.S. House,7,Republican,Tres Wittum,2
+Davidson,18-3,U.S. House,7,Democratic,Aftyn Behn,334
+Davidson,18-3,U.S. House,7,Democratic,Bo Mitchell,334
+Davidson,18-3,U.S. House,7,Democratic,Darden Hunter Copeland,185
+Davidson,18-3,U.S. House,7,Democratic,Vincent Dixie,41
+Davidson,18-3,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Davidson,18-3,U.S. House,7,Republican,Gino Bulso,9
+Davidson,18-3,U.S. House,7,Republican,Jason D. Knight,7
+Davidson,18-3,U.S. House,7,Republican,Jody Barrett,25
+Davidson,18-3,U.S. House,7,Republican,Joe Leurs,2
+Davidson,18-3,U.S. House,7,Republican,Lee Reeves,7
+Davidson,18-3,U.S. House,7,Republican,Mason Foley,12
+Davidson,18-3,U.S. House,7,Republican,Matt Van Epps,50
+Davidson,18-3,U.S. House,7,Republican,Stewart Parks,3
+Davidson,18-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,18-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,19-1,U.S. House,7,Democratic,Aftyn Behn,15
+Davidson,19-1,U.S. House,7,Democratic,Bo Mitchell,1
+Davidson,19-1,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Davidson,19-1,U.S. House,7,Democratic,Vincent Dixie,2
+Davidson,19-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,19-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,19-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,19-1,U.S. House,7,Republican,Jody Barrett,1
+Davidson,19-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,19-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,19-1,U.S. House,7,Republican,Mason Foley,1
+Davidson,19-1,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,19-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,19-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,19-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,19-2,U.S. House,7,Democratic,Aftyn Behn,234
+Davidson,19-2,U.S. House,7,Democratic,Bo Mitchell,54
+Davidson,19-2,U.S. House,7,Democratic,Darden Hunter Copeland,49
+Davidson,19-2,U.S. House,7,Democratic,Vincent Dixie,40
+Davidson,19-2,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Davidson,19-2,U.S. House,7,Republican,Gino Bulso,3
+Davidson,19-2,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,19-2,U.S. House,7,Republican,Jody Barrett,10
+Davidson,19-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,19-2,U.S. House,7,Republican,Lee Reeves,4
+Davidson,19-2,U.S. House,7,Republican,Mason Foley,10
+Davidson,19-2,U.S. House,7,Republican,Matt Van Epps,38
+Davidson,19-2,U.S. House,7,Republican,Stewart Parks,2
+Davidson,19-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,19-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,19-3,U.S. House,7,Democratic,Aftyn Behn,86
+Davidson,19-3,U.S. House,7,Democratic,Bo Mitchell,41
+Davidson,19-3,U.S. House,7,Democratic,Darden Hunter Copeland,33
+Davidson,19-3,U.S. House,7,Democratic,Vincent Dixie,92
+Davidson,19-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,19-3,U.S. House,7,Republican,Gino Bulso,2
+Davidson,19-3,U.S. House,7,Republican,Jason D. Knight,3
+Davidson,19-3,U.S. House,7,Republican,Jody Barrett,9
+Davidson,19-3,U.S. House,7,Republican,Joe Leurs,2
+Davidson,19-3,U.S. House,7,Republican,Lee Reeves,3
+Davidson,19-3,U.S. House,7,Republican,Mason Foley,3
+Davidson,19-3,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,19-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,19-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,19-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,19-4,U.S. House,7,Democratic,Aftyn Behn,90
+Davidson,19-4,U.S. House,7,Democratic,Bo Mitchell,24
+Davidson,19-4,U.S. House,7,Democratic,Darden Hunter Copeland,32
+Davidson,19-4,U.S. House,7,Democratic,Vincent Dixie,16
+Davidson,19-4,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,19-4,U.S. House,7,Republican,Gino Bulso,1
+Davidson,19-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,19-4,U.S. House,7,Republican,Jody Barrett,13
+Davidson,19-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,19-4,U.S. House,7,Republican,Lee Reeves,4
+Davidson,19-4,U.S. House,7,Republican,Mason Foley,2
+Davidson,19-4,U.S. House,7,Republican,Matt Van Epps,33
+Davidson,19-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,19-4,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,19-4,U.S. House,7,Republican,Tres Wittum,5
+Davidson,19-5,U.S. House,7,Democratic,Aftyn Behn,120
+Davidson,19-5,U.S. House,7,Democratic,Bo Mitchell,41
+Davidson,19-5,U.S. House,7,Democratic,Darden Hunter Copeland,34
+Davidson,19-5,U.S. House,7,Democratic,Vincent Dixie,21
+Davidson,19-5,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,19-5,U.S. House,7,Republican,Gino Bulso,5
+Davidson,19-5,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,19-5,U.S. House,7,Republican,Jody Barrett,20
+Davidson,19-5,U.S. House,7,Republican,Joe Leurs,1
+Davidson,19-5,U.S. House,7,Republican,Lee Reeves,9
+Davidson,19-5,U.S. House,7,Republican,Mason Foley,4
+Davidson,19-5,U.S. House,7,Republican,Matt Van Epps,41
+Davidson,19-5,U.S. House,7,Republican,Stewart Parks,1
+Davidson,19-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,19-5,U.S. House,7,Republican,Tres Wittum,2
+Davidson,20-1,U.S. House,7,Democratic,Aftyn Behn,26
+Davidson,20-1,U.S. House,7,Democratic,Bo Mitchell,9
+Davidson,20-1,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Davidson,20-1,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,20-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,20-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,20-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,20-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,20-1,U.S. House,7,Republican,Lee Reeves,2
+Davidson,20-1,U.S. House,7,Republican,Mason Foley,1
+Davidson,20-1,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,20-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,20-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,20-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,20-2,U.S. House,7,Democratic,Aftyn Behn,153
+Davidson,20-2,U.S. House,7,Democratic,Bo Mitchell,86
+Davidson,20-2,U.S. House,7,Democratic,Darden Hunter Copeland,56
+Davidson,20-2,U.S. House,7,Democratic,Vincent Dixie,30
+Davidson,20-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-2,U.S. House,7,Republican,Gino Bulso,4
+Davidson,20-2,U.S. House,7,Republican,Jason D. Knight,2
+Davidson,20-2,U.S. House,7,Republican,Jody Barrett,17
+Davidson,20-2,U.S. House,7,Republican,Joe Leurs,1
+Davidson,20-2,U.S. House,7,Republican,Lee Reeves,1
+Davidson,20-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,20-2,U.S. House,7,Republican,Matt Van Epps,24
+Davidson,20-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,20-2,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,20-2,U.S. House,7,Republican,Tres Wittum,1
+Davidson,20-3,U.S. House,7,Democratic,Aftyn Behn,251
+Davidson,20-3,U.S. House,7,Democratic,Bo Mitchell,148
+Davidson,20-3,U.S. House,7,Democratic,Darden Hunter Copeland,77
+Davidson,20-3,U.S. House,7,Democratic,Vincent Dixie,48
+Davidson,20-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-3,U.S. House,7,Republican,Gino Bulso,10
+Davidson,20-3,U.S. House,7,Republican,Jason D. Knight,2
+Davidson,20-3,U.S. House,7,Republican,Jody Barrett,29
+Davidson,20-3,U.S. House,7,Republican,Joe Leurs,1
+Davidson,20-3,U.S. House,7,Republican,Lee Reeves,14
+Davidson,20-3,U.S. House,7,Republican,Mason Foley,8
+Davidson,20-3,U.S. House,7,Republican,Matt Van Epps,113
+Davidson,20-3,U.S. House,7,Republican,Stewart Parks,6
+Davidson,20-3,U.S. House,7,Republican,Stuart Cooper,3
+Davidson,20-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,20-5,U.S. House,7,Democratic,Aftyn Behn,68
+Davidson,20-5,U.S. House,7,Democratic,Bo Mitchell,32
+Davidson,20-5,U.S. House,7,Democratic,Darden Hunter Copeland,25
+Davidson,20-5,U.S. House,7,Democratic,Vincent Dixie,17
+Davidson,20-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-5,U.S. House,7,Republican,Gino Bulso,2
+Davidson,20-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,20-5,U.S. House,7,Republican,Jody Barrett,3
+Davidson,20-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,20-5,U.S. House,7,Republican,Lee Reeves,4
+Davidson,20-5,U.S. House,7,Republican,Mason Foley,4
+Davidson,20-5,U.S. House,7,Republican,Matt Van Epps,23
+Davidson,20-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,20-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,20-5,U.S. House,7,Republican,Tres Wittum,1
+Davidson,21-1,U.S. House,7,Democratic,Aftyn Behn,80
+Davidson,21-1,U.S. House,7,Democratic,Bo Mitchell,53
+Davidson,21-1,U.S. House,7,Democratic,Darden Hunter Copeland,27
+Davidson,21-1,U.S. House,7,Democratic,Vincent Dixie,23
+Davidson,21-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,21-1,U.S. House,7,Republican,Gino Bulso,6
+Davidson,21-1,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,21-1,U.S. House,7,Republican,Jody Barrett,8
+Davidson,21-1,U.S. House,7,Republican,Joe Leurs,1
+Davidson,21-1,U.S. House,7,Republican,Lee Reeves,2
+Davidson,21-1,U.S. House,7,Republican,Mason Foley,3
+Davidson,21-1,U.S. House,7,Republican,Matt Van Epps,20
+Davidson,21-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,21-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,21-2,U.S. House,7,Democratic,Aftyn Behn,55
+Davidson,21-2,U.S. House,7,Democratic,Bo Mitchell,41
+Davidson,21-2,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Davidson,21-2,U.S. House,7,Democratic,Vincent Dixie,128
+Davidson,21-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,21-2,U.S. House,7,Republican,Gino Bulso,2
+Davidson,21-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,21-2,U.S. House,7,Republican,Jody Barrett,2
+Davidson,21-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,21-2,U.S. House,7,Republican,Lee Reeves,3
+Davidson,21-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,21-2,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,21-2,U.S. House,7,Republican,Stewart Parks,1
+Davidson,21-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-2,U.S. House,7,Republican,Tres Wittum,1
+Davidson,21-3,U.S. House,7,Democratic,Aftyn Behn,105
+Davidson,21-3,U.S. House,7,Democratic,Bo Mitchell,60
+Davidson,21-3,U.S. House,7,Democratic,Darden Hunter Copeland,72
+Davidson,21-3,U.S. House,7,Democratic,Vincent Dixie,242
+Davidson,21-3,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,21-3,U.S. House,7,Republican,Gino Bulso,4
+Davidson,21-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,21-3,U.S. House,7,Republican,Jody Barrett,4
+Davidson,21-3,U.S. House,7,Republican,Joe Leurs,1
+Davidson,21-3,U.S. House,7,Republican,Lee Reeves,1
+Davidson,21-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,21-3,U.S. House,7,Republican,Matt Van Epps,12
+Davidson,21-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,21-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,21-4,U.S. House,7,Democratic,Aftyn Behn,40
+Davidson,21-4,U.S. House,7,Democratic,Bo Mitchell,40
+Davidson,21-4,U.S. House,7,Democratic,Darden Hunter Copeland,25
+Davidson,21-4,U.S. House,7,Democratic,Vincent Dixie,137
+Davidson,21-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,21-4,U.S. House,7,Republican,Gino Bulso,2
+Davidson,21-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,21-4,U.S. House,7,Republican,Jody Barrett,4
+Davidson,21-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,21-4,U.S. House,7,Republican,Lee Reeves,1
+Davidson,21-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,21-4,U.S. House,7,Republican,Matt Van Epps,1
+Davidson,21-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,21-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-1,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,24-1,U.S. House,7,Democratic,Bo Mitchell,4
+Davidson,24-1,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,24-1,U.S. House,7,Democratic,Vincent Dixie,9
+Davidson,24-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,24-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,24-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,24-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,24-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,24-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,24-1,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,24-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,24-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,24-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-3,U.S. House,7,Democratic,Aftyn Behn,96
+Davidson,24-3,U.S. House,7,Democratic,Bo Mitchell,58
+Davidson,24-3,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Davidson,24-3,U.S. House,7,Democratic,Vincent Dixie,20
+Davidson,24-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,24-3,U.S. House,7,Republican,Gino Bulso,1
+Davidson,24-3,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,24-3,U.S. House,7,Republican,Jody Barrett,5
+Davidson,24-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-3,U.S. House,7,Republican,Lee Reeves,1
+Davidson,24-3,U.S. House,7,Republican,Mason Foley,2
+Davidson,24-3,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,24-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,24-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,24-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-4,U.S. House,7,Democratic,Aftyn Behn,27
+Davidson,24-4,U.S. House,7,Democratic,Bo Mitchell,13
+Davidson,24-4,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Davidson,24-4,U.S. House,7,Democratic,Vincent Dixie,8
+Davidson,24-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,24-4,U.S. House,7,Republican,Gino Bulso,3
+Davidson,24-4,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,24-4,U.S. House,7,Republican,Jody Barrett,0
+Davidson,24-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-4,U.S. House,7,Republican,Lee Reeves,2
+Davidson,24-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,24-4,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,24-4,U.S. House,7,Republican,Stewart Parks,2
+Davidson,24-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,24-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-5,U.S. House,7,Democratic,Aftyn Behn,307
+Davidson,24-5,U.S. House,7,Democratic,Bo Mitchell,236
+Davidson,24-5,U.S. House,7,Democratic,Darden Hunter Copeland,122
+Davidson,24-5,U.S. House,7,Democratic,Vincent Dixie,34
+Davidson,24-5,U.S. House,7,Republican,Adolph Agbéko Dagan,4
+Davidson,24-5,U.S. House,7,Republican,Gino Bulso,14
+Davidson,24-5,U.S. House,7,Republican,Jason D. Knight,2
+Davidson,24-5,U.S. House,7,Republican,Jody Barrett,22
+Davidson,24-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-5,U.S. House,7,Republican,Lee Reeves,4
+Davidson,24-5,U.S. House,7,Republican,Mason Foley,6
+Davidson,24-5,U.S. House,7,Republican,Matt Van Epps,65
+Davidson,24-5,U.S. House,7,Republican,Stewart Parks,3
+Davidson,24-5,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,24-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,26-1,U.S. House,7,Democratic,Aftyn Behn,52
+Davidson,26-1,U.S. House,7,Democratic,Bo Mitchell,21
+Davidson,26-1,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Davidson,26-1,U.S. House,7,Democratic,Vincent Dixie,7
+Davidson,26-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,26-1,U.S. House,7,Republican,Gino Bulso,3
+Davidson,26-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,26-1,U.S. House,7,Republican,Jody Barrett,4
+Davidson,26-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,26-1,U.S. House,7,Republican,Lee Reeves,1
+Davidson,26-1,U.S. House,7,Republican,Mason Foley,1
+Davidson,26-1,U.S. House,7,Republican,Matt Van Epps,14
+Davidson,26-1,U.S. House,7,Republican,Stewart Parks,3
+Davidson,26-1,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,26-1,U.S. House,7,Republican,Tres Wittum,1
+Davidson,35-4,U.S. House,7,Democratic,Aftyn Behn,19
+Davidson,35-4,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,35-4,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Davidson,35-4,U.S. House,7,Democratic,Vincent Dixie,3
+Davidson,35-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,35-4,U.S. House,7,Republican,Gino Bulso,0
+Davidson,35-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,35-4,U.S. House,7,Republican,Jody Barrett,0
+Davidson,35-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,35-4,U.S. House,7,Republican,Lee Reeves,0
+Davidson,35-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,35-4,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,35-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,35-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,35-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,35-5,U.S. House,7,Democratic,Aftyn Behn,74
+Davidson,35-5,U.S. House,7,Democratic,Bo Mitchell,435
+Davidson,35-5,U.S. House,7,Democratic,Darden Hunter Copeland,27
+Davidson,35-5,U.S. House,7,Democratic,Vincent Dixie,17
+Davidson,35-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,35-5,U.S. House,7,Republican,Gino Bulso,42
+Davidson,35-5,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,35-5,U.S. House,7,Republican,Jody Barrett,59
+Davidson,35-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,35-5,U.S. House,7,Republican,Lee Reeves,19
+Davidson,35-5,U.S. House,7,Republican,Mason Foley,12
+Davidson,35-5,U.S. House,7,Republican,Matt Van Epps,144
+Davidson,35-5,U.S. House,7,Republican,Stewart Parks,3
+Davidson,35-5,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,35-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Bo Mitchell,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Vincent Dixie,0
+Davidson,All County Precinct,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,All County Precinct,U.S. House,7,Republican,Gino Bulso,0
+Davidson,All County Precinct,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,All County Precinct,U.S. House,7,Republican,Jody Barrett,0
+Davidson,All County Precinct,U.S. House,7,Republican,Joe Leurs,0
+Davidson,All County Precinct,U.S. House,7,Republican,Lee Reeves,0
+Davidson,All County Precinct,U.S. House,7,Republican,Mason Foley,0
+Davidson,All County Precinct,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,All County Precinct,U.S. House,7,Republican,Stewart Parks,0
+Davidson,All County Precinct,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,All County Precinct,U.S. House,7,Republican,Tres Wittum,0
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Aftyn Behn,5
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Bo Mitchell,18
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Gino Bulso,9
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Jody Barrett,23
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Joe Leurs,0
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Lee Reeves,3
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Mason Foley,1
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Matt Van Epps,65
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Stewart Parks,7
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Stuart Cooper,1
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Tres Wittum,2
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Aftyn Behn,1
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Bo Mitchell,9
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Gino Bulso,19
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Jody Barrett,12
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Joe Leurs,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Lee Reeves,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Mason Foley,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Matt Van Epps,36
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Stewart Parks,7
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Tres Wittum,1
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,0
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Bo Mitchell,19
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Gino Bulso,11
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Jason D. Knight,2
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Jody Barrett,13
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Joe Leurs,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Lee Reeves,2
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Mason Foley,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,41
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Stewart Parks,8
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Stuart Cooper,2
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Tres Wittum,0
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,2
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Bo Mitchell,32
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Vincent Dixie,2
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Gino Bulso,6
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Jason D. Knight,2
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Jody Barrett,10
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Joe Leurs,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Lee Reeves,3
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Mason Foley,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,39
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Stewart Parks,3
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Tres Wittum,0
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,1
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Bo Mitchell,12
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,5-1 Parsons,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,5-1 Parsons,U.S. House,7,Republican,Gino Bulso,10
+Decatur,5-1 Parsons,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,5-1 Parsons,U.S. House,7,Republican,Jody Barrett,15
+Decatur,5-1 Parsons,U.S. House,7,Republican,Joe Leurs,0
+Decatur,5-1 Parsons,U.S. House,7,Republican,Lee Reeves,3
+Decatur,5-1 Parsons,U.S. House,7,Republican,Mason Foley,2
+Decatur,5-1 Parsons,U.S. House,7,Republican,Matt Van Epps,50
+Decatur,5-1 Parsons,U.S. House,7,Republican,Stewart Parks,7
+Decatur,5-1 Parsons,U.S. House,7,Republican,Stuart Cooper,1
+Decatur,5-1 Parsons,U.S. House,7,Republican,Tres Wittum,0
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,2
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Bo Mitchell,8
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Vincent Dixie,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,6-1 Parsons,U.S. House,7,Republican,Gino Bulso,3
+Decatur,6-1 Parsons,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Jody Barrett,9
+Decatur,6-1 Parsons,U.S. House,7,Republican,Joe Leurs,0
+Decatur,6-1 Parsons,U.S. House,7,Republican,Lee Reeves,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Mason Foley,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Matt Van Epps,32
+Decatur,6-1 Parsons,U.S. House,7,Republican,Stewart Parks,2
+Decatur,6-1 Parsons,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,6-1 Parsons,U.S. House,7,Republican,Tres Wittum,0
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Aftyn Behn,2
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Bo Mitchell,8
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Gino Bulso,7
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Jody Barrett,10
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Joe Leurs,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Lee Reeves,4
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Mason Foley,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Matt Van Epps,57
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Stewart Parks,5
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Tres Wittum,0
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,1
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Bo Mitchell,9
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,8-1 Parsons,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,8-1 Parsons,U.S. House,7,Republican,Gino Bulso,4
+Decatur,8-1 Parsons,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,8-1 Parsons,U.S. House,7,Republican,Jody Barrett,12
+Decatur,8-1 Parsons,U.S. House,7,Republican,Joe Leurs,1
+Decatur,8-1 Parsons,U.S. House,7,Republican,Lee Reeves,3
+Decatur,8-1 Parsons,U.S. House,7,Republican,Mason Foley,1
+Decatur,8-1 Parsons,U.S. House,7,Republican,Matt Van Epps,62
+Decatur,8-1 Parsons,U.S. House,7,Republican,Stewart Parks,5
+Decatur,8-1 Parsons,U.S. House,7,Republican,Stuart Cooper,3
+Decatur,8-1 Parsons,U.S. House,7,Republican,Tres Wittum,0
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Aftyn Behn,5
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Bo Mitchell,3
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Decatur,9-1 Beacon,U.S. House,7,Republican,Gino Bulso,3
+Decatur,9-1 Beacon,U.S. House,7,Republican,Jason D. Knight,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Jody Barrett,16
+Decatur,9-1 Beacon,U.S. House,7,Republican,Joe Leurs,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Lee Reeves,8
+Decatur,9-1 Beacon,U.S. House,7,Republican,Mason Foley,1
+Decatur,9-1 Beacon,U.S. House,7,Republican,Matt Van Epps,45
+Decatur,9-1 Beacon,U.S. House,7,Republican,Stewart Parks,14
+Decatur,9-1 Beacon,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Tres Wittum,1
+Dickson,1-1,U.S. House,7,Democratic,Aftyn Behn,20
+Dickson,1-1,U.S. House,7,Democratic,Bo Mitchell,71
+Dickson,1-1,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Dickson,1-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,1-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,1-1,U.S. House,7,Republican,Gino Bulso,23
+Dickson,1-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,1-1,U.S. House,7,Republican,Jody Barrett,194
+Dickson,1-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,1-1,U.S. House,7,Republican,Lee Reeves,6
+Dickson,1-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,1-1,U.S. House,7,Republican,Matt Van Epps,151
+Dickson,1-1,U.S. House,7,Republican,Stewart Parks,5
+Dickson,1-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,1-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,10-1,U.S. House,7,Democratic,Aftyn Behn,50
+Dickson,10-1,U.S. House,7,Democratic,Bo Mitchell,67
+Dickson,10-1,U.S. House,7,Democratic,Darden Hunter Copeland,41
+Dickson,10-1,U.S. House,7,Democratic,Vincent Dixie,5
+Dickson,10-1,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Dickson,10-1,U.S. House,7,Republican,Gino Bulso,29
+Dickson,10-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,10-1,U.S. House,7,Republican,Jody Barrett,213
+Dickson,10-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,10-1,U.S. House,7,Republican,Lee Reeves,15
+Dickson,10-1,U.S. House,7,Republican,Mason Foley,3
+Dickson,10-1,U.S. House,7,Republican,Matt Van Epps,141
+Dickson,10-1,U.S. House,7,Republican,Stewart Parks,2
+Dickson,10-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,10-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,11-1,U.S. House,7,Democratic,Aftyn Behn,32
+Dickson,11-1,U.S. House,7,Democratic,Bo Mitchell,55
+Dickson,11-1,U.S. House,7,Democratic,Darden Hunter Copeland,43
+Dickson,11-1,U.S. House,7,Democratic,Vincent Dixie,6
+Dickson,11-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,11-1,U.S. House,7,Republican,Gino Bulso,17
+Dickson,11-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,11-1,U.S. House,7,Republican,Jody Barrett,163
+Dickson,11-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,11-1,U.S. House,7,Republican,Lee Reeves,15
+Dickson,11-1,U.S. House,7,Republican,Mason Foley,4
+Dickson,11-1,U.S. House,7,Republican,Matt Van Epps,92
+Dickson,11-1,U.S. House,7,Republican,Stewart Parks,2
+Dickson,11-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,11-1,U.S. House,7,Republican,Tres Wittum,1
+Dickson,12-1,U.S. House,7,Democratic,Aftyn Behn,38
+Dickson,12-1,U.S. House,7,Democratic,Bo Mitchell,75
+Dickson,12-1,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Dickson,12-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,12-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,12-1,U.S. House,7,Republican,Gino Bulso,30
+Dickson,12-1,U.S. House,7,Republican,Jason D. Knight,2
+Dickson,12-1,U.S. House,7,Republican,Jody Barrett,216
+Dickson,12-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,12-1,U.S. House,7,Republican,Lee Reeves,17
+Dickson,12-1,U.S. House,7,Republican,Mason Foley,3
+Dickson,12-1,U.S. House,7,Republican,Matt Van Epps,134
+Dickson,12-1,U.S. House,7,Republican,Stewart Parks,1
+Dickson,12-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,12-1,U.S. House,7,Republican,Tres Wittum,2
+Dickson,2-1,U.S. House,7,Democratic,Aftyn Behn,17
+Dickson,2-1,U.S. House,7,Democratic,Bo Mitchell,38
+Dickson,2-1,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Dickson,2-1,U.S. House,7,Democratic,Vincent Dixie,7
+Dickson,2-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,2-1,U.S. House,7,Republican,Gino Bulso,9
+Dickson,2-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,2-1,U.S. House,7,Republican,Jody Barrett,237
+Dickson,2-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,2-1,U.S. House,7,Republican,Lee Reeves,6
+Dickson,2-1,U.S. House,7,Republican,Mason Foley,6
+Dickson,2-1,U.S. House,7,Republican,Matt Van Epps,129
+Dickson,2-1,U.S. House,7,Republican,Stewart Parks,0
+Dickson,2-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,2-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,3-1,U.S. House,7,Democratic,Aftyn Behn,24
+Dickson,3-1,U.S. House,7,Democratic,Bo Mitchell,48
+Dickson,3-1,U.S. House,7,Democratic,Darden Hunter Copeland,28
+Dickson,3-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,3-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,3-1,U.S. House,7,Republican,Gino Bulso,24
+Dickson,3-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,3-1,U.S. House,7,Republican,Jody Barrett,164
+Dickson,3-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,3-1,U.S. House,7,Republican,Lee Reeves,13
+Dickson,3-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,3-1,U.S. House,7,Republican,Matt Van Epps,153
+Dickson,3-1,U.S. House,7,Republican,Stewart Parks,4
+Dickson,3-1,U.S. House,7,Republican,Stuart Cooper,2
+Dickson,3-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,4-1,U.S. House,7,Democratic,Aftyn Behn,26
+Dickson,4-1,U.S. House,7,Democratic,Bo Mitchell,57
+Dickson,4-1,U.S. House,7,Democratic,Darden Hunter Copeland,24
+Dickson,4-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,4-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,4-1,U.S. House,7,Republican,Gino Bulso,35
+Dickson,4-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,4-1,U.S. House,7,Republican,Jody Barrett,127
+Dickson,4-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,4-1,U.S. House,7,Republican,Lee Reeves,6
+Dickson,4-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,4-1,U.S. House,7,Republican,Matt Van Epps,138
+Dickson,4-1,U.S. House,7,Republican,Stewart Parks,3
+Dickson,4-1,U.S. House,7,Republican,Stuart Cooper,3
+Dickson,4-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,5-1,U.S. House,7,Democratic,Aftyn Behn,25
+Dickson,5-1,U.S. House,7,Democratic,Bo Mitchell,46
+Dickson,5-1,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Dickson,5-1,U.S. House,7,Democratic,Vincent Dixie,0
+Dickson,5-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Dickson,5-1,U.S. House,7,Republican,Gino Bulso,14
+Dickson,5-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,5-1,U.S. House,7,Republican,Jody Barrett,160
+Dickson,5-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,5-1,U.S. House,7,Republican,Lee Reeves,7
+Dickson,5-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,5-1,U.S. House,7,Republican,Matt Van Epps,115
+Dickson,5-1,U.S. House,7,Republican,Stewart Parks,3
+Dickson,5-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,5-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,6-1,U.S. House,7,Democratic,Aftyn Behn,10
+Dickson,6-1,U.S. House,7,Democratic,Bo Mitchell,27
+Dickson,6-1,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Dickson,6-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,6-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,6-1,U.S. House,7,Republican,Gino Bulso,15
+Dickson,6-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,6-1,U.S. House,7,Republican,Jody Barrett,81
+Dickson,6-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,6-1,U.S. House,7,Republican,Lee Reeves,4
+Dickson,6-1,U.S. House,7,Republican,Mason Foley,1
+Dickson,6-1,U.S. House,7,Republican,Matt Van Epps,49
+Dickson,6-1,U.S. House,7,Republican,Stewart Parks,0
+Dickson,6-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,6-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,6-2,U.S. House,7,Democratic,Aftyn Behn,15
+Dickson,6-2,U.S. House,7,Democratic,Bo Mitchell,43
+Dickson,6-2,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Dickson,6-2,U.S. House,7,Democratic,Vincent Dixie,1
+Dickson,6-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,6-2,U.S. House,7,Republican,Gino Bulso,17
+Dickson,6-2,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,6-2,U.S. House,7,Republican,Jody Barrett,176
+Dickson,6-2,U.S. House,7,Republican,Joe Leurs,0
+Dickson,6-2,U.S. House,7,Republican,Lee Reeves,6
+Dickson,6-2,U.S. House,7,Republican,Mason Foley,1
+Dickson,6-2,U.S. House,7,Republican,Matt Van Epps,113
+Dickson,6-2,U.S. House,7,Republican,Stewart Parks,0
+Dickson,6-2,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,6-2,U.S. House,7,Republican,Tres Wittum,1
+Dickson,7-1,U.S. House,7,Democratic,Aftyn Behn,51
+Dickson,7-1,U.S. House,7,Democratic,Bo Mitchell,40
+Dickson,7-1,U.S. House,7,Democratic,Darden Hunter Copeland,42
+Dickson,7-1,U.S. House,7,Democratic,Vincent Dixie,4
+Dickson,7-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,7-1,U.S. House,7,Republican,Gino Bulso,23
+Dickson,7-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,7-1,U.S. House,7,Republican,Jody Barrett,143
+Dickson,7-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,7-1,U.S. House,7,Republican,Lee Reeves,13
+Dickson,7-1,U.S. House,7,Republican,Mason Foley,3
+Dickson,7-1,U.S. House,7,Republican,Matt Van Epps,92
+Dickson,7-1,U.S. House,7,Republican,Stewart Parks,3
+Dickson,7-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,7-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,8-1,U.S. House,7,Democratic,Aftyn Behn,37
+Dickson,8-1,U.S. House,7,Democratic,Bo Mitchell,50
+Dickson,8-1,U.S. House,7,Democratic,Darden Hunter Copeland,34
+Dickson,8-1,U.S. House,7,Democratic,Vincent Dixie,5
+Dickson,8-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,8-1,U.S. House,7,Republican,Gino Bulso,9
+Dickson,8-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,8-1,U.S. House,7,Republican,Jody Barrett,100
+Dickson,8-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,8-1,U.S. House,7,Republican,Lee Reeves,5
+Dickson,8-1,U.S. House,7,Republican,Mason Foley,1
+Dickson,8-1,U.S. House,7,Republican,Matt Van Epps,49
+Dickson,8-1,U.S. House,7,Republican,Stewart Parks,4
+Dickson,8-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,8-1,U.S. House,7,Republican,Tres Wittum,1
+Dickson,9-1,U.S. House,7,Democratic,Aftyn Behn,31
+Dickson,9-1,U.S. House,7,Democratic,Bo Mitchell,67
+Dickson,9-1,U.S. House,7,Democratic,Darden Hunter Copeland,48
+Dickson,9-1,U.S. House,7,Democratic,Vincent Dixie,10
+Dickson,9-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,9-1,U.S. House,7,Republican,Gino Bulso,11
+Dickson,9-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,9-1,U.S. House,7,Republican,Jody Barrett,227
+Dickson,9-1,U.S. House,7,Republican,Joe Leurs,2
+Dickson,9-1,U.S. House,7,Republican,Lee Reeves,11
+Dickson,9-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,9-1,U.S. House,7,Republican,Matt Van Epps,148
+Dickson,9-1,U.S. House,7,Republican,Stewart Parks,2
+Dickson,9-1,U.S. House,7,Republican,Stuart Cooper,2
+Dickson,9-1,U.S. House,7,Republican,Tres Wittum,0
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,2
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Bo Mitchell,6
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Gino Bulso,5
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Jody Barrett,61
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Joe Leurs,0
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Lee Reeves,4
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Mason Foley,1
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,28
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Stewart Parks,3
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Tres Wittum,0
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Aftyn Behn,4
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Bo Mitchell,5
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Vincent Dixie,4
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Gino Bulso,9
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Jody Barrett,65
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Joe Leurs,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Lee Reeves,2
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Mason Foley,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Matt Van Epps,41
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Stewart Parks,2
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Tres Wittum,0
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Bo Mitchell,2
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Darden Hunter Copeland,10
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Gino Bulso,5
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Jody Barrett,17
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Joe Leurs,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Lee Reeves,1
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Mason Foley,1
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Matt Van Epps,20
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Stewart Parks,5
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Tres Wittum,0
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Aftyn Behn,5
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Bo Mitchell,14
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Vincent Dixie,2
+Hickman,2-3 East Bank,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,2-3 East Bank,U.S. House,7,Republican,Gino Bulso,29
+Hickman,2-3 East Bank,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,2-3 East Bank,U.S. House,7,Republican,Jody Barrett,71
+Hickman,2-3 East Bank,U.S. House,7,Republican,Joe Leurs,0
+Hickman,2-3 East Bank,U.S. House,7,Republican,Lee Reeves,5
+Hickman,2-3 East Bank,U.S. House,7,Republican,Mason Foley,3
+Hickman,2-3 East Bank,U.S. House,7,Republican,Matt Van Epps,48
+Hickman,2-3 East Bank,U.S. House,7,Republican,Stewart Parks,7
+Hickman,2-3 East Bank,U.S. House,7,Republican,Stuart Cooper,1
+Hickman,2-3 East Bank,U.S. House,7,Republican,Tres Wittum,0
+Hickman,3-1 East CC,U.S. House,7,Democratic,Aftyn Behn,6
+Hickman,3-1 East CC,U.S. House,7,Democratic,Bo Mitchell,23
+Hickman,3-1 East CC,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Hickman,3-1 East CC,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Gino Bulso,18
+Hickman,3-1 East CC,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Jody Barrett,82
+Hickman,3-1 East CC,U.S. House,7,Republican,Joe Leurs,2
+Hickman,3-1 East CC,U.S. House,7,Republican,Lee Reeves,4
+Hickman,3-1 East CC,U.S. House,7,Republican,Mason Foley,4
+Hickman,3-1 East CC,U.S. House,7,Republican,Matt Van Epps,74
+Hickman,3-1 East CC,U.S. House,7,Republican,Stewart Parks,9
+Hickman,3-1 East CC,U.S. House,7,Republican,Stuart Cooper,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Tres Wittum,0
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Aftyn Behn,10
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Bo Mitchell,27
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Gino Bulso,18
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Jason D. Knight,2
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Jody Barrett,161
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Joe Leurs,0
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Lee Reeves,15
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Mason Foley,3
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Matt Van Epps,95
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Stewart Parks,8
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Stuart Cooper,2
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Tres Wittum,2
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Aftyn Behn,4
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Bo Mitchell,10
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Vincent Dixie,2
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Gino Bulso,12
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Jody Barrett,60
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Joe Leurs,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Lee Reeves,4
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Mason Foley,2
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Matt Van Epps,34
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Stewart Parks,3
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Tres Wittum,2
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Bo Mitchell,8
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Gino Bulso,11
+Hickman,5-2 Middle School,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Jody Barrett,40
+Hickman,5-2 Middle School,U.S. House,7,Republican,Joe Leurs,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Lee Reeves,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Mason Foley,1
+Hickman,5-2 Middle School,U.S. House,7,Republican,Matt Van Epps,18
+Hickman,5-2 Middle School,U.S. House,7,Republican,Stewart Parks,3
+Hickman,5-2 Middle School,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Tres Wittum,0
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Aftyn Behn,2
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Bo Mitchell,8
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Gino Bulso,7
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Jody Barrett,32
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Joe Leurs,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Lee Reeves,0
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Mason Foley,0
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Matt Van Epps,19
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Stewart Parks,2
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Stuart Cooper,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Tres Wittum,0
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Aftyn Behn,13
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Bo Mitchell,72
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Vincent Dixie,3
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Gino Bulso,67
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Jason D. Knight,2
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Jody Barrett,269
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Joe Leurs,1
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Lee Reeves,14
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Mason Foley,11
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Matt Van Epps,99
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Stewart Parks,6
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Stuart Cooper,5
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Bo Mitchell,0
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Gino Bulso,3
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Jody Barrett,24
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Lee Reeves,2
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,18
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Stewart Parks,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Bo Mitchell,0
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Gino Bulso,3
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Jody Barrett,30
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Lee Reeves,3
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Matt Van Epps,8
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Stewart Parks,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Aftyn Behn,6
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Bo Mitchell,9
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,7-3 Brushy,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Gino Bulso,9
+Hickman,7-3 Brushy,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,7-3 Brushy,U.S. House,7,Republican,Jody Barrett,65
+Hickman,7-3 Brushy,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Lee Reeves,3
+Hickman,7-3 Brushy,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Matt Van Epps,50
+Hickman,7-3 Brushy,U.S. House,7,Republican,Stewart Parks,3
+Hickman,7-3 Brushy,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-4 Coble,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,7-4 Coble,U.S. House,7,Democratic,Bo Mitchell,6
+Hickman,7-4 Coble,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Hickman,7-4 Coble,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Gino Bulso,3
+Hickman,7-4 Coble,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Jody Barrett,64
+Hickman,7-4 Coble,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Lee Reeves,2
+Hickman,7-4 Coble,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Matt Van Epps,15
+Hickman,7-4 Coble,U.S. House,7,Republican,Stewart Parks,3
+Hickman,7-4 Coble,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Tres Wittum,0
+Houston,Arlington,U.S. House,7,Democratic,Aftyn Behn,9
+Houston,Arlington,U.S. House,7,Democratic,Bo Mitchell,7
+Houston,Arlington,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Houston,Arlington,U.S. House,7,Democratic,Vincent Dixie,0
+Houston,Arlington,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Arlington,U.S. House,7,Republican,Gino Bulso,26
+Houston,Arlington,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Arlington,U.S. House,7,Republican,Jody Barrett,20
+Houston,Arlington,U.S. House,7,Republican,Joe Leurs,0
+Houston,Arlington,U.S. House,7,Republican,Lee Reeves,5
+Houston,Arlington,U.S. House,7,Republican,Mason Foley,1
+Houston,Arlington,U.S. House,7,Republican,Matt Van Epps,43
+Houston,Arlington,U.S. House,7,Republican,Stewart Parks,4
+Houston,Arlington,U.S. House,7,Republican,Stuart Cooper,0
+Houston,Arlington,U.S. House,7,Republican,Tres Wittum,0
+Houston,Erin,U.S. House,7,Democratic,Aftyn Behn,9
+Houston,Erin,U.S. House,7,Democratic,Bo Mitchell,8
+Houston,Erin,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Houston,Erin,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Erin,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Erin,U.S. House,7,Republican,Gino Bulso,15
+Houston,Erin,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Erin,U.S. House,7,Republican,Jody Barrett,18
+Houston,Erin,U.S. House,7,Republican,Joe Leurs,2
+Houston,Erin,U.S. House,7,Republican,Lee Reeves,1
+Houston,Erin,U.S. House,7,Republican,Mason Foley,0
+Houston,Erin,U.S. House,7,Republican,Matt Van Epps,19
+Houston,Erin,U.S. House,7,Republican,Stewart Parks,5
+Houston,Erin,U.S. House,7,Republican,Stuart Cooper,3
+Houston,Erin,U.S. House,7,Republican,Tres Wittum,0
+Houston,Erin Elementary,U.S. House,7,Democratic,Aftyn Behn,11
+Houston,Erin Elementary,U.S. House,7,Democratic,Bo Mitchell,6
+Houston,Erin Elementary,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Houston,Erin Elementary,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Erin Elementary,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Erin Elementary,U.S. House,7,Republican,Gino Bulso,40
+Houston,Erin Elementary,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Erin Elementary,U.S. House,7,Republican,Jody Barrett,29
+Houston,Erin Elementary,U.S. House,7,Republican,Joe Leurs,0
+Houston,Erin Elementary,U.S. House,7,Republican,Lee Reeves,0
+Houston,Erin Elementary,U.S. House,7,Republican,Mason Foley,0
+Houston,Erin Elementary,U.S. House,7,Republican,Matt Van Epps,19
+Houston,Erin Elementary,U.S. House,7,Republican,Stewart Parks,1
+Houston,Erin Elementary,U.S. House,7,Republican,Stuart Cooper,3
+Houston,Erin Elementary,U.S. House,7,Republican,Tres Wittum,0
+Houston,Griffins Chapel,U.S. House,7,Democratic,Aftyn Behn,7
+Houston,Griffins Chapel,U.S. House,7,Democratic,Bo Mitchell,6
+Houston,Griffins Chapel,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Houston,Griffins Chapel,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Griffins Chapel,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Houston,Griffins Chapel,U.S. House,7,Republican,Gino Bulso,31
+Houston,Griffins Chapel,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Griffins Chapel,U.S. House,7,Republican,Jody Barrett,25
+Houston,Griffins Chapel,U.S. House,7,Republican,Joe Leurs,0
+Houston,Griffins Chapel,U.S. House,7,Republican,Lee Reeves,3
+Houston,Griffins Chapel,U.S. House,7,Republican,Mason Foley,0
+Houston,Griffins Chapel,U.S. House,7,Republican,Matt Van Epps,42
+Houston,Griffins Chapel,U.S. House,7,Republican,Stewart Parks,4
+Houston,Griffins Chapel,U.S. House,7,Republican,Stuart Cooper,1
+Houston,Griffins Chapel,U.S. House,7,Republican,Tres Wittum,0
+Houston,Houston Co Middle,U.S. House,7,Democratic,Aftyn Behn,8
+Houston,Houston Co Middle,U.S. House,7,Democratic,Bo Mitchell,8
+Houston,Houston Co Middle,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Houston,Houston Co Middle,U.S. House,7,Democratic,Vincent Dixie,2
+Houston,Houston Co Middle,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Houston Co Middle,U.S. House,7,Republican,Gino Bulso,31
+Houston,Houston Co Middle,U.S. House,7,Republican,Jason D. Knight,1
+Houston,Houston Co Middle,U.S. House,7,Republican,Jody Barrett,18
+Houston,Houston Co Middle,U.S. House,7,Republican,Joe Leurs,0
+Houston,Houston Co Middle,U.S. House,7,Republican,Lee Reeves,1
+Houston,Houston Co Middle,U.S. House,7,Republican,Mason Foley,0
+Houston,Houston Co Middle,U.S. House,7,Republican,Matt Van Epps,30
+Houston,Houston Co Middle,U.S. House,7,Republican,Stewart Parks,2
+Houston,Houston Co Middle,U.S. House,7,Republican,Stuart Cooper,2
+Houston,Houston Co Middle,U.S. House,7,Republican,Tres Wittum,1
+Houston,Stewart,U.S. House,7,Democratic,Aftyn Behn,5
+Houston,Stewart,U.S. House,7,Democratic,Bo Mitchell,10
+Houston,Stewart,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Houston,Stewart,U.S. House,7,Democratic,Vincent Dixie,0
+Houston,Stewart,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Stewart,U.S. House,7,Republican,Gino Bulso,34
+Houston,Stewart,U.S. House,7,Republican,Jason D. Knight,1
+Houston,Stewart,U.S. House,7,Republican,Jody Barrett,32
+Houston,Stewart,U.S. House,7,Republican,Joe Leurs,0
+Houston,Stewart,U.S. House,7,Republican,Lee Reeves,3
+Houston,Stewart,U.S. House,7,Republican,Mason Foley,1
+Houston,Stewart,U.S. House,7,Republican,Matt Van Epps,46
+Houston,Stewart,U.S. House,7,Republican,Stewart Parks,3
+Houston,Stewart,U.S. House,7,Republican,Stuart Cooper,0
+Houston,Stewart,U.S. House,7,Republican,Tres Wittum,0
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Aftyn Behn,7
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Bo Mitchell,14
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Tennessee Ridge,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Tennessee Ridge,U.S. House,7,Republican,Gino Bulso,37
+Houston,Tennessee Ridge,U.S. House,7,Republican,Jason D. Knight,1
+Houston,Tennessee Ridge,U.S. House,7,Republican,Jody Barrett,23
+Houston,Tennessee Ridge,U.S. House,7,Republican,Joe Leurs,0
+Houston,Tennessee Ridge,U.S. House,7,Republican,Lee Reeves,2
+Houston,Tennessee Ridge,U.S. House,7,Republican,Mason Foley,2
+Houston,Tennessee Ridge,U.S. House,7,Republican,Matt Van Epps,33
+Houston,Tennessee Ridge,U.S. House,7,Republican,Stewart Parks,4
+Houston,Tennessee Ridge,U.S. House,7,Republican,Stuart Cooper,0
+Houston,Tennessee Ridge,U.S. House,7,Republican,Tres Wittum,1
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Aftyn Behn,1
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Bo Mitchell,9
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Vincent Dixie,1
+Humphreys,1-1 Jera,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Humphreys,1-1 Jera,U.S. House,7,Republican,Gino Bulso,2
+Humphreys,1-1 Jera,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Jody Barrett,6
+Humphreys,1-1 Jera,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Lee Reeves,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Mason Foley,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Matt Van Epps,20
+Humphreys,1-1 Jera,U.S. House,7,Republican,Stewart Parks,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Stuart Cooper,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Aftyn Behn,12
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Bo Mitchell,32
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Vincent Dixie,3
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Gino Bulso,25
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Jody Barrett,67
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Lee Reeves,8
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Mason Foley,6
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Matt Van Epps,74
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Stewart Parks,1
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Stuart Cooper,2
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Tres Wittum,1
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Aftyn Behn,11
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Bo Mitchell,50
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Vincent Dixie,6
+Humphreys,2-3 WFS,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,2-3 WFS,U.S. House,7,Republican,Gino Bulso,17
+Humphreys,2-3 WFS,U.S. House,7,Republican,Jason D. Knight,2
+Humphreys,2-3 WFS,U.S. House,7,Republican,Jody Barrett,45
+Humphreys,2-3 WFS,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,2-3 WFS,U.S. House,7,Republican,Lee Reeves,5
+Humphreys,2-3 WFS,U.S. House,7,Republican,Mason Foley,5
+Humphreys,2-3 WFS,U.S. House,7,Republican,Matt Van Epps,80
+Humphreys,2-3 WFS,U.S. House,7,Republican,Stewart Parks,2
+Humphreys,2-3 WFS,U.S. House,7,Republican,Stuart Cooper,1
+Humphreys,2-3 WFS,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Aftyn Behn,19
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Bo Mitchell,32
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Darden Hunter Copeland,33
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Vincent Dixie,1
+Humphreys,3-4 Apex,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,3-4 Apex,U.S. House,7,Republican,Gino Bulso,27
+Humphreys,3-4 Apex,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,3-4 Apex,U.S. House,7,Republican,Jody Barrett,33
+Humphreys,3-4 Apex,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,3-4 Apex,U.S. House,7,Republican,Lee Reeves,5
+Humphreys,3-4 Apex,U.S. House,7,Republican,Mason Foley,1
+Humphreys,3-4 Apex,U.S. House,7,Republican,Matt Van Epps,47
+Humphreys,3-4 Apex,U.S. House,7,Republican,Stewart Parks,2
+Humphreys,3-4 Apex,U.S. House,7,Republican,Stuart Cooper,3
+Humphreys,3-4 Apex,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Aftyn Behn,12
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Bo Mitchell,26
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Darden Hunter Copeland,22
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Vincent Dixie,2
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Gino Bulso,20
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Jody Barrett,42
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Lee Reeves,2
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Mason Foley,3
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Matt Van Epps,82
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Stewart Parks,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Stuart Cooper,1
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Aftyn Behn,6
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Bo Mitchell,45
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Darden Hunter Copeland,40
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Vincent Dixie,3
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Gino Bulso,13
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Jason D. Knight,1
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Jody Barrett,45
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Lee Reeves,13
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Mason Foley,4
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Matt Van Epps,72
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Stewart Parks,3
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Stuart Cooper,2
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Aftyn Behn,7
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Bo Mitchell,25
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Vincent Dixie,2
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Gino Bulso,19
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Jody Barrett,54
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Lee Reeves,8
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Mason Foley,4
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Matt Van Epps,72
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Stewart Parks,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Stuart Cooper,2
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Tres Wittum,1
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Aftyn Behn,13
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Bo Mitchell,28
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Vincent Dixie,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Gino Bulso,23
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Jason D. Knight,3
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Jody Barrett,76
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Lee Reeves,7
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Mason Foley,8
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Matt Van Epps,121
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Stewart Parks,4
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Stuart Cooper,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Aftyn Behn,44
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Bo Mitchell,23
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Darden Hunter Copeland,88
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Vincent Dixie,48
+Montgomery,10 Minglewood,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,10 Minglewood,U.S. House,7,Republican,Gino Bulso,22
+Montgomery,10 Minglewood,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,10 Minglewood,U.S. House,7,Republican,Jody Barrett,11
+Montgomery,10 Minglewood,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,10 Minglewood,U.S. House,7,Republican,Lee Reeves,10
+Montgomery,10 Minglewood,U.S. House,7,Republican,Mason Foley,1
+Montgomery,10 Minglewood,U.S. House,7,Republican,Matt Van Epps,81
+Montgomery,10 Minglewood,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,10 Minglewood,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,10 Minglewood,U.S. House,7,Republican,Tres Wittum,3
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Aftyn Behn,30
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Bo Mitchell,20
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Vincent Dixie,28
+Montgomery,11A Mosaic,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,11A Mosaic,U.S. House,7,Republican,Gino Bulso,15
+Montgomery,11A Mosaic,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,11A Mosaic,U.S. House,7,Republican,Jody Barrett,10
+Montgomery,11A Mosaic,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,11A Mosaic,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,11A Mosaic,U.S. House,7,Republican,Mason Foley,0
+Montgomery,11A Mosaic,U.S. House,7,Republican,Matt Van Epps,65
+Montgomery,11A Mosaic,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,11A Mosaic,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,11A Mosaic,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,11B Northwest,U.S. House,7,Democratic,Aftyn Behn,50
+Montgomery,11B Northwest,U.S. House,7,Democratic,Bo Mitchell,22
+Montgomery,11B Northwest,U.S. House,7,Democratic,Darden Hunter Copeland,27
+Montgomery,11B Northwest,U.S. House,7,Democratic,Vincent Dixie,28
+Montgomery,11B Northwest,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,11B Northwest,U.S. House,7,Republican,Gino Bulso,15
+Montgomery,11B Northwest,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,11B Northwest,U.S. House,7,Republican,Jody Barrett,11
+Montgomery,11B Northwest,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,11B Northwest,U.S. House,7,Republican,Lee Reeves,6
+Montgomery,11B Northwest,U.S. House,7,Republican,Mason Foley,0
+Montgomery,11B Northwest,U.S. House,7,Republican,Matt Van Epps,71
+Montgomery,11B Northwest,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,11B Northwest,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,11B Northwest,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,12 West Creek,U.S. House,7,Democratic,Aftyn Behn,63
+Montgomery,12 West Creek,U.S. House,7,Democratic,Bo Mitchell,34
+Montgomery,12 West Creek,U.S. House,7,Democratic,Darden Hunter Copeland,85
+Montgomery,12 West Creek,U.S. House,7,Democratic,Vincent Dixie,53
+Montgomery,12 West Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,12 West Creek,U.S. House,7,Republican,Gino Bulso,14
+Montgomery,12 West Creek,U.S. House,7,Republican,Jason D. Knight,3
+Montgomery,12 West Creek,U.S. House,7,Republican,Jody Barrett,13
+Montgomery,12 West Creek,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,12 West Creek,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,12 West Creek,U.S. House,7,Republican,Mason Foley,1
+Montgomery,12 West Creek,U.S. House,7,Republican,Matt Van Epps,76
+Montgomery,12 West Creek,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,12 West Creek,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,12 West Creek,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Aftyn Behn,42
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Bo Mitchell,17
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Darden Hunter Copeland,49
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Vincent Dixie,39
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Gino Bulso,18
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Jody Barrett,14
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Mason Foley,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Matt Van Epps,53
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Aftyn Behn,46
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Bo Mitchell,22
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Vincent Dixie,56
+Montgomery,13B Kenwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,13B Kenwood,U.S. House,7,Republican,Gino Bulso,17
+Montgomery,13B Kenwood,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,13B Kenwood,U.S. House,7,Republican,Jody Barrett,21
+Montgomery,13B Kenwood,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,13B Kenwood,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,13B Kenwood,U.S. House,7,Republican,Mason Foley,6
+Montgomery,13B Kenwood,U.S. House,7,Republican,Matt Van Epps,86
+Montgomery,13B Kenwood,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,13B Kenwood,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,13B Kenwood,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Aftyn Behn,28
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Bo Mitchell,15
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Darden Hunter Copeland,40
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Vincent Dixie,44
+Montgomery,14A St B ELC,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Gino Bulso,9
+Montgomery,14A St B ELC,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,14A St B ELC,U.S. House,7,Republican,Jody Barrett,7
+Montgomery,14A St B ELC,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,14A St B ELC,U.S. House,7,Republican,Mason Foley,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Matt Van Epps,48
+Montgomery,14A St B ELC,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,14A St B ELC,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,14B First MBC,U.S. House,7,Democratic,Aftyn Behn,64
+Montgomery,14B First MBC,U.S. House,7,Democratic,Bo Mitchell,28
+Montgomery,14B First MBC,U.S. House,7,Democratic,Darden Hunter Copeland,62
+Montgomery,14B First MBC,U.S. House,7,Democratic,Vincent Dixie,36
+Montgomery,14B First MBC,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Gino Bulso,31
+Montgomery,14B First MBC,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,14B First MBC,U.S. House,7,Republican,Jody Barrett,30
+Montgomery,14B First MBC,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Lee Reeves,11
+Montgomery,14B First MBC,U.S. House,7,Republican,Mason Foley,4
+Montgomery,14B First MBC,U.S. House,7,Republican,Matt Van Epps,99
+Montgomery,14B First MBC,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,15A Excell,U.S. House,7,Democratic,Aftyn Behn,77
+Montgomery,15A Excell,U.S. House,7,Democratic,Bo Mitchell,51
+Montgomery,15A Excell,U.S. House,7,Democratic,Darden Hunter Copeland,68
+Montgomery,15A Excell,U.S. House,7,Democratic,Vincent Dixie,29
+Montgomery,15A Excell,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,15A Excell,U.S. House,7,Republican,Gino Bulso,42
+Montgomery,15A Excell,U.S. House,7,Republican,Jason D. Knight,15
+Montgomery,15A Excell,U.S. House,7,Republican,Jody Barrett,58
+Montgomery,15A Excell,U.S. House,7,Republican,Joe Leurs,7
+Montgomery,15A Excell,U.S. House,7,Republican,Lee Reeves,13
+Montgomery,15A Excell,U.S. House,7,Republican,Mason Foley,6
+Montgomery,15A Excell,U.S. House,7,Republican,Matt Van Epps,345
+Montgomery,15A Excell,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,15A Excell,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,15A Excell,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,15B Sango,U.S. House,7,Democratic,Aftyn Behn,55
+Montgomery,15B Sango,U.S. House,7,Democratic,Bo Mitchell,33
+Montgomery,15B Sango,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Montgomery,15B Sango,U.S. House,7,Democratic,Vincent Dixie,29
+Montgomery,15B Sango,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,15B Sango,U.S. House,7,Republican,Gino Bulso,36
+Montgomery,15B Sango,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,15B Sango,U.S. House,7,Republican,Jody Barrett,59
+Montgomery,15B Sango,U.S. House,7,Republican,Joe Leurs,3
+Montgomery,15B Sango,U.S. House,7,Republican,Lee Reeves,12
+Montgomery,15B Sango,U.S. House,7,Republican,Mason Foley,2
+Montgomery,15B Sango,U.S. House,7,Republican,Matt Van Epps,325
+Montgomery,15B Sango,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,15B Sango,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,15B Sango,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Aftyn Behn,41
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Bo Mitchell,27
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Darden Hunter Copeland,47
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Vincent Dixie,41
+Montgomery,16A Ringgold,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,16A Ringgold,U.S. House,7,Republican,Gino Bulso,15
+Montgomery,16A Ringgold,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,16A Ringgold,U.S. House,7,Republican,Jody Barrett,10
+Montgomery,16A Ringgold,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,16A Ringgold,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,16A Ringgold,U.S. House,7,Republican,Mason Foley,1
+Montgomery,16A Ringgold,U.S. House,7,Republican,Matt Van Epps,58
+Montgomery,16A Ringgold,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,16A Ringgold,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,16A Ringgold,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,16B New Providence,U.S. House,7,Democratic,Aftyn Behn,33
+Montgomery,16B New Providence,U.S. House,7,Democratic,Bo Mitchell,22
+Montgomery,16B New Providence,U.S. House,7,Democratic,Darden Hunter Copeland,51
+Montgomery,16B New Providence,U.S. House,7,Democratic,Vincent Dixie,37
+Montgomery,16B New Providence,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,16B New Providence,U.S. House,7,Republican,Gino Bulso,24
+Montgomery,16B New Providence,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,16B New Providence,U.S. House,7,Republican,Jody Barrett,13
+Montgomery,16B New Providence,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,16B New Providence,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,16B New Providence,U.S. House,7,Republican,Mason Foley,1
+Montgomery,16B New Providence,U.S. House,7,Republican,Matt Van Epps,77
+Montgomery,16B New Providence,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,16B New Providence,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,16B New Providence,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,17A Grace,U.S. House,7,Democratic,Aftyn Behn,44
+Montgomery,17A Grace,U.S. House,7,Democratic,Bo Mitchell,14
+Montgomery,17A Grace,U.S. House,7,Democratic,Darden Hunter Copeland,53
+Montgomery,17A Grace,U.S. House,7,Democratic,Vincent Dixie,43
+Montgomery,17A Grace,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,17A Grace,U.S. House,7,Republican,Gino Bulso,17
+Montgomery,17A Grace,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,17A Grace,U.S. House,7,Republican,Jody Barrett,15
+Montgomery,17A Grace,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,17A Grace,U.S. House,7,Republican,Lee Reeves,8
+Montgomery,17A Grace,U.S. House,7,Republican,Mason Foley,0
+Montgomery,17A Grace,U.S. House,7,Republican,Matt Van Epps,76
+Montgomery,17A Grace,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,17A Grace,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,17A Grace,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Aftyn Behn,40
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Bo Mitchell,20
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Darden Hunter Copeland,46
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Vincent Dixie,59
+Montgomery,17B Glenellen,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,17B Glenellen,U.S. House,7,Republican,Gino Bulso,12
+Montgomery,17B Glenellen,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,17B Glenellen,U.S. House,7,Republican,Jody Barrett,12
+Montgomery,17B Glenellen,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,17B Glenellen,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,17B Glenellen,U.S. House,7,Republican,Mason Foley,3
+Montgomery,17B Glenellen,U.S. House,7,Republican,Matt Van Epps,62
+Montgomery,17B Glenellen,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,17B Glenellen,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,17B Glenellen,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Aftyn Behn,39
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Bo Mitchell,27
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Darden Hunter Copeland,43
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Vincent Dixie,62
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Gino Bulso,9
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Jody Barrett,15
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Joe Leurs,4
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Mason Foley,1
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Matt Van Epps,56
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Aftyn Behn,38
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Bo Mitchell,26
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Vincent Dixie,45
+Montgomery,18B Pisgah,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,18B Pisgah,U.S. House,7,Republican,Gino Bulso,11
+Montgomery,18B Pisgah,U.S. House,7,Republican,Jason D. Knight,0
+Montgomery,18B Pisgah,U.S. House,7,Republican,Jody Barrett,10
+Montgomery,18B Pisgah,U.S. House,7,Republican,Joe Leurs,3
+Montgomery,18B Pisgah,U.S. House,7,Republican,Lee Reeves,19
+Montgomery,18B Pisgah,U.S. House,7,Republican,Mason Foley,2
+Montgomery,18B Pisgah,U.S. House,7,Republican,Matt Van Epps,70
+Montgomery,18B Pisgah,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,18B Pisgah,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,18B Pisgah,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,19A Rossview,U.S. House,7,Democratic,Aftyn Behn,64
+Montgomery,19A Rossview,U.S. House,7,Democratic,Bo Mitchell,45
+Montgomery,19A Rossview,U.S. House,7,Democratic,Darden Hunter Copeland,64
+Montgomery,19A Rossview,U.S. House,7,Democratic,Vincent Dixie,70
+Montgomery,19A Rossview,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,19A Rossview,U.S. House,7,Republican,Gino Bulso,32
+Montgomery,19A Rossview,U.S. House,7,Republican,Jason D. Knight,9
+Montgomery,19A Rossview,U.S. House,7,Republican,Jody Barrett,34
+Montgomery,19A Rossview,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,19A Rossview,U.S. House,7,Republican,Lee Reeves,13
+Montgomery,19A Rossview,U.S. House,7,Republican,Mason Foley,6
+Montgomery,19A Rossview,U.S. House,7,Republican,Matt Van Epps,243
+Montgomery,19A Rossview,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,19A Rossview,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,19A Rossview,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Aftyn Behn,38
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Bo Mitchell,17
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Darden Hunter Copeland,58
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Vincent Dixie,27
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Gino Bulso,12
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Jody Barrett,31
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Mason Foley,2
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Matt Van Epps,122
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Tres Wittum,2
+Montgomery,1A St B CC,U.S. House,7,Democratic,Aftyn Behn,76
+Montgomery,1A St B CC,U.S. House,7,Democratic,Bo Mitchell,47
+Montgomery,1A St B CC,U.S. House,7,Democratic,Darden Hunter Copeland,86
+Montgomery,1A St B CC,U.S. House,7,Democratic,Vincent Dixie,44
+Montgomery,1A St B CC,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,1A St B CC,U.S. House,7,Republican,Gino Bulso,31
+Montgomery,1A St B CC,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,1A St B CC,U.S. House,7,Republican,Jody Barrett,39
+Montgomery,1A St B CC,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,1A St B CC,U.S. House,7,Republican,Lee Reeves,13
+Montgomery,1A St B CC,U.S. House,7,Republican,Mason Foley,3
+Montgomery,1A St B CC,U.S. House,7,Republican,Matt Van Epps,214
+Montgomery,1A St B CC,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,1A St B CC,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,1A St B CC,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Aftyn Behn,59
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Bo Mitchell,36
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Darden Hunter Copeland,46
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Vincent Dixie,42
+Montgomery,1B St B UMC,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,1B St B UMC,U.S. House,7,Republican,Gino Bulso,29
+Montgomery,1B St B UMC,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,1B St B UMC,U.S. House,7,Republican,Jody Barrett,19
+Montgomery,1B St B UMC,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,1B St B UMC,U.S. House,7,Republican,Lee Reeves,6
+Montgomery,1B St B UMC,U.S. House,7,Republican,Mason Foley,1
+Montgomery,1B St B UMC,U.S. House,7,Republican,Matt Van Epps,122
+Montgomery,1B St B UMC,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,1B St B UMC,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,1B St B UMC,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,20A Northeast,U.S. House,7,Democratic,Aftyn Behn,55
+Montgomery,20A Northeast,U.S. House,7,Democratic,Bo Mitchell,21
+Montgomery,20A Northeast,U.S. House,7,Democratic,Darden Hunter Copeland,76
+Montgomery,20A Northeast,U.S. House,7,Democratic,Vincent Dixie,55
+Montgomery,20A Northeast,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,20A Northeast,U.S. House,7,Republican,Gino Bulso,19
+Montgomery,20A Northeast,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,20A Northeast,U.S. House,7,Republican,Jody Barrett,18
+Montgomery,20A Northeast,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,20A Northeast,U.S. House,7,Republican,Lee Reeves,5
+Montgomery,20A Northeast,U.S. House,7,Republican,Mason Foley,2
+Montgomery,20A Northeast,U.S. House,7,Republican,Matt Van Epps,63
+Montgomery,20A Northeast,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,20A Northeast,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,20A Northeast,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,20B Oakland,U.S. House,7,Democratic,Aftyn Behn,44
+Montgomery,20B Oakland,U.S. House,7,Democratic,Bo Mitchell,18
+Montgomery,20B Oakland,U.S. House,7,Democratic,Darden Hunter Copeland,50
+Montgomery,20B Oakland,U.S. House,7,Democratic,Vincent Dixie,33
+Montgomery,20B Oakland,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,20B Oakland,U.S. House,7,Republican,Gino Bulso,11
+Montgomery,20B Oakland,U.S. House,7,Republican,Jason D. Knight,4
+Montgomery,20B Oakland,U.S. House,7,Republican,Jody Barrett,20
+Montgomery,20B Oakland,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,20B Oakland,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,20B Oakland,U.S. House,7,Republican,Mason Foley,1
+Montgomery,20B Oakland,U.S. House,7,Republican,Matt Van Epps,117
+Montgomery,20B Oakland,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,20B Oakland,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,20B Oakland,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Aftyn Behn,88
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Bo Mitchell,58
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Vincent Dixie,24
+Montgomery,21A Hilldale,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,21A Hilldale,U.S. House,7,Republican,Gino Bulso,34
+Montgomery,21A Hilldale,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,21A Hilldale,U.S. House,7,Republican,Jody Barrett,48
+Montgomery,21A Hilldale,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,21A Hilldale,U.S. House,7,Republican,Lee Reeves,20
+Montgomery,21A Hilldale,U.S. House,7,Republican,Mason Foley,10
+Montgomery,21A Hilldale,U.S. House,7,Republican,Matt Van Epps,274
+Montgomery,21A Hilldale,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,21A Hilldale,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,21A Hilldale,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Aftyn Behn,71
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Bo Mitchell,42
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Darden Hunter Copeland,63
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Vincent Dixie,45
+Montgomery,21B Barksdale,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,21B Barksdale,U.S. House,7,Republican,Gino Bulso,12
+Montgomery,21B Barksdale,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,21B Barksdale,U.S. House,7,Republican,Jody Barrett,20
+Montgomery,21B Barksdale,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,21B Barksdale,U.S. House,7,Republican,Mason Foley,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Matt Van Epps,128
+Montgomery,21B Barksdale,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Aftyn Behn,78
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Bo Mitchell,62
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Darden Hunter Copeland,73
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Vincent Dixie,30
+Montgomery,2A Clarksville,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,2A Clarksville,U.S. House,7,Republican,Gino Bulso,58
+Montgomery,2A Clarksville,U.S. House,7,Republican,Jason D. Knight,10
+Montgomery,2A Clarksville,U.S. House,7,Republican,Jody Barrett,58
+Montgomery,2A Clarksville,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,2A Clarksville,U.S. House,7,Republican,Lee Reeves,10
+Montgomery,2A Clarksville,U.S. House,7,Republican,Mason Foley,17
+Montgomery,2A Clarksville,U.S. House,7,Republican,Matt Van Epps,311
+Montgomery,2A Clarksville,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,2A Clarksville,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,2A Clarksville,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,2B Bible,U.S. House,7,Democratic,Aftyn Behn,78
+Montgomery,2B Bible,U.S. House,7,Democratic,Bo Mitchell,43
+Montgomery,2B Bible,U.S. House,7,Democratic,Darden Hunter Copeland,72
+Montgomery,2B Bible,U.S. House,7,Democratic,Vincent Dixie,37
+Montgomery,2B Bible,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,2B Bible,U.S. House,7,Republican,Gino Bulso,30
+Montgomery,2B Bible,U.S. House,7,Republican,Jason D. Knight,13
+Montgomery,2B Bible,U.S. House,7,Republican,Jody Barrett,48
+Montgomery,2B Bible,U.S. House,7,Republican,Joe Leurs,6
+Montgomery,2B Bible,U.S. House,7,Republican,Lee Reeves,6
+Montgomery,2B Bible,U.S. House,7,Republican,Mason Foley,1
+Montgomery,2B Bible,U.S. House,7,Republican,Matt Van Epps,208
+Montgomery,2B Bible,U.S. House,7,Republican,Stewart Parks,8
+Montgomery,2B Bible,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,2B Bible,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Aftyn Behn,39
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Bo Mitchell,53
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Darden Hunter Copeland,63
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Vincent Dixie,15
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Gino Bulso,33
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Jason D. Knight,4
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Jody Barrett,57
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Lee Reeves,17
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Mason Foley,6
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Matt Van Epps,288
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Stewart Parks,4
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Aftyn Behn,59
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Bo Mitchell,45
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Vincent Dixie,15
+Montgomery,3B Fredonia,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,3B Fredonia,U.S. House,7,Republican,Gino Bulso,37
+Montgomery,3B Fredonia,U.S. House,7,Republican,Jason D. Knight,12
+Montgomery,3B Fredonia,U.S. House,7,Republican,Jody Barrett,77
+Montgomery,3B Fredonia,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,3B Fredonia,U.S. House,7,Republican,Lee Reeves,8
+Montgomery,3B Fredonia,U.S. House,7,Republican,Mason Foley,2
+Montgomery,3B Fredonia,U.S. House,7,Republican,Matt Van Epps,366
+Montgomery,3B Fredonia,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,3B Fredonia,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,3B Fredonia,U.S. House,7,Republican,Tres Wittum,7
+Montgomery,4A MCMS,U.S. House,7,Democratic,Aftyn Behn,53
+Montgomery,4A MCMS,U.S. House,7,Democratic,Bo Mitchell,30
+Montgomery,4A MCMS,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Montgomery,4A MCMS,U.S. House,7,Democratic,Vincent Dixie,6
+Montgomery,4A MCMS,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,4A MCMS,U.S. House,7,Republican,Gino Bulso,52
+Montgomery,4A MCMS,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,4A MCMS,U.S. House,7,Republican,Jody Barrett,74
+Montgomery,4A MCMS,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,4A MCMS,U.S. House,7,Republican,Lee Reeves,12
+Montgomery,4A MCMS,U.S. House,7,Republican,Mason Foley,4
+Montgomery,4A MCMS,U.S. House,7,Republican,Matt Van Epps,283
+Montgomery,4A MCMS,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,4A MCMS,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,4A MCMS,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Aftyn Behn,77
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Bo Mitchell,34
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Darden Hunter Copeland,59
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Vincent Dixie,37
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Gino Bulso,26
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Jody Barrett,33
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Lee Reeves,10
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Mason Foley,5
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Matt Van Epps,149
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Aftyn Behn,91
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Bo Mitchell,68
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Darden Hunter Copeland,56
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Vincent Dixie,56
+Montgomery,5 Cumberland,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,5 Cumberland,U.S. House,7,Republican,Gino Bulso,19
+Montgomery,5 Cumberland,U.S. House,7,Republican,Jason D. Knight,1
+Montgomery,5 Cumberland,U.S. House,7,Republican,Jody Barrett,21
+Montgomery,5 Cumberland,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,5 Cumberland,U.S. House,7,Republican,Lee Reeves,5
+Montgomery,5 Cumberland,U.S. House,7,Republican,Mason Foley,3
+Montgomery,5 Cumberland,U.S. House,7,Republican,Matt Van Epps,111
+Montgomery,5 Cumberland,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,5 Cumberland,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,5 Cumberland,U.S. House,7,Republican,Tres Wittum,3
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Aftyn Behn,33
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Bo Mitchell,41
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Vincent Dixie,5
+Montgomery,6A Cumberland,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,6A Cumberland,U.S. House,7,Republican,Gino Bulso,32
+Montgomery,6A Cumberland,U.S. House,7,Republican,Jason D. Knight,3
+Montgomery,6A Cumberland,U.S. House,7,Republican,Jody Barrett,37
+Montgomery,6A Cumberland,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,6A Cumberland,U.S. House,7,Republican,Lee Reeves,12
+Montgomery,6A Cumberland,U.S. House,7,Republican,Mason Foley,3
+Montgomery,6A Cumberland,U.S. House,7,Republican,Matt Van Epps,245
+Montgomery,6A Cumberland,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,6A Cumberland,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,6A Cumberland,U.S. House,7,Republican,Tres Wittum,6
+Montgomery,6B Bethel,U.S. House,7,Democratic,Aftyn Behn,17
+Montgomery,6B Bethel,U.S. House,7,Democratic,Bo Mitchell,31
+Montgomery,6B Bethel,U.S. House,7,Democratic,Darden Hunter Copeland,39
+Montgomery,6B Bethel,U.S. House,7,Democratic,Vincent Dixie,6
+Montgomery,6B Bethel,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,6B Bethel,U.S. House,7,Republican,Gino Bulso,25
+Montgomery,6B Bethel,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,6B Bethel,U.S. House,7,Republican,Jody Barrett,60
+Montgomery,6B Bethel,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,6B Bethel,U.S. House,7,Republican,Lee Reeves,8
+Montgomery,6B Bethel,U.S. House,7,Republican,Mason Foley,1
+Montgomery,6B Bethel,U.S. House,7,Republican,Matt Van Epps,251
+Montgomery,6B Bethel,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,6B Bethel,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,6B Bethel,U.S. House,7,Republican,Tres Wittum,2
+Montgomery,7A Liberty,U.S. House,7,Democratic,Aftyn Behn,40
+Montgomery,7A Liberty,U.S. House,7,Democratic,Bo Mitchell,29
+Montgomery,7A Liberty,U.S. House,7,Democratic,Darden Hunter Copeland,50
+Montgomery,7A Liberty,U.S. House,7,Democratic,Vincent Dixie,22
+Montgomery,7A Liberty,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,7A Liberty,U.S. House,7,Republican,Gino Bulso,32
+Montgomery,7A Liberty,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,7A Liberty,U.S. House,7,Republican,Jody Barrett,29
+Montgomery,7A Liberty,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,7A Liberty,U.S. House,7,Republican,Lee Reeves,5
+Montgomery,7A Liberty,U.S. House,7,Republican,Mason Foley,5
+Montgomery,7A Liberty,U.S. House,7,Republican,Matt Van Epps,173
+Montgomery,7A Liberty,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,7A Liberty,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,7A Liberty,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Aftyn Behn,32
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Bo Mitchell,23
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Vincent Dixie,12
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Gino Bulso,46
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Jason D. Knight,9
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Jody Barrett,69
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Lee Reeves,15
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Mason Foley,5
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Matt Van Epps,300
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,8 Bethel,U.S. House,7,Democratic,Aftyn Behn,38
+Montgomery,8 Bethel,U.S. House,7,Democratic,Bo Mitchell,28
+Montgomery,8 Bethel,U.S. House,7,Democratic,Darden Hunter Copeland,69
+Montgomery,8 Bethel,U.S. House,7,Democratic,Vincent Dixie,33
+Montgomery,8 Bethel,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Gino Bulso,9
+Montgomery,8 Bethel,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,8 Bethel,U.S. House,7,Republican,Jody Barrett,12
+Montgomery,8 Bethel,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Lee Reeves,1
+Montgomery,8 Bethel,U.S. House,7,Republican,Mason Foley,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Matt Van Epps,64
+Montgomery,8 Bethel,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,8 Bethel,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Aftyn Behn,31
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Bo Mitchell,26
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Vincent Dixie,76
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Gino Bulso,16
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Jody Barrett,20
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Mason Foley,1
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Matt Van Epps,93
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,9B St John,U.S. House,7,Democratic,Aftyn Behn,36
+Montgomery,9B St John,U.S. House,7,Democratic,Bo Mitchell,18
+Montgomery,9B St John,U.S. House,7,Democratic,Darden Hunter Copeland,50
+Montgomery,9B St John,U.S. House,7,Democratic,Vincent Dixie,52
+Montgomery,9B St John,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,9B St John,U.S. House,7,Republican,Gino Bulso,13
+Montgomery,9B St John,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,9B St John,U.S. House,7,Republican,Jody Barrett,15
+Montgomery,9B St John,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,9B St John,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,9B St John,U.S. House,7,Republican,Mason Foley,2
+Montgomery,9B St John,U.S. House,7,Republican,Matt Van Epps,64
+Montgomery,9B St John,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,9B St John,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,9B St John,U.S. House,7,Republican,Tres Wittum,0
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Aftyn Behn,1
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Bo Mitchell,8
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Gino Bulso,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Jason D. Knight,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Jody Barrett,14
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Lee Reeves,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Matt Van Epps,31
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Stewart Parks,3
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Stuart Cooper,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Bo Mitchell,2
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Gino Bulso,3
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Jason D. Knight,1
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Jody Barrett,13
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Lee Reeves,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Matt Van Epps,15
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Stewart Parks,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Stuart Cooper,1
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,2-1 Pineview,U.S. House,7,Democratic,Aftyn Behn,1
+Perry,2-1 Pineview,U.S. House,7,Democratic,Bo Mitchell,16
+Perry,2-1 Pineview,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Perry,2-1 Pineview,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Gino Bulso,1
+Perry,2-1 Pineview,U.S. House,7,Republican,Jason D. Knight,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Jody Barrett,23
+Perry,2-1 Pineview,U.S. House,7,Republican,Joe Leurs,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Lee Reeves,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Mason Foley,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Matt Van Epps,26
+Perry,2-1 Pineview,U.S. House,7,Republican,Stewart Parks,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Stuart Cooper,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Tres Wittum,0
+Perry,2-2 Pope,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,2-2 Pope,U.S. House,7,Democratic,Bo Mitchell,3
+Perry,2-2 Pope,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Perry,2-2 Pope,U.S. House,7,Democratic,Vincent Dixie,1
+Perry,2-2 Pope,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,2-2 Pope,U.S. House,7,Republican,Gino Bulso,8
+Perry,2-2 Pope,U.S. House,7,Republican,Jason D. Knight,0
+Perry,2-2 Pope,U.S. House,7,Republican,Jody Barrett,7
+Perry,2-2 Pope,U.S. House,7,Republican,Joe Leurs,0
+Perry,2-2 Pope,U.S. House,7,Republican,Lee Reeves,4
+Perry,2-2 Pope,U.S. House,7,Republican,Mason Foley,1
+Perry,2-2 Pope,U.S. House,7,Republican,Matt Van Epps,20
+Perry,2-2 Pope,U.S. House,7,Republican,Stewart Parks,3
+Perry,2-2 Pope,U.S. House,7,Republican,Stuart Cooper,0
+Perry,2-2 Pope,U.S. House,7,Republican,Tres Wittum,0
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Aftyn Behn,4
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Bo Mitchell,19
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Gino Bulso,9
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Jason D. Knight,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Jody Barrett,22
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Lee Reeves,2
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Matt Van Epps,23
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Stewart Parks,3
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Stuart Cooper,1
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Aftyn Behn,1
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Bo Mitchell,5
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Gino Bulso,11
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Jason D. Knight,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Jody Barrett,10
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Joe Leurs,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Lee Reeves,1
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Mason Foley,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Matt Van Epps,19
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Stewart Parks,1
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Stuart Cooper,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Tres Wittum,0
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Bo Mitchell,8
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Gino Bulso,4
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Jason D. Knight,1
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Jody Barrett,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Lee Reeves,2
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Matt Van Epps,12
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Stewart Parks,1
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Stuart Cooper,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Aftyn Behn,2
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Bo Mitchell,10
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Gino Bulso,12
+Perry,4-3 Lobelville,U.S. House,7,Republican,Jason D. Knight,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Jody Barrett,17
+Perry,4-3 Lobelville,U.S. House,7,Republican,Joe Leurs,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Lee Reeves,1
+Perry,4-3 Lobelville,U.S. House,7,Republican,Mason Foley,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Matt Van Epps,28
+Perry,4-3 Lobelville,U.S. House,7,Republican,Stewart Parks,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Stuart Cooper,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Tres Wittum,0
+Perry,5-1 Linden,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,5-1 Linden,U.S. House,7,Democratic,Bo Mitchell,26
+Perry,5-1 Linden,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Perry,5-1 Linden,U.S. House,7,Democratic,Vincent Dixie,1
+Perry,5-1 Linden,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,5-1 Linden,U.S. House,7,Republican,Gino Bulso,7
+Perry,5-1 Linden,U.S. House,7,Republican,Jason D. Knight,1
+Perry,5-1 Linden,U.S. House,7,Republican,Jody Barrett,28
+Perry,5-1 Linden,U.S. House,7,Republican,Joe Leurs,0
+Perry,5-1 Linden,U.S. House,7,Republican,Lee Reeves,1
+Perry,5-1 Linden,U.S. House,7,Republican,Mason Foley,1
+Perry,5-1 Linden,U.S. House,7,Republican,Matt Van Epps,30
+Perry,5-1 Linden,U.S. House,7,Republican,Stewart Parks,3
+Perry,5-1 Linden,U.S. House,7,Republican,Stuart Cooper,0
+Perry,5-1 Linden,U.S. House,7,Republican,Tres Wittum,1
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Aftyn Behn,6
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Bo Mitchell,9
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Gino Bulso,5
+Perry,6-1 Lobelville,U.S. House,7,Republican,Jason D. Knight,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Jody Barrett,33
+Perry,6-1 Lobelville,U.S. House,7,Republican,Joe Leurs,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Lee Reeves,2
+Perry,6-1 Lobelville,U.S. House,7,Republican,Mason Foley,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Matt Van Epps,26
+Perry,6-1 Lobelville,U.S. House,7,Republican,Stewart Parks,4
+Perry,6-1 Lobelville,U.S. House,7,Republican,Stuart Cooper,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Tres Wittum,0
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Aftyn Behn,17
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Bo Mitchell,24
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Vincent Dixie,8
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Gino Bulso,48
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Jody Barrett,59
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Joe Leurs,2
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Lee Reeves,6
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Mason Foley,7
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Matt Van Epps,241
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Stewart Parks,4
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Tres Wittum,1
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Aftyn Behn,44
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Bo Mitchell,20
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Darden Hunter Copeland,51
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Vincent Dixie,11
+Robertson,02-1 Woodall,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,02-1 Woodall,U.S. House,7,Republican,Gino Bulso,29
+Robertson,02-1 Woodall,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,02-1 Woodall,U.S. House,7,Republican,Jody Barrett,28
+Robertson,02-1 Woodall,U.S. House,7,Republican,Joe Leurs,2
+Robertson,02-1 Woodall,U.S. House,7,Republican,Lee Reeves,17
+Robertson,02-1 Woodall,U.S. House,7,Republican,Mason Foley,19
+Robertson,02-1 Woodall,U.S. House,7,Republican,Matt Van Epps,182
+Robertson,02-1 Woodall,U.S. House,7,Republican,Stewart Parks,13
+Robertson,02-1 Woodall,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,02-1 Woodall,U.S. House,7,Republican,Tres Wittum,0
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Aftyn Behn,13
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Bo Mitchell,21
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Vincent Dixie,3
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Gino Bulso,21
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Jody Barrett,29
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Joe Leurs,0
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Lee Reeves,2
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Mason Foley,6
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Matt Van Epps,129
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Stewart Parks,8
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Tres Wittum,0
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Aftyn Behn,37
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Bo Mitchell,14
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Vincent Dixie,6
+Robertson,03-2 Heritage,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,03-2 Heritage,U.S. House,7,Republican,Gino Bulso,30
+Robertson,03-2 Heritage,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,03-2 Heritage,U.S. House,7,Republican,Jody Barrett,38
+Robertson,03-2 Heritage,U.S. House,7,Republican,Joe Leurs,0
+Robertson,03-2 Heritage,U.S. House,7,Republican,Lee Reeves,14
+Robertson,03-2 Heritage,U.S. House,7,Republican,Mason Foley,4
+Robertson,03-2 Heritage,U.S. House,7,Republican,Matt Van Epps,180
+Robertson,03-2 Heritage,U.S. House,7,Republican,Stewart Parks,9
+Robertson,03-2 Heritage,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,03-2 Heritage,U.S. House,7,Republican,Tres Wittum,2
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Aftyn Behn,27
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Bo Mitchell,56
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Darden Hunter Copeland,47
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Vincent Dixie,5
+Robertson,04-1 Watauga,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,04-1 Watauga,U.S. House,7,Republican,Gino Bulso,33
+Robertson,04-1 Watauga,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,04-1 Watauga,U.S. House,7,Republican,Jody Barrett,44
+Robertson,04-1 Watauga,U.S. House,7,Republican,Joe Leurs,0
+Robertson,04-1 Watauga,U.S. House,7,Republican,Lee Reeves,11
+Robertson,04-1 Watauga,U.S. House,7,Republican,Mason Foley,25
+Robertson,04-1 Watauga,U.S. House,7,Republican,Matt Van Epps,229
+Robertson,04-1 Watauga,U.S. House,7,Republican,Stewart Parks,2
+Robertson,04-1 Watauga,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,04-1 Watauga,U.S. House,7,Republican,Tres Wittum,3
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Aftyn Behn,23
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Bo Mitchell,31
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Darden Hunter Copeland,60
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Vincent Dixie,4
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Gino Bulso,43
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Jody Barrett,44
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Joe Leurs,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Lee Reeves,12
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Mason Foley,7
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Matt Van Epps,166
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Stewart Parks,2
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Tres Wittum,0
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Aftyn Behn,19
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Bo Mitchell,29
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Vincent Dixie,7
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Gino Bulso,42
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Jody Barrett,49
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Joe Leurs,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Lee Reeves,6
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Mason Foley,9
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Matt Van Epps,172
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Stewart Parks,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Tres Wittum,2
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Aftyn Behn,21
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Bo Mitchell,31
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Darden Hunter Copeland,20
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Vincent Dixie,7
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Gino Bulso,13
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Jody Barrett,39
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Joe Leurs,0
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Lee Reeves,11
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Mason Foley,7
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Matt Van Epps,138
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Stewart Parks,7
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Tres Wittum,0
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Aftyn Behn,11
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Bo Mitchell,23
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Vincent Dixie,3
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Gino Bulso,36
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Jason D. Knight,3
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Jody Barrett,46
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Joe Leurs,0
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Lee Reeves,11
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Mason Foley,9
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Matt Van Epps,244
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Stewart Parks,6
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Stuart Cooper,3
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Tres Wittum,0
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Aftyn Behn,6
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Bo Mitchell,7
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Vincent Dixie,2
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Gino Bulso,10
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Jody Barrett,28
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Joe Leurs,0
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Lee Reeves,2
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Mason Foley,1
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Matt Van Epps,103
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Stewart Parks,3
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Tres Wittum,0
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Aftyn Behn,6
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Bo Mitchell,8
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Vincent Dixie,2
+Robertson,08-1 Krisle,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,08-1 Krisle,U.S. House,7,Republican,Gino Bulso,16
+Robertson,08-1 Krisle,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,08-1 Krisle,U.S. House,7,Republican,Jody Barrett,25
+Robertson,08-1 Krisle,U.S. House,7,Republican,Joe Leurs,1
+Robertson,08-1 Krisle,U.S. House,7,Republican,Lee Reeves,3
+Robertson,08-1 Krisle,U.S. House,7,Republican,Mason Foley,0
+Robertson,08-1 Krisle,U.S. House,7,Republican,Matt Van Epps,84
+Robertson,08-1 Krisle,U.S. House,7,Republican,Stewart Parks,1
+Robertson,08-1 Krisle,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,08-1 Krisle,U.S. House,7,Republican,Tres Wittum,0
+Robertson,08-2 HATS,U.S. House,7,Democratic,Aftyn Behn,7
+Robertson,08-2 HATS,U.S. House,7,Democratic,Bo Mitchell,7
+Robertson,08-2 HATS,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Robertson,08-2 HATS,U.S. House,7,Democratic,Vincent Dixie,1
+Robertson,08-2 HATS,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,08-2 HATS,U.S. House,7,Republican,Gino Bulso,13
+Robertson,08-2 HATS,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,08-2 HATS,U.S. House,7,Republican,Jody Barrett,18
+Robertson,08-2 HATS,U.S. House,7,Republican,Joe Leurs,0
+Robertson,08-2 HATS,U.S. House,7,Republican,Lee Reeves,5
+Robertson,08-2 HATS,U.S. House,7,Republican,Mason Foley,3
+Robertson,08-2 HATS,U.S. House,7,Republican,Matt Van Epps,98
+Robertson,08-2 HATS,U.S. House,7,Republican,Stewart Parks,4
+Robertson,08-2 HATS,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,08-2 HATS,U.S. House,7,Republican,Tres Wittum,0
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Aftyn Behn,13
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Bo Mitchell,7
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Vincent Dixie,2
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Gino Bulso,19
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Jody Barrett,32
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Joe Leurs,0
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Lee Reeves,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Mason Foley,4
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Matt Van Epps,157
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Stewart Parks,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Tres Wittum,0
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Aftyn Behn,28
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Bo Mitchell,27
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Darden Hunter Copeland,84
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Vincent Dixie,16
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Gino Bulso,48
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Jason D. Knight,5
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Jody Barrett,24
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Joe Leurs,0
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Lee Reeves,8
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Mason Foley,16
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Matt Van Epps,164
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Stewart Parks,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Stuart Cooper,3
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Tres Wittum,1
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Aftyn Behn,31
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Bo Mitchell,42
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Darden Hunter Copeland,88
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Vincent Dixie,18
+Robertson,10-1 South Haven,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,10-1 South Haven,U.S. House,7,Republican,Gino Bulso,44
+Robertson,10-1 South Haven,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,10-1 South Haven,U.S. House,7,Republican,Jody Barrett,51
+Robertson,10-1 South Haven,U.S. House,7,Republican,Joe Leurs,0
+Robertson,10-1 South Haven,U.S. House,7,Republican,Lee Reeves,26
+Robertson,10-1 South Haven,U.S. House,7,Republican,Mason Foley,12
+Robertson,10-1 South Haven,U.S. House,7,Republican,Matt Van Epps,257
+Robertson,10-1 South Haven,U.S. House,7,Republican,Stewart Parks,3
+Robertson,10-1 South Haven,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,10-1 South Haven,U.S. House,7,Republican,Tres Wittum,1
+Robertson,11-1 Westside,U.S. House,7,Democratic,Aftyn Behn,50
+Robertson,11-1 Westside,U.S. House,7,Democratic,Bo Mitchell,33
+Robertson,11-1 Westside,U.S. House,7,Democratic,Darden Hunter Copeland,73
+Robertson,11-1 Westside,U.S. House,7,Democratic,Vincent Dixie,13
+Robertson,11-1 Westside,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,11-1 Westside,U.S. House,7,Republican,Gino Bulso,28
+Robertson,11-1 Westside,U.S. House,7,Republican,Jason D. Knight,3
+Robertson,11-1 Westside,U.S. House,7,Republican,Jody Barrett,53
+Robertson,11-1 Westside,U.S. House,7,Republican,Joe Leurs,1
+Robertson,11-1 Westside,U.S. House,7,Republican,Lee Reeves,9
+Robertson,11-1 Westside,U.S. House,7,Republican,Mason Foley,8
+Robertson,11-1 Westside,U.S. House,7,Republican,Matt Van Epps,200
+Robertson,11-1 Westside,U.S. House,7,Republican,Stewart Parks,3
+Robertson,11-1 Westside,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,11-1 Westside,U.S. House,7,Republican,Tres Wittum,3
+Robertson,11-2 Heads,U.S. House,7,Democratic,Aftyn Behn,2
+Robertson,11-2 Heads,U.S. House,7,Democratic,Bo Mitchell,1
+Robertson,11-2 Heads,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Robertson,11-2 Heads,U.S. House,7,Democratic,Vincent Dixie,1
+Robertson,11-2 Heads,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Gino Bulso,20
+Robertson,11-2 Heads,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,11-2 Heads,U.S. House,7,Republican,Jody Barrett,16
+Robertson,11-2 Heads,U.S. House,7,Republican,Joe Leurs,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Lee Reeves,8
+Robertson,11-2 Heads,U.S. House,7,Republican,Mason Foley,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Matt Van Epps,54
+Robertson,11-2 Heads,U.S. House,7,Republican,Stewart Parks,1
+Robertson,11-2 Heads,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Tres Wittum,0
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Aftyn Behn,17
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Bo Mitchell,36
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Darden Hunter Copeland,52
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Vincent Dixie,31
+Robertson,12-1 Bransford,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Gino Bulso,10
+Robertson,12-1 Bransford,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Jody Barrett,5
+Robertson,12-1 Bransford,U.S. House,7,Republican,Joe Leurs,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Lee Reeves,1
+Robertson,12-1 Bransford,U.S. House,7,Republican,Mason Foley,4
+Robertson,12-1 Bransford,U.S. House,7,Republican,Matt Van Epps,12
+Robertson,12-1 Bransford,U.S. House,7,Republican,Stewart Parks,1
+Robertson,12-1 Bransford,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Tres Wittum,0
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Bo Mitchell,6
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Vincent Dixie,2
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Gino Bulso,13
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Jason D. Knight,0
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Jody Barrett,13
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Joe Leurs,0
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Lee Reeves,3
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Mason Foley,1
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Matt Van Epps,64
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Stewart Parks,4
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Stuart Cooper,1
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Tres Wittum,0
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Aftyn Behn,7
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Bo Mitchell,4
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Vincent Dixie,2
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Gino Bulso,17
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Jason D. Knight,6
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Jody Barrett,17
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Joe Leurs,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Lee Reeves,3
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Mason Foley,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Matt Van Epps,70
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Stewart Parks,7
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Tres Wittum,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Bo Mitchell,7
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Vincent Dixie,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Gino Bulso,19
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Jason D. Knight,2
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Jody Barrett,37
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Joe Leurs,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Lee Reeves,8
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Mason Foley,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Matt Van Epps,112
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Stewart Parks,7
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Tres Wittum,1
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Aftyn Behn,8
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Bo Mitchell,9
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Vincent Dixie,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Gino Bulso,15
+Stewart,4-1 Church Street,U.S. House,7,Republican,Jason D. Knight,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Jody Barrett,22
+Stewart,4-1 Church Street,U.S. House,7,Republican,Joe Leurs,0
+Stewart,4-1 Church Street,U.S. House,7,Republican,Lee Reeves,3
+Stewart,4-1 Church Street,U.S. House,7,Republican,Mason Foley,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Matt Van Epps,67
+Stewart,4-1 Church Street,U.S. House,7,Republican,Stewart Parks,3
+Stewart,4-1 Church Street,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,4-1 Church Street,U.S. House,7,Republican,Tres Wittum,0
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Aftyn Behn,5
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Bo Mitchell,16
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Vincent Dixie,2
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Gino Bulso,34
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Jason D. Knight,1
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Jody Barrett,19
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Joe Leurs,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Lee Reeves,8
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Mason Foley,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Matt Van Epps,101
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Stewart Parks,3
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Tres Wittum,1
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Bo Mitchell,25
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Vincent Dixie,5
+Stewart,6-1 Public Library,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,6-1 Public Library,U.S. House,7,Republican,Gino Bulso,27
+Stewart,6-1 Public Library,U.S. House,7,Republican,Jason D. Knight,5
+Stewart,6-1 Public Library,U.S. House,7,Republican,Jody Barrett,27
+Stewart,6-1 Public Library,U.S. House,7,Republican,Joe Leurs,2
+Stewart,6-1 Public Library,U.S. House,7,Republican,Lee Reeves,2
+Stewart,6-1 Public Library,U.S. House,7,Republican,Mason Foley,2
+Stewart,6-1 Public Library,U.S. House,7,Republican,Matt Van Epps,84
+Stewart,6-1 Public Library,U.S. House,7,Republican,Stewart Parks,10
+Stewart,6-1 Public Library,U.S. House,7,Republican,Stuart Cooper,1
+Stewart,6-1 Public Library,U.S. House,7,Republican,Tres Wittum,0
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Bo Mitchell,13
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Vincent Dixie,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Gino Bulso,39
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Jason D. Knight,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Jody Barrett,12
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Joe Leurs,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Lee Reeves,7
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Mason Foley,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Matt Van Epps,92
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Stewart Parks,6
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Tres Wittum,0
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Aftyn Behn,5
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Bo Mitchell,15
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Darden Hunter Copeland,20
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Vincent Dixie,1
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Gino Bulso,14
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Jason D. Knight,1
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Jody Barrett,43
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Joe Leurs,0
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Lee Reeves,5
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Mason Foley,2
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Matt Van Epps,66
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Stewart Parks,8
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Tres Wittum,0
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Bo Mitchell,2
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Gino Bulso,2
+Wayne,2-1 Clifton,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Jody Barrett,7
+Wayne,2-1 Clifton,U.S. House,7,Republican,Joe Leurs,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Lee Reeves,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Mason Foley,1
+Wayne,2-1 Clifton,U.S. House,7,Republican,Matt Van Epps,13
+Wayne,2-1 Clifton,U.S. House,7,Republican,Stewart Parks,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Tres Wittum,0
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Bo Mitchell,1
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Gino Bulso,3
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Jody Barrett,29
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Joe Leurs,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Lee Reeves,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Mason Foley,2
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Matt Van Epps,44
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Stewart Parks,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Tres Wittum,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Bo Mitchell,4
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Vincent Dixie,1
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Gino Bulso,5
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Jody Barrett,22
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Joe Leurs,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Lee Reeves,3
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Mason Foley,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Matt Van Epps,21
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Stewart Parks,6
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Stuart Cooper,2
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Tres Wittum,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Bo Mitchell,4
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Gino Bulso,3
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Jody Barrett,12
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Joe Leurs,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Lee Reeves,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Mason Foley,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Matt Van Epps,21
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Stewart Parks,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Tres Wittum,0
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Aftyn Behn,2
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Bo Mitchell,7
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Vincent Dixie,2
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Gino Bulso,6
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Jody Barrett,14
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Joe Leurs,0
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Lee Reeves,1
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Mason Foley,4
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Matt Van Epps,37
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Stewart Parks,5
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Stuart Cooper,2
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Tres Wittum,0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Bo Mitchell,0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Gino Bulso,3
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Jody Barrett,16
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Joe Leurs,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Lee Reeves,2
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Mason Foley,6
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Matt Van Epps,25
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Stewart Parks,3
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Tres Wittum,0
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Aftyn Behn,2
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Bo Mitchell,1
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Gino Bulso,6
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Jody Barrett,21
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Joe Leurs,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Lee Reeves,3
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Mason Foley,1
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Matt Van Epps,44
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Stewart Parks,2
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Tres Wittum,0
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Bo Mitchell,2
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Vincent Dixie,2
+Wayne,5-2 Lutts,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Gino Bulso,7
+Wayne,5-2 Lutts,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Jody Barrett,5
+Wayne,5-2 Lutts,U.S. House,7,Republican,Joe Leurs,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Lee Reeves,1
+Wayne,5-2 Lutts,U.S. House,7,Republican,Mason Foley,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Matt Van Epps,24
+Wayne,5-2 Lutts,U.S. House,7,Republican,Stewart Parks,3
+Wayne,5-2 Lutts,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Tres Wittum,0
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Bo Mitchell,6
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Vincent Dixie,1
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Gino Bulso,5
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Jody Barrett,11
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Joe Leurs,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Lee Reeves,1
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Mason Foley,1
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Matt Van Epps,14
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Stewart Parks,4
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Tres Wittum,0
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Bo Mitchell,2
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Gino Bulso,1
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Jody Barrett,14
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Joe Leurs,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Lee Reeves,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Mason Foley,1
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Matt Van Epps,27
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Stewart Parks,1
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Tres Wittum,0
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Bo Mitchell,1
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Gino Bulso,5
+Wayne,6-2 South Gate,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Jody Barrett,40
+Wayne,6-2 South Gate,U.S. House,7,Republican,Joe Leurs,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Lee Reeves,9
+Wayne,6-2 South Gate,U.S. House,7,Republican,Mason Foley,7
+Wayne,6-2 South Gate,U.S. House,7,Republican,Matt Van Epps,41
+Wayne,6-2 South Gate,U.S. House,7,Republican,Stewart Parks,2
+Wayne,6-2 South Gate,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Tres Wittum,0
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Bo Mitchell,5
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Gino Bulso,3
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Jody Barrett,14
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Joe Leurs,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Lee Reeves,1
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Mason Foley,1
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Matt Van Epps,33
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Stewart Parks,3
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Stuart Cooper,1
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Tres Wittum,0
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Aftyn Behn,2
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Bo Mitchell,6
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Gino Bulso,6
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Jason D. Knight,1
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Jody Barrett,20
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Joe Leurs,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Lee Reeves,3
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Mason Foley,1
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Matt Van Epps,47
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Stewart Parks,3
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Tres Wittum,0
+Williamson,1-1,U.S. House,7,Democratic,Aftyn Behn,79
+Williamson,1-1,U.S. House,7,Democratic,Bo Mitchell,83
+Williamson,1-1,U.S. House,7,Democratic,Darden Hunter Copeland,78
+Williamson,1-1,U.S. House,7,Democratic,Vincent Dixie,16
+Williamson,1-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,1-1,U.S. House,7,Republican,Gino Bulso,62
+Williamson,1-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,1-1,U.S. House,7,Republican,Jody Barrett,116
+Williamson,1-1,U.S. House,7,Republican,Joe Leurs,0
+Williamson,1-1,U.S. House,7,Republican,Lee Reeves,99
+Williamson,1-1,U.S. House,7,Republican,Mason Foley,67
+Williamson,1-1,U.S. House,7,Republican,Matt Van Epps,249
+Williamson,1-1,U.S. House,7,Republican,Stewart Parks,21
+Williamson,1-1,U.S. House,7,Republican,Stuart Cooper,5
+Williamson,1-1,U.S. House,7,Republican,Tres Wittum,5
+Williamson,1-5,U.S. House,7,Democratic,Aftyn Behn,35
+Williamson,1-5,U.S. House,7,Democratic,Bo Mitchell,19
+Williamson,1-5,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Williamson,1-5,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,1-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,1-5,U.S. House,7,Republican,Gino Bulso,15
+Williamson,1-5,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,1-5,U.S. House,7,Republican,Jody Barrett,72
+Williamson,1-5,U.S. House,7,Republican,Joe Leurs,0
+Williamson,1-5,U.S. House,7,Republican,Lee Reeves,29
+Williamson,1-5,U.S. House,7,Republican,Mason Foley,13
+Williamson,1-5,U.S. House,7,Republican,Matt Van Epps,106
+Williamson,1-5,U.S. House,7,Republican,Stewart Parks,4
+Williamson,1-5,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,1-5,U.S. House,7,Republican,Tres Wittum,0
+Williamson,1-6,U.S. House,7,Democratic,Aftyn Behn,55
+Williamson,1-6,U.S. House,7,Democratic,Bo Mitchell,73
+Williamson,1-6,U.S. House,7,Democratic,Darden Hunter Copeland,48
+Williamson,1-6,U.S. House,7,Democratic,Vincent Dixie,5
+Williamson,1-6,U.S. House,7,Republican,Adolph Agbéko Dagan,5
+Williamson,1-6,U.S. House,7,Republican,Gino Bulso,31
+Williamson,1-6,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,1-6,U.S. House,7,Republican,Jody Barrett,119
+Williamson,1-6,U.S. House,7,Republican,Joe Leurs,3
+Williamson,1-6,U.S. House,7,Republican,Lee Reeves,112
+Williamson,1-6,U.S. House,7,Republican,Mason Foley,49
+Williamson,1-6,U.S. House,7,Republican,Matt Van Epps,193
+Williamson,1-6,U.S. House,7,Republican,Stewart Parks,28
+Williamson,1-6,U.S. House,7,Republican,Stuart Cooper,5
+Williamson,1-6,U.S. House,7,Republican,Tres Wittum,1
+Williamson,10-1,U.S. House,7,Democratic,Aftyn Behn,131
+Williamson,10-1,U.S. House,7,Democratic,Bo Mitchell,68
+Williamson,10-1,U.S. House,7,Democratic,Darden Hunter Copeland,119
+Williamson,10-1,U.S. House,7,Democratic,Vincent Dixie,14
+Williamson,10-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,10-1,U.S. House,7,Republican,Gino Bulso,54
+Williamson,10-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,10-1,U.S. House,7,Republican,Jody Barrett,87
+Williamson,10-1,U.S. House,7,Republican,Joe Leurs,1
+Williamson,10-1,U.S. House,7,Republican,Lee Reeves,24
+Williamson,10-1,U.S. House,7,Republican,Mason Foley,22
+Williamson,10-1,U.S. House,7,Republican,Matt Van Epps,116
+Williamson,10-1,U.S. House,7,Republican,Stewart Parks,4
+Williamson,10-1,U.S. House,7,Republican,Stuart Cooper,3
+Williamson,10-1,U.S. House,7,Republican,Tres Wittum,1
+Williamson,10-2,U.S. House,7,Democratic,Aftyn Behn,93
+Williamson,10-2,U.S. House,7,Democratic,Bo Mitchell,34
+Williamson,10-2,U.S. House,7,Democratic,Darden Hunter Copeland,69
+Williamson,10-2,U.S. House,7,Democratic,Vincent Dixie,8
+Williamson,10-2,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Williamson,10-2,U.S. House,7,Republican,Gino Bulso,38
+Williamson,10-2,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,10-2,U.S. House,7,Republican,Jody Barrett,81
+Williamson,10-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-2,U.S. House,7,Republican,Lee Reeves,47
+Williamson,10-2,U.S. House,7,Republican,Mason Foley,10
+Williamson,10-2,U.S. House,7,Republican,Matt Van Epps,93
+Williamson,10-2,U.S. House,7,Republican,Stewart Parks,0
+Williamson,10-2,U.S. House,7,Republican,Stuart Cooper,6
+Williamson,10-2,U.S. House,7,Republican,Tres Wittum,3
+Williamson,10-3,U.S. House,7,Democratic,Aftyn Behn,6
+Williamson,10-3,U.S. House,7,Democratic,Bo Mitchell,3
+Williamson,10-3,U.S. House,7,Democratic,Darden Hunter Copeland,6
+Williamson,10-3,U.S. House,7,Democratic,Vincent Dixie,2
+Williamson,10-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,10-3,U.S. House,7,Republican,Gino Bulso,9
+Williamson,10-3,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,10-3,U.S. House,7,Republican,Jody Barrett,8
+Williamson,10-3,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-3,U.S. House,7,Republican,Lee Reeves,1
+Williamson,10-3,U.S. House,7,Republican,Mason Foley,2
+Williamson,10-3,U.S. House,7,Republican,Matt Van Epps,14
+Williamson,10-3,U.S. House,7,Republican,Stewart Parks,0
+Williamson,10-3,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,10-3,U.S. House,7,Republican,Tres Wittum,0
+Williamson,10-4,U.S. House,7,Democratic,Aftyn Behn,72
+Williamson,10-4,U.S. House,7,Democratic,Bo Mitchell,24
+Williamson,10-4,U.S. House,7,Democratic,Darden Hunter Copeland,56
+Williamson,10-4,U.S. House,7,Democratic,Vincent Dixie,15
+Williamson,10-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,10-4,U.S. House,7,Republican,Gino Bulso,37
+Williamson,10-4,U.S. House,7,Republican,Jason D. Knight,3
+Williamson,10-4,U.S. House,7,Republican,Jody Barrett,52
+Williamson,10-4,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-4,U.S. House,7,Republican,Lee Reeves,7
+Williamson,10-4,U.S. House,7,Republican,Mason Foley,24
+Williamson,10-4,U.S. House,7,Republican,Matt Van Epps,78
+Williamson,10-4,U.S. House,7,Republican,Stewart Parks,1
+Williamson,10-4,U.S. House,7,Republican,Stuart Cooper,3
+Williamson,10-4,U.S. House,7,Republican,Tres Wittum,3
+Williamson,10-5,U.S. House,7,Democratic,Aftyn Behn,76
+Williamson,10-5,U.S. House,7,Democratic,Bo Mitchell,30
+Williamson,10-5,U.S. House,7,Democratic,Darden Hunter Copeland,59
+Williamson,10-5,U.S. House,7,Democratic,Vincent Dixie,22
+Williamson,10-5,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,10-5,U.S. House,7,Republican,Gino Bulso,18
+Williamson,10-5,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,10-5,U.S. House,7,Republican,Jody Barrett,53
+Williamson,10-5,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-5,U.S. House,7,Republican,Lee Reeves,24
+Williamson,10-5,U.S. House,7,Republican,Mason Foley,14
+Williamson,10-5,U.S. House,7,Republican,Matt Van Epps,46
+Williamson,10-5,U.S. House,7,Republican,Stewart Parks,0
+Williamson,10-5,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,10-5,U.S. House,7,Republican,Tres Wittum,2
+Williamson,10-6,U.S. House,7,Democratic,Aftyn Behn,27
+Williamson,10-6,U.S. House,7,Democratic,Bo Mitchell,22
+Williamson,10-6,U.S. House,7,Democratic,Darden Hunter Copeland,25
+Williamson,10-6,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,10-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,10-6,U.S. House,7,Republican,Gino Bulso,37
+Williamson,10-6,U.S. House,7,Republican,Jason D. Knight,3
+Williamson,10-6,U.S. House,7,Republican,Jody Barrett,59
+Williamson,10-6,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-6,U.S. House,7,Republican,Lee Reeves,20
+Williamson,10-6,U.S. House,7,Republican,Mason Foley,7
+Williamson,10-6,U.S. House,7,Republican,Matt Van Epps,76
+Williamson,10-6,U.S. House,7,Republican,Stewart Parks,3
+Williamson,10-6,U.S. House,7,Republican,Stuart Cooper,1
+Williamson,10-6,U.S. House,7,Republican,Tres Wittum,2
+Williamson,11-1,U.S. House,7,Democratic,Aftyn Behn,150
+Williamson,11-1,U.S. House,7,Democratic,Bo Mitchell,62
+Williamson,11-1,U.S. House,7,Democratic,Darden Hunter Copeland,118
+Williamson,11-1,U.S. House,7,Democratic,Vincent Dixie,20
+Williamson,11-1,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Williamson,11-1,U.S. House,7,Republican,Gino Bulso,32
+Williamson,11-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,11-1,U.S. House,7,Republican,Jody Barrett,134
+Williamson,11-1,U.S. House,7,Republican,Joe Leurs,2
+Williamson,11-1,U.S. House,7,Republican,Lee Reeves,92
+Williamson,11-1,U.S. House,7,Republican,Mason Foley,59
+Williamson,11-1,U.S. House,7,Republican,Matt Van Epps,198
+Williamson,11-1,U.S. House,7,Republican,Stewart Parks,1
+Williamson,11-1,U.S. House,7,Republican,Stuart Cooper,16
+Williamson,11-1,U.S. House,7,Republican,Tres Wittum,0
+Williamson,11-2,U.S. House,7,Democratic,Aftyn Behn,7
+Williamson,11-2,U.S. House,7,Democratic,Bo Mitchell,2
+Williamson,11-2,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Williamson,11-2,U.S. House,7,Democratic,Vincent Dixie,0
+Williamson,11-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,11-2,U.S. House,7,Republican,Gino Bulso,3
+Williamson,11-2,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,11-2,U.S. House,7,Republican,Jody Barrett,3
+Williamson,11-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,11-2,U.S. House,7,Republican,Lee Reeves,1
+Williamson,11-2,U.S. House,7,Republican,Mason Foley,1
+Williamson,11-2,U.S. House,7,Republican,Matt Van Epps,15
+Williamson,11-2,U.S. House,7,Republican,Stewart Parks,0
+Williamson,11-2,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,11-2,U.S. House,7,Republican,Tres Wittum,0
+Williamson,11-3,U.S. House,7,Democratic,Aftyn Behn,33
+Williamson,11-3,U.S. House,7,Democratic,Bo Mitchell,10
+Williamson,11-3,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Williamson,11-3,U.S. House,7,Democratic,Vincent Dixie,3
+Williamson,11-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,11-3,U.S. House,7,Republican,Gino Bulso,15
+Williamson,11-3,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,11-3,U.S. House,7,Republican,Jody Barrett,60
+Williamson,11-3,U.S. House,7,Republican,Joe Leurs,0
+Williamson,11-3,U.S. House,7,Republican,Lee Reeves,10
+Williamson,11-3,U.S. House,7,Republican,Mason Foley,10
+Williamson,11-3,U.S. House,7,Republican,Matt Van Epps,73
+Williamson,11-3,U.S. House,7,Republican,Stewart Parks,3
+Williamson,11-3,U.S. House,7,Republican,Stuart Cooper,4
+Williamson,11-3,U.S. House,7,Republican,Tres Wittum,1
+Williamson,11-4,U.S. House,7,Democratic,Aftyn Behn,59
+Williamson,11-4,U.S. House,7,Democratic,Bo Mitchell,32
+Williamson,11-4,U.S. House,7,Democratic,Darden Hunter Copeland,53
+Williamson,11-4,U.S. House,7,Democratic,Vincent Dixie,43
+Williamson,11-4,U.S. House,7,Republican,Adolph Agbéko Dagan,4
+Williamson,11-4,U.S. House,7,Republican,Gino Bulso,28
+Williamson,11-4,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,11-4,U.S. House,7,Republican,Jody Barrett,59
+Williamson,11-4,U.S. House,7,Republican,Joe Leurs,1
+Williamson,11-4,U.S. House,7,Republican,Lee Reeves,28
+Williamson,11-4,U.S. House,7,Republican,Mason Foley,14
+Williamson,11-4,U.S. House,7,Republican,Matt Van Epps,88
+Williamson,11-4,U.S. House,7,Republican,Stewart Parks,3
+Williamson,11-4,U.S. House,7,Republican,Stuart Cooper,1
+Williamson,11-4,U.S. House,7,Republican,Tres Wittum,0
+Williamson,11-5,U.S. House,7,Democratic,Aftyn Behn,58
+Williamson,11-5,U.S. House,7,Democratic,Bo Mitchell,44
+Williamson,11-5,U.S. House,7,Democratic,Darden Hunter Copeland,74
+Williamson,11-5,U.S. House,7,Democratic,Vincent Dixie,35
+Williamson,11-5,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Williamson,11-5,U.S. House,7,Republican,Gino Bulso,32
+Williamson,11-5,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,11-5,U.S. House,7,Republican,Jody Barrett,104
+Williamson,11-5,U.S. House,7,Republican,Joe Leurs,1
+Williamson,11-5,U.S. House,7,Republican,Lee Reeves,44
+Williamson,11-5,U.S. House,7,Republican,Mason Foley,16
+Williamson,11-5,U.S. House,7,Republican,Matt Van Epps,152
+Williamson,11-5,U.S. House,7,Republican,Stewart Parks,6
+Williamson,11-5,U.S. House,7,Republican,Stuart Cooper,2
+Williamson,11-5,U.S. House,7,Republican,Tres Wittum,1
+Williamson,12-1,U.S. House,7,Democratic,Aftyn Behn,137
+Williamson,12-1,U.S. House,7,Democratic,Bo Mitchell,47
+Williamson,12-1,U.S. House,7,Democratic,Darden Hunter Copeland,106
+Williamson,12-1,U.S. House,7,Democratic,Vincent Dixie,18
+Williamson,12-1,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Williamson,12-1,U.S. House,7,Republican,Gino Bulso,48
+Williamson,12-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,12-1,U.S. House,7,Republican,Jody Barrett,162
+Williamson,12-1,U.S. House,7,Republican,Joe Leurs,4
+Williamson,12-1,U.S. House,7,Republican,Lee Reeves,47
+Williamson,12-1,U.S. House,7,Republican,Mason Foley,30
+Williamson,12-1,U.S. House,7,Republican,Matt Van Epps,204
+Williamson,12-1,U.S. House,7,Republican,Stewart Parks,0
+Williamson,12-1,U.S. House,7,Republican,Stuart Cooper,12
+Williamson,12-1,U.S. House,7,Republican,Tres Wittum,1
+Williamson,2-1,U.S. House,7,Democratic,Aftyn Behn,45
+Williamson,2-1,U.S. House,7,Democratic,Bo Mitchell,29
+Williamson,2-1,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Williamson,2-1,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,2-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,2-1,U.S. House,7,Republican,Gino Bulso,27
+Williamson,2-1,U.S. House,7,Republican,Jason D. Knight,3
+Williamson,2-1,U.S. House,7,Republican,Jody Barrett,48
+Williamson,2-1,U.S. House,7,Republican,Joe Leurs,1
+Williamson,2-1,U.S. House,7,Republican,Lee Reeves,21
+Williamson,2-1,U.S. House,7,Republican,Mason Foley,14
+Williamson,2-1,U.S. House,7,Republican,Matt Van Epps,107
+Williamson,2-1,U.S. House,7,Republican,Stewart Parks,0
+Williamson,2-1,U.S. House,7,Republican,Stuart Cooper,1
+Williamson,2-1,U.S. House,7,Republican,Tres Wittum,2
+Williamson,7-2,U.S. House,7,Democratic,Aftyn Behn,6
+Williamson,7-2,U.S. House,7,Democratic,Bo Mitchell,5
+Williamson,7-2,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Williamson,7-2,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,7-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,7-2,U.S. House,7,Republican,Gino Bulso,7
+Williamson,7-2,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,7-2,U.S. House,7,Republican,Jody Barrett,6
+Williamson,7-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,7-2,U.S. House,7,Republican,Lee Reeves,6
+Williamson,7-2,U.S. House,7,Republican,Mason Foley,1
+Williamson,7-2,U.S. House,7,Republican,Matt Van Epps,11
+Williamson,7-2,U.S. House,7,Republican,Stewart Parks,0
+Williamson,7-2,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,7-2,U.S. House,7,Republican,Tres Wittum,2
+Williamson,8-2,U.S. House,7,Democratic,Aftyn Behn,70
+Williamson,8-2,U.S. House,7,Democratic,Bo Mitchell,27
+Williamson,8-2,U.S. House,7,Democratic,Darden Hunter Copeland,52
+Williamson,8-2,U.S. House,7,Democratic,Vincent Dixie,5
+Williamson,8-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,8-2,U.S. House,7,Republican,Gino Bulso,92
+Williamson,8-2,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,8-2,U.S. House,7,Republican,Jody Barrett,47
+Williamson,8-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,8-2,U.S. House,7,Republican,Lee Reeves,22
+Williamson,8-2,U.S. House,7,Republican,Mason Foley,6
+Williamson,8-2,U.S. House,7,Republican,Matt Van Epps,90
+Williamson,8-2,U.S. House,7,Republican,Stewart Parks,3
+Williamson,8-2,U.S. House,7,Republican,Stuart Cooper,2
+Williamson,8-2,U.S. House,7,Republican,Tres Wittum,0
+Williamson,8-4,U.S. House,7,Democratic,Aftyn Behn,49
+Williamson,8-4,U.S. House,7,Democratic,Bo Mitchell,37
+Williamson,8-4,U.S. House,7,Democratic,Darden Hunter Copeland,52
+Williamson,8-4,U.S. House,7,Democratic,Vincent Dixie,16
+Williamson,8-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,8-4,U.S. House,7,Republican,Gino Bulso,74
+Williamson,8-4,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,8-4,U.S. House,7,Republican,Jody Barrett,47
+Williamson,8-4,U.S. House,7,Republican,Joe Leurs,0
+Williamson,8-4,U.S. House,7,Republican,Lee Reeves,14
+Williamson,8-4,U.S. House,7,Republican,Mason Foley,18
+Williamson,8-4,U.S. House,7,Republican,Matt Van Epps,138
+Williamson,8-4,U.S. House,7,Republican,Stewart Parks,0
+Williamson,8-4,U.S. House,7,Republican,Stuart Cooper,5
+Williamson,8-4,U.S. House,7,Republican,Tres Wittum,1
+Williamson,9-3,U.S. House,7,Democratic,Aftyn Behn,56
+Williamson,9-3,U.S. House,7,Democratic,Bo Mitchell,30
+Williamson,9-3,U.S. House,7,Democratic,Darden Hunter Copeland,131
+Williamson,9-3,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,9-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,9-3,U.S. House,7,Republican,Gino Bulso,28
+Williamson,9-3,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,9-3,U.S. House,7,Republican,Jody Barrett,319
+Williamson,9-3,U.S. House,7,Republican,Joe Leurs,2
+Williamson,9-3,U.S. House,7,Republican,Lee Reeves,104
+Williamson,9-3,U.S. House,7,Republican,Mason Foley,19
+Williamson,9-3,U.S. House,7,Republican,Matt Van Epps,184
+Williamson,9-3,U.S. House,7,Republican,Stewart Parks,0
+Williamson,9-3,U.S. House,7,Republican,Stuart Cooper,2
+Williamson,9-3,U.S. House,7,Republican,Tres Wittum,3
+Williamson,9-6,U.S. House,7,Democratic,Aftyn Behn,79
+Williamson,9-6,U.S. House,7,Democratic,Bo Mitchell,58
+Williamson,9-6,U.S. House,7,Democratic,Darden Hunter Copeland,102
+Williamson,9-6,U.S. House,7,Democratic,Vincent Dixie,13
+Williamson,9-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,9-6,U.S. House,7,Republican,Gino Bulso,44
+Williamson,9-6,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,9-6,U.S. House,7,Republican,Jody Barrett,161
+Williamson,9-6,U.S. House,7,Republican,Joe Leurs,1
+Williamson,9-6,U.S. House,7,Republican,Lee Reeves,76
+Williamson,9-6,U.S. House,7,Republican,Mason Foley,12
+Williamson,9-6,U.S. House,7,Republican,Matt Van Epps,163
+Williamson,9-6,U.S. House,7,Republican,Stewart Parks,5
+Williamson,9-6,U.S. House,7,Republican,Stuart Cooper,8
+Williamson,9-6,U.S. House,7,Republican,Tres Wittum,0

--- a/2025/20251202__tn__special__general__county.csv
+++ b/2025/20251202__tn__special__general__county.csv
@@ -1,0 +1,85 @@
+county,office,district,party,candidate,votes
+Benton,U.S. House,7,Democratic,Aftyn Behn,470
+Benton,U.S. House,7,Republican,Matt Van Epps,1724
+Benton,U.S. House,7,Independent,Bobby Dodge,7
+Benton,U.S. House,7,Independent,Jon Thorp,16
+Benton,U.S. House,7,Independent,Robert James Sutherby,6
+Benton,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Cheatham,U.S. House,7,Democratic,Aftyn Behn,3910
+Cheatham,U.S. House,7,Republican,Matt Van Epps,7917
+Cheatham,U.S. House,7,Independent,Bobby Dodge,13
+Cheatham,U.S. House,7,Independent,Jon Thorp,63
+Cheatham,U.S. House,7,Independent,Robert James Sutherby,6
+Cheatham,U.S. House,7,Independent,"Teresa ""Terri"" Christie",38
+Davidson,U.S. House,7,Democratic,Aftyn Behn,32990
+Davidson,U.S. House,7,Republican,Matt Van Epps,9163
+Davidson,U.S. House,7,Independent,Bobby Dodge,46
+Davidson,U.S. House,7,Independent,Jon Thorp,135
+Davidson,U.S. House,7,Independent,Robert James Sutherby,27
+Davidson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",122
+Decatur,U.S. House,7,Democratic,Aftyn Behn,486
+Decatur,U.S. House,7,Republican,Matt Van Epps,1970
+Decatur,U.S. House,7,Independent,Bobby Dodge,2
+Decatur,U.S. House,7,Independent,Jon Thorp,13
+Decatur,U.S. House,7,Independent,Robert James Sutherby,3
+Decatur,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Dickson,U.S. House,7,Democratic,Aftyn Behn,3812
+Dickson,U.S. House,7,Republican,Matt Van Epps,9169
+Dickson,U.S. House,7,Independent,Bobby Dodge,17
+Dickson,U.S. House,7,Independent,Jon Thorp,75
+Dickson,U.S. House,7,Independent,Robert James Sutherby,8
+Dickson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",30
+Hickman,U.S. House,7,Democratic,Aftyn Behn,1157
+Hickman,U.S. House,7,Republican,Matt Van Epps,3883
+Hickman,U.S. House,7,Independent,Bobby Dodge,11
+Hickman,U.S. House,7,Independent,Jon Thorp,34
+Hickman,U.S. House,7,Independent,Robert James Sutherby,3
+Hickman,U.S. House,7,Independent,"Teresa ""Terri"" Christie",28
+Houston,U.S. House,7,Democratic,Aftyn Behn,506
+Houston,U.S. House,7,Republican,Matt Van Epps,1408
+Houston,U.S. House,7,Independent,Bobby Dodge,1
+Houston,U.S. House,7,Independent,Jon Thorp,11
+Houston,U.S. House,7,Independent,Robert James Sutherby,3
+Houston,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Humphreys,U.S. House,7,Democratic,Aftyn Behn,1159
+Humphreys,U.S. House,7,Republican,Matt Van Epps,3035
+Humphreys,U.S. House,7,Independent,Bobby Dodge,9
+Humphreys,U.S. House,7,Independent,Jon Thorp,29
+Humphreys,U.S. House,7,Independent,Robert James Sutherby,1
+Humphreys,U.S. House,7,Independent,"Teresa ""Terri"" Christie",17
+Montgomery,U.S. House,7,Democratic,Aftyn Behn,19552
+Montgomery,U.S. House,7,Republican,Matt Van Epps,22997
+Montgomery,U.S. House,7,Independent,Bobby Dodge,44
+Montgomery,U.S. House,7,Independent,Jon Thorp,254
+Montgomery,U.S. House,7,Independent,Robert James Sutherby,34
+Montgomery,U.S. House,7,Independent,"Teresa ""Terri"" Christie",237
+Perry,U.S. House,7,Democratic,Aftyn Behn,364
+Perry,U.S. House,7,Republican,Matt Van Epps,1274
+Perry,U.S. House,7,Independent,Bobby Dodge,1
+Perry,U.S. House,7,Independent,Jon Thorp,16
+Perry,U.S. House,7,Independent,Robert James Sutherby,2
+Perry,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,U.S. House,7,Democratic,Aftyn Behn,4911
+Robertson,U.S. House,7,Republican,Matt Van Epps,12608
+Robertson,U.S. House,7,Independent,Bobby Dodge,23
+Robertson,U.S. House,7,Independent,Jon Thorp,130
+Robertson,U.S. House,7,Independent,Robert James Sutherby,14
+Robertson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",54
+Stewart,U.S. House,7,Democratic,Aftyn Behn,767
+Stewart,U.S. House,7,Republican,Matt Van Epps,2588
+Stewart,U.S. House,7,Independent,Bobby Dodge,2
+Stewart,U.S. House,7,Independent,Jon Thorp,23
+Stewart,U.S. House,7,Independent,Robert James Sutherby,3
+Stewart,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Wayne,U.S. House,7,Democratic,Aftyn Behn,417
+Wayne,U.S. House,7,Republican,Matt Van Epps,2412
+Wayne,U.S. House,7,Independent,Bobby Dodge,4
+Wayne,U.S. House,7,Independent,Jon Thorp,9
+Wayne,U.S. House,7,Independent,Robert James Sutherby,3
+Wayne,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Williamson,U.S. House,7,Democratic,Aftyn Behn,10608
+Williamson,U.S. House,7,Republican,Matt Van Epps,16886
+Williamson,U.S. House,7,Independent,Bobby Dodge,18
+Williamson,U.S. House,7,Independent,Jon Thorp,124
+Williamson,U.S. House,7,Independent,Robert James Sutherby,16
+Williamson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",41

--- a/2025/20251202__tn__special__general__precinct.csv
+++ b/2025/20251202__tn__special__general__precinct.csv
@@ -1,0 +1,1375 @@
+county,precinct,office,district,party,candidate,votes
+Benton,1 Holladay,U.S. House,7,Democratic,Aftyn Behn,102
+Benton,1 Holladay,U.S. House,7,Republican,Matt Van Epps,455
+Benton,1 Holladay,U.S. House,7,Independent,Bobby Dodge,1
+Benton,1 Holladay,U.S. House,7,Independent,Jon Thorp,7
+Benton,1 Holladay,U.S. House,7,Independent,Robert James Sutherby,0
+Benton,1 Holladay,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Aftyn Behn,112
+Benton,3 Camden City Hall,U.S. House,7,Republican,Matt Van Epps,359
+Benton,3 Camden City Hall,U.S. House,7,Independent,Bobby Dodge,3
+Benton,3 Camden City Hall,U.S. House,7,Independent,Jon Thorp,4
+Benton,3 Camden City Hall,U.S. House,7,Independent,Robert James Sutherby,1
+Benton,3 Camden City Hall,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Aftyn Behn,131
+Benton,4 Camden Elementary,U.S. House,7,Republican,Matt Van Epps,453
+Benton,4 Camden Elementary,U.S. House,7,Independent,Bobby Dodge,0
+Benton,4 Camden Elementary,U.S. House,7,Independent,Jon Thorp,2
+Benton,4 Camden Elementary,U.S. House,7,Independent,Robert James Sutherby,1
+Benton,4 Camden Elementary,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Benton,6 Big Sandy,U.S. House,7,Democratic,Aftyn Behn,125
+Benton,6 Big Sandy,U.S. House,7,Republican,Matt Van Epps,457
+Benton,6 Big Sandy,U.S. House,7,Independent,Bobby Dodge,3
+Benton,6 Big Sandy,U.S. House,7,Independent,Jon Thorp,3
+Benton,6 Big Sandy,U.S. House,7,Independent,Robert James Sutherby,4
+Benton,6 Big Sandy,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Aftyn Behn,616
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Matt Van Epps,819
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,Bobby Dodge,2
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,Jon Thorp,5
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Aftyn Behn,492
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Matt Van Epps,1339
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,Bobby Dodge,3
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,Jon Thorp,7
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,Robert James Sutherby,0
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Aftyn Behn,600
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Matt Van Epps,1616
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,Bobby Dodge,2
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,Jon Thorp,15
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Aftyn Behn,265
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Matt Van Epps,913
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,Bobby Dodge,1
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,Jon Thorp,10
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Aftyn Behn,193
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Matt Van Epps,632
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,Bobby Dodge,0
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,Jon Thorp,3
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Aftyn Behn,226
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Matt Van Epps,436
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,Bobby Dodge,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,Jon Thorp,4
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,Robert James Sutherby,0
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Aftyn Behn,550
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Matt Van Epps,829
+Cheatham,5-2 Pegram,U.S. House,7,Independent,Bobby Dodge,0
+Cheatham,5-2 Pegram,U.S. House,7,Independent,Jon Thorp,6
+Cheatham,5-2 Pegram,U.S. House,7,Independent,Robert James Sutherby,2
+Cheatham,5-2 Pegram,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Aftyn Behn,968
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Matt Van Epps,1333
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,Bobby Dodge,3
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,Jon Thorp,13
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,Robert James Sutherby,0
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,01-1,U.S. House,7,Democratic,Aftyn Behn,589
+Davidson,01-1,U.S. House,7,Republican,Matt Van Epps,903
+Davidson,01-1,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,01-1,U.S. House,7,Independent,Jon Thorp,6
+Davidson,01-1,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,01-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,01-2,U.S. House,7,Democratic,Aftyn Behn,217
+Davidson,01-2,U.S. House,7,Republican,Matt Van Epps,234
+Davidson,01-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-2,U.S. House,7,Independent,Jon Thorp,5
+Davidson,01-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,01-3,U.S. House,7,Democratic,Aftyn Behn,445
+Davidson,01-3,U.S. House,7,Republican,Matt Van Epps,140
+Davidson,01-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,01-3,U.S. House,7,Independent,Jon Thorp,1
+Davidson,01-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,01-4,U.S. House,7,Democratic,Aftyn Behn,632
+Davidson,01-4,U.S. House,7,Republican,Matt Van Epps,87
+Davidson,01-4,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-4,U.S. House,7,Independent,Jon Thorp,2
+Davidson,01-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,01-5,U.S. House,7,Democratic,Aftyn Behn,684
+Davidson,01-5,U.S. House,7,Republican,Matt Van Epps,37
+Davidson,01-5,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,01-5,U.S. House,7,Independent,Jon Thorp,5
+Davidson,01-5,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,01-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,01-6,U.S. House,7,Democratic,Aftyn Behn,194
+Davidson,01-6,U.S. House,7,Republican,Matt Van Epps,18
+Davidson,01-6,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-6,U.S. House,7,Independent,Jon Thorp,0
+Davidson,01-6,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,01-7,U.S. House,7,Democratic,Aftyn Behn,1869
+Davidson,01-7,U.S. House,7,Republican,Matt Van Epps,101
+Davidson,01-7,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-7,U.S. House,7,Independent,Jon Thorp,1
+Davidson,01-7,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,01-7,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Davidson,02-1,U.S. House,7,Democratic,Aftyn Behn,339
+Davidson,02-1,U.S. House,7,Republican,Matt Van Epps,34
+Davidson,02-1,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,02-1,U.S. House,7,Independent,Jon Thorp,1
+Davidson,02-1,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,02-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,02-2,U.S. House,7,Democratic,Aftyn Behn,629
+Davidson,02-2,U.S. House,7,Republican,Matt Van Epps,33
+Davidson,02-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,02-2,U.S. House,7,Independent,Jon Thorp,0
+Davidson,02-2,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,02-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Davidson,02-3,U.S. House,7,Democratic,Aftyn Behn,273
+Davidson,02-3,U.S. House,7,Republican,Matt Van Epps,29
+Davidson,02-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,02-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,02-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,02-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,02-4,U.S. House,7,Democratic,Aftyn Behn,788
+Davidson,02-4,U.S. House,7,Republican,Matt Van Epps,103
+Davidson,02-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,02-4,U.S. House,7,Independent,Jon Thorp,0
+Davidson,02-4,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,02-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",8
+Davidson,02-5,U.S. House,7,Democratic,Aftyn Behn,1620
+Davidson,02-5,U.S. House,7,Republican,Matt Van Epps,84
+Davidson,02-5,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,02-5,U.S. House,7,Independent,Jon Thorp,3
+Davidson,02-5,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,02-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Davidson,03-1,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,03-1,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,03-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,03-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,03-2,U.S. House,7,Democratic,Aftyn Behn,1534
+Davidson,03-2,U.S. House,7,Republican,Matt Van Epps,271
+Davidson,03-2,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,03-2,U.S. House,7,Independent,Jon Thorp,2
+Davidson,03-2,U.S. House,7,Independent,Robert James Sutherby,3
+Davidson,03-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Davidson,03-3,U.S. House,7,Democratic,Aftyn Behn,61
+Davidson,03-3,U.S. House,7,Republican,Matt Van Epps,53
+Davidson,03-3,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-3,U.S. House,7,Independent,Jon Thorp,1
+Davidson,03-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,03-5,U.S. House,7,Democratic,Aftyn Behn,231
+Davidson,03-5,U.S. House,7,Republican,Matt Van Epps,82
+Davidson,03-5,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-5,U.S. House,7,Independent,Jon Thorp,2
+Davidson,03-5,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,03-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,03-6,U.S. House,7,Democratic,Aftyn Behn,236
+Davidson,03-6,U.S. House,7,Republican,Matt Van Epps,93
+Davidson,03-6,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-6,U.S. House,7,Independent,Jon Thorp,0
+Davidson,03-6,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,03-8,U.S. House,7,Democratic,Aftyn Behn,1303
+Davidson,03-8,U.S. House,7,Republican,Matt Van Epps,78
+Davidson,03-8,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,03-8,U.S. House,7,Independent,Jon Thorp,3
+Davidson,03-8,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-8,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,05-1,U.S. House,7,Democratic,Aftyn Behn,40
+Davidson,05-1,U.S. House,7,Republican,Matt Van Epps,13
+Davidson,05-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,05-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,05-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,05-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-2,U.S. House,7,Democratic,Aftyn Behn,82
+Davidson,10-2,U.S. House,7,Republican,Matt Van Epps,154
+Davidson,10-2,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,10-2,U.S. House,7,Independent,Jon Thorp,1
+Davidson,10-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,10-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-3,U.S. House,7,Democratic,Aftyn Behn,169
+Davidson,10-3,U.S. House,7,Republican,Matt Van Epps,232
+Davidson,10-3,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,10-3,U.S. House,7,Independent,Jon Thorp,2
+Davidson,10-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,10-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-7,U.S. House,7,Democratic,Aftyn Behn,23
+Davidson,10-7,U.S. House,7,Republican,Matt Van Epps,9
+Davidson,10-7,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,10-7,U.S. House,7,Independent,Jon Thorp,0
+Davidson,10-7,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,10-7,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-9,U.S. House,7,Democratic,Aftyn Behn,93
+Davidson,10-9,U.S. House,7,Republican,Matt Van Epps,233
+Davidson,10-9,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,10-9,U.S. House,7,Independent,Jon Thorp,2
+Davidson,10-9,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,10-9,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,15-2,U.S. House,7,Democratic,Aftyn Behn,44
+Davidson,15-2,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,15-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,15-2,U.S. House,7,Independent,Jon Thorp,0
+Davidson,15-2,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,15-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,16-1,U.S. House,7,Democratic,Aftyn Behn,183
+Davidson,16-1,U.S. House,7,Republican,Matt Van Epps,56
+Davidson,16-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,16-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,16-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,16-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,16-3,U.S. House,7,Democratic,Aftyn Behn,50
+Davidson,16-3,U.S. House,7,Republican,Matt Van Epps,17
+Davidson,16-3,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,16-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,16-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,16-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,17-1,U.S. House,7,Democratic,Aftyn Behn,477
+Davidson,17-1,U.S. House,7,Republican,Matt Van Epps,211
+Davidson,17-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,17-1,U.S. House,7,Independent,Jon Thorp,2
+Davidson,17-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,17-2,U.S. House,7,Democratic,Aftyn Behn,374
+Davidson,17-2,U.S. House,7,Republican,Matt Van Epps,78
+Davidson,17-2,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,17-2,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,17-3,U.S. House,7,Democratic,Aftyn Behn,80
+Davidson,17-3,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,17-3,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,17-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,17-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,17-4,U.S. House,7,Democratic,Aftyn Behn,383
+Davidson,17-4,U.S. House,7,Republican,Matt Van Epps,89
+Davidson,17-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,17-4,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-4,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,17-5,U.S. House,7,Democratic,Aftyn Behn,102
+Davidson,17-5,U.S. House,7,Republican,Matt Van Epps,55
+Davidson,17-5,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,17-5,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-5,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Davidson,17-6,U.S. House,7,Democratic,Aftyn Behn,94
+Davidson,17-6,U.S. House,7,Republican,Matt Van Epps,6
+Davidson,17-6,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,17-6,U.S. House,7,Independent,Jon Thorp,0
+Davidson,17-6,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,17-7,U.S. House,7,Democratic,Aftyn Behn,1328
+Davidson,17-7,U.S. House,7,Republican,Matt Van Epps,284
+Davidson,17-7,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,17-7,U.S. House,7,Independent,Jon Thorp,2
+Davidson,17-7,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-7,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,17-8,U.S. House,7,Democratic,Aftyn Behn,595
+Davidson,17-8,U.S. House,7,Republican,Matt Van Epps,135
+Davidson,17-8,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,17-8,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-8,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-8,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,18-1,U.S. House,7,Democratic,Aftyn Behn,732
+Davidson,18-1,U.S. House,7,Republican,Matt Van Epps,102
+Davidson,18-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,18-1,U.S. House,7,Independent,Jon Thorp,2
+Davidson,18-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,18-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,18-2,U.S. House,7,Democratic,Aftyn Behn,700
+Davidson,18-2,U.S. House,7,Republican,Matt Van Epps,170
+Davidson,18-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,18-2,U.S. House,7,Independent,Jon Thorp,4
+Davidson,18-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,18-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,18-3,U.S. House,7,Democratic,Aftyn Behn,2200
+Davidson,18-3,U.S. House,7,Republican,Matt Van Epps,369
+Davidson,18-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,18-3,U.S. House,7,Independent,Jon Thorp,10
+Davidson,18-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,18-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Davidson,19-1,U.S. House,7,Democratic,Aftyn Behn,111
+Davidson,19-1,U.S. House,7,Republican,Matt Van Epps,47
+Davidson,19-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,19-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,19-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,19-2,U.S. House,7,Democratic,Aftyn Behn,1209
+Davidson,19-2,U.S. House,7,Republican,Matt Van Epps,339
+Davidson,19-2,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,19-2,U.S. House,7,Independent,Jon Thorp,5
+Davidson,19-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,19-3,U.S. House,7,Democratic,Aftyn Behn,698
+Davidson,19-3,U.S. House,7,Republican,Matt Van Epps,111
+Davidson,19-3,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,19-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,19-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,19-4,U.S. House,7,Democratic,Aftyn Behn,658
+Davidson,19-4,U.S. House,7,Republican,Matt Van Epps,349
+Davidson,19-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,19-4,U.S. House,7,Independent,Jon Thorp,6
+Davidson,19-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,19-5,U.S. House,7,Democratic,Aftyn Behn,793
+Davidson,19-5,U.S. House,7,Republican,Matt Van Epps,443
+Davidson,19-5,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,19-5,U.S. House,7,Independent,Jon Thorp,3
+Davidson,19-5,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,20-1,U.S. House,7,Democratic,Aftyn Behn,157
+Davidson,20-1,U.S. House,7,Republican,Matt Van Epps,72
+Davidson,20-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,20-1,U.S. House,7,Independent,Jon Thorp,2
+Davidson,20-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,20-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,20-2,U.S. House,7,Democratic,Aftyn Behn,1155
+Davidson,20-2,U.S. House,7,Republican,Matt Van Epps,394
+Davidson,20-2,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,20-2,U.S. House,7,Independent,Jon Thorp,6
+Davidson,20-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,20-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,20-3,U.S. House,7,Democratic,Aftyn Behn,1547
+Davidson,20-3,U.S. House,7,Republican,Matt Van Epps,711
+Davidson,20-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,20-3,U.S. House,7,Independent,Jon Thorp,21
+Davidson,20-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,20-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Davidson,20-5,U.S. House,7,Democratic,Aftyn Behn,437
+Davidson,20-5,U.S. House,7,Republican,Matt Van Epps,125
+Davidson,20-5,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,20-5,U.S. House,7,Independent,Jon Thorp,0
+Davidson,20-5,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,20-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,21-1,U.S. House,7,Democratic,Aftyn Behn,528
+Davidson,21-1,U.S. House,7,Republican,Matt Van Epps,139
+Davidson,21-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,21-1,U.S. House,7,Independent,Jon Thorp,4
+Davidson,21-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,21-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,21-2,U.S. House,7,Democratic,Aftyn Behn,564
+Davidson,21-2,U.S. House,7,Republican,Matt Van Epps,80
+Davidson,21-2,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,21-2,U.S. House,7,Independent,Jon Thorp,0
+Davidson,21-2,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,21-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,21-3,U.S. House,7,Democratic,Aftyn Behn,1085
+Davidson,21-3,U.S. House,7,Republican,Matt Van Epps,149
+Davidson,21-3,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,21-3,U.S. House,7,Independent,Jon Thorp,5
+Davidson,21-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,21-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,21-4,U.S. House,7,Democratic,Aftyn Behn,600
+Davidson,21-4,U.S. House,7,Republican,Matt Van Epps,58
+Davidson,21-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,21-4,U.S. House,7,Independent,Jon Thorp,0
+Davidson,21-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,21-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,24-1,U.S. House,7,Democratic,Aftyn Behn,24
+Davidson,24-1,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,24-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,24-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,24-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,24-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,24-3,U.S. House,7,Democratic,Aftyn Behn,594
+Davidson,24-3,U.S. House,7,Republican,Matt Van Epps,128
+Davidson,24-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,24-3,U.S. House,7,Independent,Jon Thorp,2
+Davidson,24-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,24-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,24-4,U.S. House,7,Democratic,Aftyn Behn,204
+Davidson,24-4,U.S. House,7,Republican,Matt Van Epps,34
+Davidson,24-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,24-4,U.S. House,7,Independent,Jon Thorp,1
+Davidson,24-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,24-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,24-5,U.S. House,7,Democratic,Aftyn Behn,1770
+Davidson,24-5,U.S. House,7,Republican,Matt Van Epps,427
+Davidson,24-5,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,24-5,U.S. House,7,Independent,Jon Thorp,6
+Davidson,24-5,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,24-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Davidson,26-1,U.S. House,7,Democratic,Aftyn Behn,349
+Davidson,26-1,U.S. House,7,Republican,Matt Van Epps,117
+Davidson,26-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,26-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,26-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,26-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,35-4,U.S. House,7,Democratic,Aftyn Behn,89
+Davidson,35-4,U.S. House,7,Republican,Matt Van Epps,29
+Davidson,35-4,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,35-4,U.S. House,7,Independent,Jon Thorp,0
+Davidson,35-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,35-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,35-5,U.S. House,7,Democratic,Aftyn Behn,1025
+Davidson,35-5,U.S. House,7,Republican,Matt Van Epps,798
+Davidson,35-5,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,35-5,U.S. House,7,Independent,Jon Thorp,13
+Davidson,35-5,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,35-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,All County Precinct,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,All County Precinct,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,All County Precinct,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,All County Precinct,U.S. House,7,Independent,Jon Thorp,0
+Davidson,All County Precinct,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,All County Precinct,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Aftyn Behn,69
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Matt Van Epps,270
+Decatur,1-1 Dunbar,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,1-1 Dunbar,U.S. House,7,Independent,Jon Thorp,0
+Decatur,1-1 Dunbar,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,1-1 Dunbar,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Aftyn Behn,43
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Matt Van Epps,212
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,Jon Thorp,1
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,61
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,219
+Decatur,3-1 Decaturville,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,3-1 Decaturville,U.S. House,7,Independent,Jon Thorp,2
+Decatur,3-1 Decaturville,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,3-1 Decaturville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,89
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,189
+Decatur,4-1 Decaturville,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,4-1 Decaturville,U.S. House,7,Independent,Jon Thorp,0
+Decatur,4-1 Decaturville,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,4-1 Decaturville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,56
+Decatur,5-1 Parsons,U.S. House,7,Republican,Matt Van Epps,182
+Decatur,5-1 Parsons,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,5-1 Parsons,U.S. House,7,Independent,Jon Thorp,2
+Decatur,5-1 Parsons,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,5-1 Parsons,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,44
+Decatur,6-1 Parsons,U.S. House,7,Republican,Matt Van Epps,164
+Decatur,6-1 Parsons,U.S. House,7,Independent,Bobby Dodge,1
+Decatur,6-1 Parsons,U.S. House,7,Independent,Jon Thorp,3
+Decatur,6-1 Parsons,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,6-1 Parsons,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Aftyn Behn,52
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Matt Van Epps,249
+Decatur,7-1 Crossroads,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,7-1 Crossroads,U.S. House,7,Independent,Jon Thorp,1
+Decatur,7-1 Crossroads,U.S. House,7,Independent,Robert James Sutherby,1
+Decatur,7-1 Crossroads,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,37
+Decatur,8-1 Parsons,U.S. House,7,Republican,Matt Van Epps,242
+Decatur,8-1 Parsons,U.S. House,7,Independent,Bobby Dodge,1
+Decatur,8-1 Parsons,U.S. House,7,Independent,Jon Thorp,2
+Decatur,8-1 Parsons,U.S. House,7,Independent,Robert James Sutherby,1
+Decatur,8-1 Parsons,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Aftyn Behn,35
+Decatur,9-1 Beacon,U.S. House,7,Republican,Matt Van Epps,243
+Decatur,9-1 Beacon,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,9-1 Beacon,U.S. House,7,Independent,Jon Thorp,2
+Decatur,9-1 Beacon,U.S. House,7,Independent,Robert James Sutherby,1
+Decatur,9-1 Beacon,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Dickson,1-1,U.S. House,7,Democratic,Aftyn Behn,301
+Dickson,1-1,U.S. House,7,Republican,Matt Van Epps,831
+Dickson,1-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,1-1,U.S. House,7,Independent,Jon Thorp,3
+Dickson,1-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,1-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Dickson,10-1,U.S. House,7,Democratic,Aftyn Behn,399
+Dickson,10-1,U.S. House,7,Republican,Matt Van Epps,844
+Dickson,10-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,10-1,U.S. House,7,Independent,Jon Thorp,10
+Dickson,10-1,U.S. House,7,Independent,Robert James Sutherby,2
+Dickson,10-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Dickson,11-1,U.S. House,7,Democratic,Aftyn Behn,358
+Dickson,11-1,U.S. House,7,Republican,Matt Van Epps,594
+Dickson,11-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,11-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,11-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,11-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Dickson,12-1,U.S. House,7,Democratic,Aftyn Behn,409
+Dickson,12-1,U.S. House,7,Republican,Matt Van Epps,950
+Dickson,12-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,12-1,U.S. House,7,Independent,Jon Thorp,9
+Dickson,12-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,12-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,2-1,U.S. House,7,Democratic,Aftyn Behn,259
+Dickson,2-1,U.S. House,7,Republican,Matt Van Epps,814
+Dickson,2-1,U.S. House,7,Independent,Bobby Dodge,0
+Dickson,2-1,U.S. House,7,Independent,Jon Thorp,4
+Dickson,2-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,2-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Dickson,3-1,U.S. House,7,Democratic,Aftyn Behn,233
+Dickson,3-1,U.S. House,7,Republican,Matt Van Epps,888
+Dickson,3-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,3-1,U.S. House,7,Independent,Jon Thorp,7
+Dickson,3-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,3-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,4-1,U.S. House,7,Democratic,Aftyn Behn,240
+Dickson,4-1,U.S. House,7,Republican,Matt Van Epps,742
+Dickson,4-1,U.S. House,7,Independent,Bobby Dodge,3
+Dickson,4-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,4-1,U.S. House,7,Independent,Robert James Sutherby,2
+Dickson,4-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Dickson,5-1,U.S. House,7,Democratic,Aftyn Behn,275
+Dickson,5-1,U.S. House,7,Republican,Matt Van Epps,673
+Dickson,5-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,5-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,5-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,5-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,6-1,U.S. House,7,Democratic,Aftyn Behn,151
+Dickson,6-1,U.S. House,7,Republican,Matt Van Epps,340
+Dickson,6-1,U.S. House,7,Independent,Bobby Dodge,0
+Dickson,6-1,U.S. House,7,Independent,Jon Thorp,2
+Dickson,6-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,6-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Dickson,6-2,U.S. House,7,Democratic,Aftyn Behn,224
+Dickson,6-2,U.S. House,7,Republican,Matt Van Epps,694
+Dickson,6-2,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,6-2,U.S. House,7,Independent,Jon Thorp,4
+Dickson,6-2,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,6-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,7-1,U.S. House,7,Democratic,Aftyn Behn,328
+Dickson,7-1,U.S. House,7,Republican,Matt Van Epps,685
+Dickson,7-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,7-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,7-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,7-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,8-1,U.S. House,7,Democratic,Aftyn Behn,288
+Dickson,8-1,U.S. House,7,Republican,Matt Van Epps,408
+Dickson,8-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,8-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,8-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,8-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Dickson,9-1,U.S. House,7,Democratic,Aftyn Behn,347
+Dickson,9-1,U.S. House,7,Republican,Matt Van Epps,706
+Dickson,9-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,9-1,U.S. House,7,Independent,Jon Thorp,11
+Dickson,9-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,9-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,66
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,215
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,Jon Thorp,2
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Aftyn Behn,67
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Matt Van Epps,254
+Hickman,1-2 Pinewood,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,1-2 Pinewood,U.S. House,7,Independent,Jon Thorp,1
+Hickman,1-2 Pinewood,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,1-2 Pinewood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Aftyn Behn,29
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Matt Van Epps,116
+Hickman,2-2 Fairfield,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,2-2 Fairfield,U.S. House,7,Independent,Jon Thorp,2
+Hickman,2-2 Fairfield,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,2-2 Fairfield,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Aftyn Behn,138
+Hickman,2-3 East Bank,U.S. House,7,Republican,Matt Van Epps,402
+Hickman,2-3 East Bank,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,2-3 East Bank,U.S. House,7,Independent,Jon Thorp,2
+Hickman,2-3 East Bank,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,2-3 East Bank,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Hickman,3-1 East CC,U.S. House,7,Democratic,Aftyn Behn,135
+Hickman,3-1 East CC,U.S. House,7,Republican,Matt Van Epps,428
+Hickman,3-1 East CC,U.S. House,7,Independent,Bobby Dodge,2
+Hickman,3-1 East CC,U.S. House,7,Independent,Jon Thorp,4
+Hickman,3-1 East CC,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,3-1 East CC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Aftyn Behn,193
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Matt Van Epps,664
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,Bobby Dodge,2
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,Jon Thorp,1
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,Robert James Sutherby,1
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Aftyn Behn,66
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Matt Van Epps,259
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,Jon Thorp,5
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Aftyn Behn,50
+Hickman,5-2 Middle School,U.S. House,7,Republican,Matt Van Epps,153
+Hickman,5-2 Middle School,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,5-2 Middle School,U.S. House,7,Independent,Jon Thorp,3
+Hickman,5-2 Middle School,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,5-2 Middle School,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Aftyn Behn,68
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Matt Van Epps,186
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,Jon Thorp,0
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Aftyn Behn,204
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Matt Van Epps,559
+Hickman,6-1 Justice Center,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,6-1 Justice Center,U.S. House,7,Independent,Jon Thorp,3
+Hickman,6-1 Justice Center,U.S. House,7,Independent,Robert James Sutherby,1
+Hickman,6-1 Justice Center,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,19
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,112
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,Jon Thorp,3
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Aftyn Behn,8
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Matt Van Epps,86
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,Jon Thorp,1
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Aftyn Behn,94
+Hickman,7-3 Brushy,U.S. House,7,Republican,Matt Van Epps,292
+Hickman,7-3 Brushy,U.S. House,7,Independent,Bobby Dodge,2
+Hickman,7-3 Brushy,U.S. House,7,Independent,Jon Thorp,0
+Hickman,7-3 Brushy,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,7-3 Brushy,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,7-4 Coble,U.S. House,7,Democratic,Aftyn Behn,20
+Hickman,7-4 Coble,U.S. House,7,Republican,Matt Van Epps,157
+Hickman,7-4 Coble,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,7-4 Coble,U.S. House,7,Independent,Jon Thorp,7
+Hickman,7-4 Coble,U.S. House,7,Independent,Robert James Sutherby,1
+Hickman,7-4 Coble,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Houston,Arlington,U.S. House,7,Democratic,Aftyn Behn,85
+Houston,Arlington,U.S. House,7,Republican,Matt Van Epps,245
+Houston,Arlington,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Arlington,U.S. House,7,Independent,Jon Thorp,0
+Houston,Arlington,U.S. House,7,Independent,Robert James Sutherby,1
+Houston,Arlington,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Houston,Erin,U.S. House,7,Democratic,Aftyn Behn,62
+Houston,Erin,U.S. House,7,Republican,Matt Van Epps,125
+Houston,Erin,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Erin,U.S. House,7,Independent,Jon Thorp,3
+Houston,Erin,U.S. House,7,Independent,Robert James Sutherby,2
+Houston,Erin,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Houston,Erin Elementary,U.S. House,7,Democratic,Aftyn Behn,75
+Houston,Erin Elementary,U.S. House,7,Republican,Matt Van Epps,187
+Houston,Erin Elementary,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Erin Elementary,U.S. House,7,Independent,Jon Thorp,1
+Houston,Erin Elementary,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Erin Elementary,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Houston,Griffins Chapel,U.S. House,7,Democratic,Aftyn Behn,64
+Houston,Griffins Chapel,U.S. House,7,Republican,Matt Van Epps,246
+Houston,Griffins Chapel,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Griffins Chapel,U.S. House,7,Independent,Jon Thorp,1
+Houston,Griffins Chapel,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Griffins Chapel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Houston,Houston Co Middle,U.S. House,7,Democratic,Aftyn Behn,70
+Houston,Houston Co Middle,U.S. House,7,Republican,Matt Van Epps,195
+Houston,Houston Co Middle,U.S. House,7,Independent,Bobby Dodge,1
+Houston,Houston Co Middle,U.S. House,7,Independent,Jon Thorp,0
+Houston,Houston Co Middle,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Houston Co Middle,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Houston,Stewart,U.S. House,7,Democratic,Aftyn Behn,68
+Houston,Stewart,U.S. House,7,Republican,Matt Van Epps,223
+Houston,Stewart,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Stewart,U.S. House,7,Independent,Jon Thorp,3
+Houston,Stewart,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Stewart,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Aftyn Behn,82
+Houston,Tennessee Ridge,U.S. House,7,Republican,Matt Van Epps,187
+Houston,Tennessee Ridge,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Tennessee Ridge,U.S. House,7,Independent,Jon Thorp,3
+Houston,Tennessee Ridge,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Tennessee Ridge,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Aftyn Behn,34
+Humphreys,1-1 Jera,U.S. House,7,Republican,Matt Van Epps,68
+Humphreys,1-1 Jera,U.S. House,7,Independent,Bobby Dodge,0
+Humphreys,1-1 Jera,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,1-1 Jera,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,1-1 Jera,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Aftyn Behn,165
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Matt Van Epps,454
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,Bobby Dodge,2
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Humphreys,2-3 WCN,U.S. House,7,Democratic,Aftyn Behn,163
+Humphreys,2-3 WCN,U.S. House,7,Republican,Matt Van Epps,361
+Humphreys,2-3 WCN,U.S. House,7,Independent,Bobby Dodge,1
+Humphreys,2-3 WCN,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,2-3 WCN,U.S. House,7,Independent,Robert James Sutherby,1
+Humphreys,2-3 WCN,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Aftyn Behn,153
+Humphreys,3-4 Apex,U.S. House,7,Republican,Matt Van Epps,268
+Humphreys,3-4 Apex,U.S. House,7,Independent,Bobby Dodge,1
+Humphreys,3-4 Apex,U.S. House,7,Independent,Jon Thorp,4
+Humphreys,3-4 Apex,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,3-4 Apex,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Aftyn Behn,170
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Matt Van Epps,449
+Humphreys,4-5 Woodland,U.S. House,7,Independent,Bobby Dodge,2
+Humphreys,4-5 Woodland,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,4-5 Woodland,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,4-5 Woodland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Aftyn Behn,185
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Matt Van Epps,430
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,Bobby Dodge,1
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,Jon Thorp,1
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Aftyn Behn,135
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Matt Van Epps,440
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,Bobby Dodge,2
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,Jon Thorp,4
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Aftyn Behn,154
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Matt Van Epps,565
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,Bobby Dodge,0
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,Jon Thorp,12
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Aftyn Behn,528
+Montgomery,10 Minglewood,U.S. House,7,Republican,Matt Van Epps,325
+Montgomery,10 Minglewood,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,10 Minglewood,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,10 Minglewood,U.S. House,7,Independent,Robert James Sutherby,3
+Montgomery,10 Minglewood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",12
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Aftyn Behn,308
+Montgomery,11A Mosaic,U.S. House,7,Republican,Matt Van Epps,326
+Montgomery,11A Mosaic,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,11A Mosaic,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,11A Mosaic,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,11A Mosaic,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Montgomery,11B Northwest,U.S. House,7,Democratic,Aftyn Behn,402
+Montgomery,11B Northwest,U.S. House,7,Republican,Matt Van Epps,293
+Montgomery,11B Northwest,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,11B Northwest,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,11B Northwest,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,11B Northwest,U.S. House,7,Independent,"Teresa ""Terri"" Christie",8
+Montgomery,12 West Creek,U.S. House,7,Democratic,Aftyn Behn,801
+Montgomery,12 West Creek,U.S. House,7,Republican,Matt Van Epps,398
+Montgomery,12 West Creek,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,12 West Creek,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,12 West Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,12 West Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Aftyn Behn,439
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Matt Van Epps,208
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,Jon Thorp,3
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Aftyn Behn,504
+Montgomery,13B Kenwood,U.S. House,7,Republican,Matt Van Epps,298
+Montgomery,13B Kenwood,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,13B Kenwood,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,13B Kenwood,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,13B Kenwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Aftyn Behn,472
+Montgomery,14A St B ELC,U.S. House,7,Republican,Matt Van Epps,213
+Montgomery,14A St B ELC,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,14A St B ELC,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,14A St B ELC,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,14A St B ELC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,14B First MBC,U.S. House,7,Democratic,Aftyn Behn,483
+Montgomery,14B First MBC,U.S. House,7,Republican,Matt Van Epps,430
+Montgomery,14B First MBC,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,14B First MBC,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,14B First MBC,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,14B First MBC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,15A Excell,U.S. House,7,Democratic,Aftyn Behn,702
+Montgomery,15A Excell,U.S. House,7,Republican,Matt Van Epps,1258
+Montgomery,15A Excell,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,15A Excell,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,15A Excell,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,15A Excell,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,15B Sango,U.S. House,7,Democratic,Aftyn Behn,537
+Montgomery,15B Sango,U.S. House,7,Republican,Matt Van Epps,1188
+Montgomery,15B Sango,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,15B Sango,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,15B Sango,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,15B Sango,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Aftyn Behn,476
+Montgomery,16A Ringgold,U.S. House,7,Republican,Matt Van Epps,269
+Montgomery,16A Ringgold,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,16A Ringgold,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,16A Ringgold,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,16A Ringgold,U.S. House,7,Independent,"Teresa ""Terri"" Christie",8
+Montgomery,16B New Providence,U.S. House,7,Democratic,Aftyn Behn,392
+Montgomery,16B New Providence,U.S. House,7,Republican,Matt Van Epps,302
+Montgomery,16B New Providence,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,16B New Providence,U.S. House,7,Independent,Jon Thorp,3
+Montgomery,16B New Providence,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,16B New Providence,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,17A Grace,U.S. House,7,Democratic,Aftyn Behn,531
+Montgomery,17A Grace,U.S. House,7,Republican,Matt Van Epps,372
+Montgomery,17A Grace,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,17A Grace,U.S. House,7,Independent,Jon Thorp,2
+Montgomery,17A Grace,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,17A Grace,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Aftyn Behn,526
+Montgomery,17B Glenellen,U.S. House,7,Republican,Matt Van Epps,380
+Montgomery,17B Glenellen,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,17B Glenellen,U.S. House,7,Independent,Jon Thorp,8
+Montgomery,17B Glenellen,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,17B Glenellen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Aftyn Behn,592
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Matt Van Epps,299
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Aftyn Behn,476
+Montgomery,18B Pisgah,U.S. House,7,Republican,Matt Van Epps,340
+Montgomery,18B Pisgah,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,18B Pisgah,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,18B Pisgah,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,18B Pisgah,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,19A Rossview,U.S. House,7,Democratic,Aftyn Behn,742
+Montgomery,19A Rossview,U.S. House,7,Republican,Matt Van Epps,986
+Montgomery,19A Rossview,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,19A Rossview,U.S. House,7,Independent,Jon Thorp,13
+Montgomery,19A Rossview,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,19A Rossview,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Aftyn Behn,452
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Matt Van Epps,539
+Montgomery,19B South Guthrie,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,19B South Guthrie,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,19B South Guthrie,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,19B South Guthrie,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,1A St B CC,U.S. House,7,Democratic,Aftyn Behn,659
+Montgomery,1A St B CC,U.S. House,7,Republican,Matt Van Epps,734
+Montgomery,1A St B CC,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,1A St B CC,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,1A St B CC,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,1A St B CC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Aftyn Behn,556
+Montgomery,1B St B UMC,U.S. House,7,Republican,Matt Van Epps,559
+Montgomery,1B St B UMC,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,1B St B UMC,U.S. House,7,Independent,Jon Thorp,9
+Montgomery,1B St B UMC,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,1B St B UMC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,20A Northeast,U.S. House,7,Democratic,Aftyn Behn,567
+Montgomery,20A Northeast,U.S. House,7,Republican,Matt Van Epps,374
+Montgomery,20A Northeast,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,20A Northeast,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,20A Northeast,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,20A Northeast,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,20B Oakland,U.S. House,7,Democratic,Aftyn Behn,429
+Montgomery,20B Oakland,U.S. House,7,Republican,Matt Van Epps,425
+Montgomery,20B Oakland,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,20B Oakland,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,20B Oakland,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,20B Oakland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Aftyn Behn,565
+Montgomery,21A Hilldale,U.S. House,7,Republican,Matt Van Epps,843
+Montgomery,21A Hilldale,U.S. House,7,Independent,Bobby Dodge,4
+Montgomery,21A Hilldale,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,21A Hilldale,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,21A Hilldale,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Aftyn Behn,506
+Montgomery,21B Barksdale,U.S. House,7,Republican,Matt Van Epps,425
+Montgomery,21B Barksdale,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,21B Barksdale,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,21B Barksdale,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,21B Barksdale,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Aftyn Behn,653
+Montgomery,2A Clarksville,U.S. House,7,Republican,Matt Van Epps,1045
+Montgomery,2A Clarksville,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,2A Clarksville,U.S. House,7,Independent,Jon Thorp,14
+Montgomery,2A Clarksville,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,2A Clarksville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Montgomery,2B Bible,U.S. House,7,Democratic,Aftyn Behn,750
+Montgomery,2B Bible,U.S. House,7,Republican,Matt Van Epps,881
+Montgomery,2B Bible,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,2B Bible,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,2B Bible,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,2B Bible,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Aftyn Behn,517
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Matt Van Epps,1140
+Montgomery,3A East Montgomery,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,3A East Montgomery,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,3A East Montgomery,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,3A East Montgomery,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Aftyn Behn,488
+Montgomery,3B Fredonia,U.S. House,7,Republican,Matt Van Epps,1334
+Montgomery,3B Fredonia,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,3B Fredonia,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,3B Fredonia,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,3B Fredonia,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Montgomery,4A MCMS,U.S. House,7,Democratic,Aftyn Behn,328
+Montgomery,4A MCMS,U.S. House,7,Republican,Matt Van Epps,1052
+Montgomery,4A MCMS,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,4A MCMS,U.S. House,7,Independent,Jon Thorp,8
+Montgomery,4A MCMS,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,4A MCMS,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Aftyn Behn,568
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Matt Van Epps,613
+Montgomery,4B WR Event Center,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,4B WR Event Center,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,4B WR Event Center,U.S. House,7,Independent,Robert James Sutherby,3
+Montgomery,4B WR Event Center,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Aftyn Behn,696
+Montgomery,5 Cumberland,U.S. House,7,Republican,Matt Van Epps,348
+Montgomery,5 Cumberland,U.S. House,7,Independent,Bobby Dodge,4
+Montgomery,5 Cumberland,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,5 Cumberland,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,5 Cumberland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Aftyn Behn,313
+Montgomery,6A Cumberland,U.S. House,7,Republican,Matt Van Epps,888
+Montgomery,6A Cumberland,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,6A Cumberland,U.S. House,7,Independent,Jon Thorp,8
+Montgomery,6A Cumberland,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,6A Cumberland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,6B Bethel,U.S. House,7,Democratic,Aftyn Behn,279
+Montgomery,6B Bethel,U.S. House,7,Republican,Matt Van Epps,1054
+Montgomery,6B Bethel,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,6B Bethel,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,6B Bethel,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,6B Bethel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Montgomery,7A Liberty,U.S. House,7,Democratic,Aftyn Behn,409
+Montgomery,7A Liberty,U.S. House,7,Republican,Matt Van Epps,687
+Montgomery,7A Liberty,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,7A Liberty,U.S. House,7,Independent,Jon Thorp,12
+Montgomery,7A Liberty,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,7A Liberty,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Aftyn Behn,283
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Matt Van Epps,1118
+Montgomery,7B Woodlawn,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,7B Woodlawn,U.S. House,7,Independent,Jon Thorp,12
+Montgomery,7B Woodlawn,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,7B Woodlawn,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Montgomery,8 Bethel,U.S. House,7,Democratic,Aftyn Behn,542
+Montgomery,8 Bethel,U.S. House,7,Republican,Matt Van Epps,298
+Montgomery,8 Bethel,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,8 Bethel,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,8 Bethel,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,8 Bethel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Aftyn Behn,622
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Matt Van Epps,474
+Montgomery,9A Hazelwood,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,9A Hazelwood,U.S. House,7,Independent,Jon Thorp,1
+Montgomery,9A Hazelwood,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,9A Hazelwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,9B St John,U.S. House,7,Democratic,Aftyn Behn,459
+Montgomery,9B St John,U.S. House,7,Republican,Matt Van Epps,281
+Montgomery,9B St John,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,9B St John,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,9B St John,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,9B St John,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Aftyn Behn,35
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Matt Van Epps,130
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,Bobby Dodge,0
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,Jon Thorp,2
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Aftyn Behn,12
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Matt Van Epps,89
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,Bobby Dodge,0
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,Jon Thorp,0
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,2-1 Pineview,U.S. House,7,Democratic,Aftyn Behn,50
+Perry,2-1 Pineview,U.S. House,7,Republican,Matt Van Epps,146
+Perry,2-1 Pineview,U.S. House,7,Independent,Bobby Dodge,0
+Perry,2-1 Pineview,U.S. House,7,Independent,Jon Thorp,1
+Perry,2-1 Pineview,U.S. House,7,Independent,Robert James Sutherby,1
+Perry,2-1 Pineview,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,2-2 Pope,U.S. House,7,Democratic,Aftyn Behn,22
+Perry,2-2 Pope,U.S. House,7,Republican,Matt Van Epps,115
+Perry,2-2 Pope,U.S. House,7,Independent,Bobby Dodge,0
+Perry,2-2 Pope,U.S. House,7,Independent,Jon Thorp,1
+Perry,2-2 Pope,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,2-2 Pope,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Aftyn Behn,47
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Matt Van Epps,163
+Perry,3-1 Coon Creek,U.S. House,7,Independent,Bobby Dodge,0
+Perry,3-1 Coon Creek,U.S. House,7,Independent,Jon Thorp,4
+Perry,3-1 Coon Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,3-1 Coon Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Aftyn Behn,29
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Matt Van Epps,99
+Perry,3-2 Flatwoods,U.S. House,7,Independent,Bobby Dodge,0
+Perry,3-2 Flatwoods,U.S. House,7,Independent,Jon Thorp,1
+Perry,3-2 Flatwoods,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,3-2 Flatwoods,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Aftyn Behn,23
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Matt Van Epps,56
+Perry,4-1 Brush Creek,U.S. House,7,Independent,Bobby Dodge,1
+Perry,4-1 Brush Creek,U.S. House,7,Independent,Jon Thorp,0
+Perry,4-1 Brush Creek,U.S. House,7,Independent,Robert James Sutherby,1
+Perry,4-1 Brush Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Aftyn Behn,29
+Perry,4-3 Lobelville,U.S. House,7,Republican,Matt Van Epps,145
+Perry,4-3 Lobelville,U.S. House,7,Independent,Bobby Dodge,0
+Perry,4-3 Lobelville,U.S. House,7,Independent,Jon Thorp,1
+Perry,4-3 Lobelville,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,4-3 Lobelville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Perry,5-1 Linden,U.S. House,7,Democratic,Aftyn Behn,65
+Perry,5-1 Linden,U.S. House,7,Republican,Matt Van Epps,148
+Perry,5-1 Linden,U.S. House,7,Independent,Bobby Dodge,0
+Perry,5-1 Linden,U.S. House,7,Independent,Jon Thorp,4
+Perry,5-1 Linden,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,5-1 Linden,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Aftyn Behn,52
+Perry,6-1 Lobelville,U.S. House,7,Republican,Matt Van Epps,183
+Perry,6-1 Lobelville,U.S. House,7,Independent,Bobby Dodge,0
+Perry,6-1 Lobelville,U.S. House,7,Independent,Jon Thorp,2
+Perry,6-1 Lobelville,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,6-1 Lobelville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Aftyn Behn,306
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Matt Van Epps,1202
+Robertson,01-1 East Robertson,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,01-1 East Robertson,U.S. House,7,Independent,Jon Thorp,13
+Robertson,01-1 East Robertson,U.S. House,7,Independent,Robert James Sutherby,3
+Robertson,01-1 East Robertson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Aftyn Behn,463
+Robertson,02-1 Woodall,U.S. House,7,Republican,Matt Van Epps,1011
+Robertson,02-1 Woodall,U.S. House,7,Independent,Bobby Dodge,3
+Robertson,02-1 Woodall,U.S. House,7,Independent,Jon Thorp,11
+Robertson,02-1 Woodall,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,02-1 Woodall,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Aftyn Behn,150
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Matt Van Epps,556
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,Jon Thorp,4
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Aftyn Behn,354
+Robertson,03-2 Heritage,U.S. House,7,Republican,Matt Van Epps,986
+Robertson,03-2 Heritage,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,03-2 Heritage,U.S. House,7,Independent,Jon Thorp,10
+Robertson,03-2 Heritage,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,03-2 Heritage,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Aftyn Behn,429
+Robertson,04-1 Watauga,U.S. House,7,Republican,Matt Van Epps,1098
+Robertson,04-1 Watauga,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,04-1 Watauga,U.S. House,7,Independent,Jon Thorp,10
+Robertson,04-1 Watauga,U.S. House,7,Independent,Robert James Sutherby,2
+Robertson,04-1 Watauga,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Aftyn Behn,343
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Matt Van Epps,893
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,Jon Thorp,12
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Aftyn Behn,265
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Matt Van Epps,808
+Robertson,06-1 Coopertown,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,06-1 Coopertown,U.S. House,7,Independent,Jon Thorp,10
+Robertson,06-1 Coopertown,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,06-1 Coopertown,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Aftyn Behn,174
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Matt Van Epps,601
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,Jon Thorp,9
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Aftyn Behn,243
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Matt Van Epps,1013
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,Bobby Dodge,4
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,Jon Thorp,10
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Aftyn Behn,89
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Matt Van Epps,369
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,Jon Thorp,3
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Aftyn Behn,75
+Robertson,08-1 Krisle,U.S. House,7,Republican,Matt Van Epps,353
+Robertson,08-1 Krisle,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,08-1 Krisle,U.S. House,7,Independent,Jon Thorp,8
+Robertson,08-1 Krisle,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,08-1 Krisle,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,08-2 HATS,U.S. House,7,Democratic,Aftyn Behn,78
+Robertson,08-2 HATS,U.S. House,7,Republican,Matt Van Epps,391
+Robertson,08-2 HATS,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,08-2 HATS,U.S. House,7,Independent,Jon Thorp,0
+Robertson,08-2 HATS,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,08-2 HATS,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Aftyn Behn,116
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Matt Van Epps,607
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,Jon Thorp,5
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Aftyn Behn,426
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Matt Van Epps,625
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,Jon Thorp,4
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Aftyn Behn,519
+Robertson,10-1 South Haven,U.S. House,7,Republican,Matt Van Epps,934
+Robertson,10-1 South Haven,U.S. House,7,Independent,Bobby Dodge,3
+Robertson,10-1 South Haven,U.S. House,7,Independent,Jon Thorp,10
+Robertson,10-1 South Haven,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,10-1 South Haven,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Robertson,11-1 Westside,U.S. House,7,Democratic,Aftyn Behn,478
+Robertson,11-1 Westside,U.S. House,7,Republican,Matt Van Epps,796
+Robertson,11-1 Westside,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,11-1 Westside,U.S. House,7,Independent,Jon Thorp,8
+Robertson,11-1 Westside,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,11-1 Westside,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Robertson,11-2 Heads,U.S. House,7,Democratic,Aftyn Behn,42
+Robertson,11-2 Heads,U.S. House,7,Republican,Matt Van Epps,272
+Robertson,11-2 Heads,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,11-2 Heads,U.S. House,7,Independent,Jon Thorp,0
+Robertson,11-2 Heads,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,11-2 Heads,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Aftyn Behn,361
+Robertson,12-1 Bransford,U.S. House,7,Republican,Matt Van Epps,93
+Robertson,12-1 Bransford,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,12-1 Bransford,U.S. House,7,Independent,Jon Thorp,3
+Robertson,12-1 Bransford,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,12-1 Bransford,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Aftyn Behn,98
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Matt Van Epps,315
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,Jon Thorp,2
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Aftyn Behn,100
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Matt Van Epps,328
+Stewart,2-1 Big Rock,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,2-1 Big Rock,U.S. House,7,Independent,Jon Thorp,2
+Stewart,2-1 Big Rock,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,2-1 Big Rock,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Aftyn Behn,102
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Matt Van Epps,413
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,Bobby Dodge,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,Jon Thorp,2
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Aftyn Behn,101
+Stewart,4-1 Church Street,U.S. House,7,Republican,Matt Van Epps,298
+Stewart,4-1 Church Street,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,4-1 Church Street,U.S. House,7,Independent,Jon Thorp,5
+Stewart,4-1 Church Street,U.S. House,7,Independent,Robert James Sutherby,1
+Stewart,4-1 Church Street,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Aftyn Behn,125
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Matt Van Epps,442
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,Bobby Dodge,1
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,Jon Thorp,5
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,Robert James Sutherby,2
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Aftyn Behn,134
+Stewart,6-1 Public Library,U.S. House,7,Republican,Matt Van Epps,402
+Stewart,6-1 Public Library,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,6-1 Public Library,U.S. House,7,Independent,Jon Thorp,4
+Stewart,6-1 Public Library,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,6-1 Public Library,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Aftyn Behn,107
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Matt Van Epps,390
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,Jon Thorp,3
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Aftyn Behn,76
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Matt Van Epps,318
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,Jon Thorp,2
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Aftyn Behn,22
+Wayne,2-1 Clifton,U.S. House,7,Republican,Matt Van Epps,73
+Wayne,2-1 Clifton,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,2-1 Clifton,U.S. House,7,Independent,Jon Thorp,0
+Wayne,2-1 Clifton,U.S. House,7,Independent,Robert James Sutherby,1
+Wayne,2-1 Clifton,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Aftyn Behn,18
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Matt Van Epps,150
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,Jon Thorp,0
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Aftyn Behn,32
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Matt Van Epps,166
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,Jon Thorp,1
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Aftyn Behn,15
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Matt Van Epps,89
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,Jon Thorp,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Aftyn Behn,45
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Matt Van Epps,228
+Wayne,4-1 Collinwood,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,4-1 Collinwood,U.S. House,7,Independent,Jon Thorp,1
+Wayne,4-1 Collinwood,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,4-1 Collinwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Aftyn Behn,16
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Matt Van Epps,124
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,Jon Thorp,0
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,Robert James Sutherby,1
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Aftyn Behn,33
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Matt Van Epps,187
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,Jon Thorp,0
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Aftyn Behn,20
+Wayne,5-2 Lutts,U.S. House,7,Republican,Matt Van Epps,115
+Wayne,5-2 Lutts,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,5-2 Lutts,U.S. House,7,Independent,Jon Thorp,1
+Wayne,5-2 Lutts,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,5-2 Lutts,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Aftyn Behn,18
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Matt Van Epps,99
+Wayne,5-3 Woodmen,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,5-3 Woodmen,U.S. House,7,Independent,Jon Thorp,0
+Wayne,5-3 Woodmen,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,5-3 Woodmen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Aftyn Behn,24
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Matt Van Epps,133
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,Jon Thorp,1
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Aftyn Behn,34
+Wayne,6-2 South Gate,U.S. House,7,Republican,Matt Van Epps,319
+Wayne,6-2 South Gate,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,6-2 South Gate,U.S. House,7,Independent,Jon Thorp,2
+Wayne,6-2 South Gate,U.S. House,7,Independent,Robert James Sutherby,1
+Wayne,6-2 South Gate,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Aftyn Behn,36
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Matt Van Epps,152
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,Jon Thorp,0
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Aftyn Behn,28
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Matt Van Epps,259
+Wayne,7-2 Ovilla,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,7-2 Ovilla,U.S. House,7,Independent,Jon Thorp,0
+Wayne,7-2 Ovilla,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,7-2 Ovilla,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,1-1,U.S. House,7,Democratic,Aftyn Behn,656
+Williamson,1-1,U.S. House,7,Republican,Matt Van Epps,1507
+Williamson,1-1,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,1-1,U.S. House,7,Independent,Jon Thorp,13
+Williamson,1-1,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,1-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Williamson,1-5,U.S. House,7,Democratic,Aftyn Behn,253
+Williamson,1-5,U.S. House,7,Republican,Matt Van Epps,665
+Williamson,1-5,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,1-5,U.S. House,7,Independent,Jon Thorp,5
+Williamson,1-5,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,1-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,1-6,U.S. House,7,Democratic,Aftyn Behn,641
+Williamson,1-6,U.S. House,7,Republican,Matt Van Epps,1389
+Williamson,1-6,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,1-6,U.S. House,7,Independent,Jon Thorp,19
+Williamson,1-6,U.S. House,7,Independent,Robert James Sutherby,2
+Williamson,1-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Williamson,10-1,U.S. House,7,Democratic,Aftyn Behn,884
+Williamson,10-1,U.S. House,7,Republican,Matt Van Epps,854
+Williamson,10-1,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-1,U.S. House,7,Independent,Jon Thorp,4
+Williamson,10-1,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,10-2,U.S. House,7,Democratic,Aftyn Behn,589
+Williamson,10-2,U.S. House,7,Republican,Matt Van Epps,692
+Williamson,10-2,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,10-2,U.S. House,7,Independent,Jon Thorp,1
+Williamson,10-2,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,10-3,U.S. House,7,Democratic,Aftyn Behn,51
+Williamson,10-3,U.S. House,7,Republican,Matt Van Epps,70
+Williamson,10-3,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-3,U.S. House,7,Independent,Jon Thorp,1
+Williamson,10-3,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,10-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,10-4,U.S. House,7,Democratic,Aftyn Behn,554
+Williamson,10-4,U.S. House,7,Republican,Matt Van Epps,547
+Williamson,10-4,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-4,U.S. House,7,Independent,Jon Thorp,9
+Williamson,10-4,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,10-5,U.S. House,7,Democratic,Aftyn Behn,577
+Williamson,10-5,U.S. House,7,Republican,Matt Van Epps,415
+Williamson,10-5,U.S. House,7,Independent,Bobby Dodge,3
+Williamson,10-5,U.S. House,7,Independent,Jon Thorp,5
+Williamson,10-5,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,10-6,U.S. House,7,Democratic,Aftyn Behn,265
+Williamson,10-6,U.S. House,7,Republican,Matt Van Epps,491
+Williamson,10-6,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-6,U.S. House,7,Independent,Jon Thorp,7
+Williamson,10-6,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,10-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,11-1,U.S. House,7,Democratic,Aftyn Behn,985
+Williamson,11-1,U.S. House,7,Republican,Matt Van Epps,1450
+Williamson,11-1,U.S. House,7,Independent,Bobby Dodge,2
+Williamson,11-1,U.S. House,7,Independent,Jon Thorp,13
+Williamson,11-1,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,11-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Williamson,11-2,U.S. House,7,Democratic,Aftyn Behn,57
+Williamson,11-2,U.S. House,7,Republican,Matt Van Epps,78
+Williamson,11-2,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,11-2,U.S. House,7,Independent,Jon Thorp,0
+Williamson,11-2,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,11-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,11-3,U.S. House,7,Democratic,Aftyn Behn,289
+Williamson,11-3,U.S. House,7,Republican,Matt Van Epps,604
+Williamson,11-3,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,11-3,U.S. House,7,Independent,Jon Thorp,5
+Williamson,11-3,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,11-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,11-4,U.S. House,7,Democratic,Aftyn Behn,549
+Williamson,11-4,U.S. House,7,Republican,Matt Van Epps,471
+Williamson,11-4,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,11-4,U.S. House,7,Independent,Jon Thorp,2
+Williamson,11-4,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,11-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,11-5,U.S. House,7,Democratic,Aftyn Behn,579
+Williamson,11-5,U.S. House,7,Republican,Matt Van Epps,1023
+Williamson,11-5,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,11-5,U.S. House,7,Independent,Jon Thorp,3
+Williamson,11-5,U.S. House,7,Independent,Robert James Sutherby,2
+Williamson,11-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,12-1,U.S. House,7,Democratic,Aftyn Behn,955
+Williamson,12-1,U.S. House,7,Republican,Matt Van Epps,1282
+Williamson,12-1,U.S. House,7,Independent,Bobby Dodge,2
+Williamson,12-1,U.S. House,7,Independent,Jon Thorp,2
+Williamson,12-1,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,12-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,2-1,U.S. House,7,Democratic,Aftyn Behn,373
+Williamson,2-1,U.S. House,7,Republican,Matt Van Epps,863
+Williamson,2-1,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,2-1,U.S. House,7,Independent,Jon Thorp,5
+Williamson,2-1,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,2-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,7-2,U.S. House,7,Democratic,Aftyn Behn,109
+Williamson,7-2,U.S. House,7,Republican,Matt Van Epps,82
+Williamson,7-2,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,7-2,U.S. House,7,Independent,Jon Thorp,1
+Williamson,7-2,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,7-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,8-2,U.S. House,7,Democratic,Aftyn Behn,462
+Williamson,8-2,U.S. House,7,Republican,Matt Van Epps,722
+Williamson,8-2,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,8-2,U.S. House,7,Independent,Jon Thorp,3
+Williamson,8-2,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,8-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,8-4,U.S. House,7,Democratic,Aftyn Behn,463
+Williamson,8-4,U.S. House,7,Republican,Matt Van Epps,744
+Williamson,8-4,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,8-4,U.S. House,7,Independent,Jon Thorp,7
+Williamson,8-4,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,8-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Williamson,9-3,U.S. House,7,Democratic,Aftyn Behn,625
+Williamson,9-3,U.S. House,7,Republican,Matt Van Epps,1726
+Williamson,9-3,U.S. House,7,Independent,Bobby Dodge,2
+Williamson,9-3,U.S. House,7,Independent,Jon Thorp,11
+Williamson,9-3,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,9-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,9-6,U.S. House,7,Democratic,Aftyn Behn,692
+Williamson,9-6,U.S. House,7,Republican,Matt Van Epps,1211
+Williamson,9-6,U.S. House,7,Independent,Bobby Dodge,5
+Williamson,9-6,U.S. House,7,Independent,Jon Thorp,8
+Williamson,9-6,U.S. House,7,Independent,Robert James Sutherby,3
+Williamson,9-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1

--- a/cleaning/tn_2025_special_us_house_d7_parser.py
+++ b/cleaning/tn_2025_special_us_house_d7_parser.py
@@ -1,0 +1,188 @@
+"""
+Parser for the 2025 Tennessee U.S. House District 7 special elections
+(unexpired term), covering both the October 7, 2025 special primary and the
+December 2, 2025 special general.
+
+Source (TN SoS "All by Precinct" spreadsheets, which list every precinct's
+votes for every candidate; grand totals were cross-checked against the official
+by-county PDFs and match exactly):
+  primary:  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20251007AllbyPrecinct.xlsx
+  general:  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20251202AllbyPrecinct.xlsx
+
+Outputs (in 2025/):
+  20251007__tn__special__primary__county.csv
+  20251007__tn__special__primary__precinct.csv
+  20251202__tn__special__general__county.csv
+  20251202__tn__special__general__precinct.csv
+
+The XLSX is a wide layout: one row per (precinct, candidate-group) with up to 10
+candidates per row in RNAME*/PARTY*/PVTALLY* columns. A precinct may span
+multiple rows when a party fields more than 10 candidates (the Republican
+primary had 11). County-level totals are derived by summing the precinct votes
+per county, which matches the official by-county PDFs exactly. The
+"All County Precinct" bucket (absentee/early votes reported at the county level)
+is kept as a precinct, matching the repo's 2022 convention, so precinct sums
+reconcile to county totals.
+
+Conventions (matching the repo's canonical files):
+  county:   Title case, e.g. "Humphreys" (the primary source misspells it
+            "Humhreys" and the general source uppercases it; both are normalized)
+  office:   "U.S. House"
+  district: "7"
+  party:    full names ("Democratic", "Republican", "Independent")
+  precinct: as printed in the source (e.g. "1 Holladay", "All County Precinct")
+
+Requires `requests` (in the Pipfile) and `openpyxl` (a third-party package;
+install separately, e.g. `pip install openpyxl`) to read the .xlsx workbook,
+which is far more reliable than parsing the multi-county PDFs.
+"""
+
+import csv
+import os
+import re
+from collections import defaultdict
+
+import requests
+
+try:
+    import openpyxl
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("This parser requires openpyxl: pipenv install openpyxl") from exc
+
+BASE = "https://sos-prod.tnsosgovfiles.com/s3fs-public/document"
+PRIMARY_URL = f"{BASE}/20251007AllbyPrecinct.xlsx"
+GENERAL_URL = f"{BASE}/20251202AllbyPrecinct.xlsx"
+
+OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "2025")
+
+OFFICE = "U.S. House"
+DISTRICT = "7"
+
+# Canonical Title-case county names, keyed by lowercased source spelling so the
+# primary's "Humhreys" typo and the general's all-caps names both normalize.
+COUNTY_CANON = {
+    "benton": "Benton", "cheatham": "Cheatham", "davidson": "Davidson",
+    "decatur": "Decatur", "dickson": "Dickson", "hickman": "Hickman",
+    "houston": "Houston", "humphreys": "Humphreys", "humhreys": "Humphreys",
+    "montgomery": "Montgomery", "perry": "Perry", "robertson": "Robertson",
+    "stewart": "Stewart", "wayne": "Wayne", "williamson": "Williamson",
+}
+
+PARTY_ORDER = {"Democratic": 0, "Republican": 1, "Independent": 2}
+
+
+def norm_county(raw):
+    return COUNTY_CANON.get(str(raw).strip().lower(), str(raw).strip().title())
+
+
+def fetch_workbook(url):
+    resp = requests.get(url)
+    resp.raise_for_status()
+    # openpyxl reads from a file-like object via load_workbook; write bytes to a
+    # temp file to avoid seeking issues with some stream wrappers.
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".xlsx") as f:
+        f.write(resp.content)
+        f.flush()
+        return openpyxl.load_workbook(f.name, read_only=True, data_only=True)
+
+
+def iter_precinct_rows(url):
+    """Yield (county, precinct, party, candidate, votes) for every candidate."""
+    wb = fetch_workbook(url)
+    ws = wb["Sheet1"]
+    rows = ws.iter_rows(values_only=True)
+    header = next(rows)
+    rname_cols = [header.index(f"RNAME{i}") for i in range(1, 11)
+                  if f"RNAME{i}" in header]
+    party_cols = [header.index(f"PARTY{i}") for i in range(1, 11)
+                  if f"PARTY{i}" in header]
+    tally_cols = [header.index(f"PVTALLY{i}") for i in range(1, 11)
+                  if f"PVTALLY{i}" in header]
+    n = min(len(rname_cols), len(party_cols), len(tally_cols))
+    ci_county = header.index("COUNTY")
+    ci_precinct = header.index("PRECINCT")
+    for r in rows:
+        county = norm_county(r[ci_county])
+        precinct = str(r[ci_precinct]).strip()
+        for k in range(n):
+            name = r[rname_cols[k]]
+            if not name:
+                continue
+            party = str(r[party_cols[k]] or "").strip()
+            votes = r[tally_cols[k]] or 0
+            yield county, precinct, party, str(name).strip(), int(votes)
+
+
+def sort_key_county(row):
+    # row: [county, office, district, party, candidate, votes]
+    return (row[0], PARTY_ORDER.get(row[3], 99), row[4])
+
+
+def sort_key_precinct(row):
+    # row: [county, precinct, office, district, party, candidate, votes]
+    return (row[0], row[1], PARTY_ORDER.get(row[4], 99), row[5])
+
+
+def build(url, county_path, precinct_path):
+    precinct_rows = []
+    county_sums = defaultdict(int)  # (county, party, candidate) -> votes
+    for county, precinct, party, candidate, votes in iter_precinct_rows(url):
+        precinct_rows.append(
+            [county, precinct, OFFICE, DISTRICT, party, candidate, votes]
+        )
+        county_sums[(county, party, candidate)] += votes
+
+    county_rows = [
+        [county, OFFICE, DISTRICT, party, candidate, votes]
+        for (county, party, candidate), votes in county_sums.items()
+    ]
+    county_rows.sort(key=sort_key_county)
+    precinct_rows.sort(key=sort_key_precinct)
+
+    write_csv(
+        county_path,
+        ["county", "office", "district", "party", "candidate", "votes"],
+        county_rows,
+    )
+    write_csv(
+        precinct_path,
+        ["county", "precinct", "office", "district", "party", "candidate", "votes"],
+        precinct_rows,
+    )
+
+    # Sanity check: precinct sums must equal county totals.
+    ps = defaultdict(int)
+    for r in precinct_rows:
+        ps[(r[0], r[4], r[5])] += r[6]
+    for key, v in county_sums.items():
+        assert ps[key] == v, f"mismatch {key}: {ps[key]} != {v}"
+    return county_rows, precinct_rows
+
+
+def write_csv(path, header, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(rows)
+    print(f"Wrote {path} ({len(rows)} rows)")
+
+
+def main():
+    county_dir = os.path.abspath(OUT_DIR)
+    os.makedirs(county_dir, exist_ok=True)
+
+    build(
+        PRIMARY_URL,
+        os.path.join(county_dir, "20251007__tn__special__primary__county.csv"),
+        os.path.join(county_dir, "20251007__tn__special__primary__precinct.csv"),
+    )
+    build(
+        GENERAL_URL,
+        os.path.join(county_dir, "20251202__tn__special__general__county.csv"),
+        os.path.join(county_dir, "20251202__tn__special__general__precinct.csv"),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds county- and precinct-level CSVs for the 2025 Tennessee U.S. House District 7 special elections (unexpired term), parsed from the TN SoS ["All by Precinct" spreadsheets](https://sos.tn.gov/elections/results#2025).

### Files
- `2025/20251007__tn__special__primary__county.csv` / `__precinct.csv` — Oct 7 special primary
- `2025/20251202__tn__special__general__county.csv` / `__precinct.csv` — Dec 2 special general

### Coverage
- **Primary** — both parties: 11 Republicans (Matt Van Epps 19,006; Jody Barrett 9,337; Gino Bulso 4,005; Lee Reeves 1,929; Mason Foley 1,022; Stewart Parks 595; Jason D. Knight 381; Stuart Cooper 239; Tres Wittum 133; Joe Leurs 122; Adolph Agbéko Dagan 93) and 4 Democrats (Aftyn Behn 8,653; Darden Hunter Copeland 7,720; Bo Mitchell 7,498; Vincent Dixie 7,153).
- **General** — 6 candidates: Matt Van Epps (R) 97,034; Aftyn Behn (D) 81,109; Jon Thorp (Ind) 932; Teresa "Terri" Christie (Ind) 610; Bobby Dodge (Ind) 198; Robert James Sutherby (Ind) 129.

District 7 spans 14 counties (Benton, Cheatham, Davidson, Decatur, Dickson, Hickman, Houston, Humphreys, Montgomery, Perry, Robertson, Stewart, Wayne, Williamson).

### Source & verification
County totals are derived by summing precinct votes per county from the structured XLSX. I cross-checked every candidate's grand total against the official by-county PDFs (`...byCounty.pdf`) — all 21 match exactly, so the precinct data is complete (including the `All County Precinct` absentee/early-vote bucket, which is kept as a precinct per the repo's 2022 convention). Files pass inline equivalents of all four OpenElections data tests (file format, missing values, duplicate entries, vote breakdown totals); precinct sums equal county totals for both elections.

### Conventions
Matches the repo's canonical files: Title-case counties (the primary source misspells `Humphreys` as `Humhreys` and the general source uppercases county names — both normalized), `U.S. House` office, district `7`, full party names, precinct names as printed, and proper CSV quote-doubling (e.g. `"Teresa ""Terri"" Christie"`). UTF-8 names preserved (e.g. `Adolph Agbéko Dagan`).

A reproducible parser is at `cleaning/tn_2025_special_us_house_d7_parser.py` (requires `requests` from the Pipfile plus `openpyxl` for the .xlsx workbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)