### PR TITLE
Add 2026 TN May primary results (county + precinct)

### DIFF
--- a/2025/20251007__tn__special__primary__county.csv
+++ b/2025/20251007__tn__special__primary__county.csv
@@ -1,0 +1,211 @@
+county,office,district,party,candidate,votes
+Benton,U.S. House,7,Democratic,Aftyn Behn,36
+Benton,U.S. House,7,Democratic,Bo Mitchell,65
+Benton,U.S. House,7,Democratic,Darden Hunter Copeland,68
+Benton,U.S. House,7,Democratic,Vincent Dixie,2
+Benton,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Benton,U.S. House,7,Republican,Gino Bulso,123
+Benton,U.S. House,7,Republican,Jason D. Knight,1
+Benton,U.S. House,7,Republican,Jody Barrett,132
+Benton,U.S. House,7,Republican,Joe Leurs,0
+Benton,U.S. House,7,Republican,Lee Reeves,17
+Benton,U.S. House,7,Republican,Mason Foley,11
+Benton,U.S. House,7,Republican,Matt Van Epps,336
+Benton,U.S. House,7,Republican,Stewart Parks,25
+Benton,U.S. House,7,Republican,Stuart Cooper,4
+Benton,U.S. House,7,Republican,Tres Wittum,2
+Cheatham,U.S. House,7,Democratic,Aftyn Behn,397
+Cheatham,U.S. House,7,Democratic,Bo Mitchell,601
+Cheatham,U.S. House,7,Democratic,Darden Hunter Copeland,512
+Cheatham,U.S. House,7,Democratic,Vincent Dixie,98
+Cheatham,U.S. House,7,Republican,Adolph Agbéko Dagan,7
+Cheatham,U.S. House,7,Republican,Gino Bulso,234
+Cheatham,U.S. House,7,Republican,Jason D. Knight,26
+Cheatham,U.S. House,7,Republican,Jody Barrett,681
+Cheatham,U.S. House,7,Republican,Joe Leurs,17
+Cheatham,U.S. House,7,Republican,Lee Reeves,116
+Cheatham,U.S. House,7,Republican,Mason Foley,90
+Cheatham,U.S. House,7,Republican,Matt Van Epps,1695
+Cheatham,U.S. House,7,Republican,Stewart Parks,42
+Cheatham,U.S. House,7,Republican,Stuart Cooper,14
+Cheatham,U.S. House,7,Republican,Tres Wittum,13
+Davidson,U.S. House,7,Democratic,Aftyn Behn,3919
+Davidson,U.S. House,7,Democratic,Bo Mitchell,2920
+Davidson,U.S. House,7,Democratic,Darden Hunter Copeland,1856
+Davidson,U.S. House,7,Democratic,Vincent Dixie,5110
+Davidson,U.S. House,7,Republican,Adolph Agbéko Dagan,20
+Davidson,U.S. House,7,Republican,Gino Bulso,318
+Davidson,U.S. House,7,Republican,Jason D. Knight,34
+Davidson,U.S. House,7,Republican,Jody Barrett,474
+Davidson,U.S. House,7,Republican,Joe Leurs,14
+Davidson,U.S. House,7,Republican,Lee Reeves,158
+Davidson,U.S. House,7,Republican,Mason Foley,130
+Davidson,U.S. House,7,Republican,Matt Van Epps,1359
+Davidson,U.S. House,7,Republican,Stewart Parks,52
+Davidson,U.S. House,7,Republican,Stuart Cooper,25
+Davidson,U.S. House,7,Republican,Tres Wittum,24
+Decatur,U.S. House,7,Democratic,Aftyn Behn,19
+Decatur,U.S. House,7,Democratic,Bo Mitchell,118
+Decatur,U.S. House,7,Democratic,Darden Hunter Copeland,75
+Decatur,U.S. House,7,Democratic,Vincent Dixie,3
+Decatur,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Decatur,U.S. House,7,Republican,Gino Bulso,72
+Decatur,U.S. House,7,Republican,Jason D. Knight,10
+Decatur,U.S. House,7,Republican,Jody Barrett,120
+Decatur,U.S. House,7,Republican,Joe Leurs,1
+Decatur,U.S. House,7,Republican,Lee Reeves,27
+Decatur,U.S. House,7,Republican,Mason Foley,6
+Decatur,U.S. House,7,Republican,Matt Van Epps,427
+Decatur,U.S. House,7,Republican,Stewart Parks,58
+Decatur,U.S. House,7,Republican,Stuart Cooper,7
+Decatur,U.S. House,7,Republican,Tres Wittum,4
+Dickson,U.S. House,7,Democratic,Aftyn Behn,376
+Dickson,U.S. House,7,Democratic,Bo Mitchell,684
+Dickson,U.S. House,7,Democratic,Darden Hunter Copeland,400
+Dickson,U.S. House,7,Democratic,Vincent Dixie,53
+Dickson,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Dickson,U.S. House,7,Republican,Gino Bulso,256
+Dickson,U.S. House,7,Republican,Jason D. Knight,6
+Dickson,U.S. House,7,Republican,Jody Barrett,2201
+Dickson,U.S. House,7,Republican,Joe Leurs,7
+Dickson,U.S. House,7,Republican,Lee Reeves,124
+Dickson,U.S. House,7,Republican,Mason Foley,32
+Dickson,U.S. House,7,Republican,Matt Van Epps,1504
+Dickson,U.S. House,7,Republican,Stewart Parks,29
+Dickson,U.S. House,7,Republican,Stuart Cooper,11
+Dickson,U.S. House,7,Republican,Tres Wittum,5
+Hickman,U.S. House,7,Democratic,Aftyn Behn,57
+Hickman,U.S. House,7,Democratic,Bo Mitchell,190
+Hickman,U.S. House,7,Democratic,Darden Hunter Copeland,164
+Hickman,U.S. House,7,Democratic,Vincent Dixie,16
+Hickman,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Hickman,U.S. House,7,Republican,Gino Bulso,199
+Hickman,U.S. House,7,Republican,Jason D. Knight,8
+Hickman,U.S. House,7,Republican,Jody Barrett,1041
+Hickman,U.S. House,7,Republican,Joe Leurs,4
+Hickman,U.S. House,7,Republican,Lee Reeves,59
+Hickman,U.S. House,7,Republican,Mason Foley,26
+Hickman,U.S. House,7,Republican,Matt Van Epps,567
+Hickman,U.S. House,7,Republican,Stewart Parks,54
+Hickman,U.S. House,7,Republican,Stuart Cooper,10
+Hickman,U.S. House,7,Republican,Tres Wittum,4
+Houston,U.S. House,7,Democratic,Aftyn Behn,56
+Houston,U.S. House,7,Democratic,Bo Mitchell,59
+Houston,U.S. House,7,Democratic,Darden Hunter Copeland,81
+Houston,U.S. House,7,Democratic,Vincent Dixie,6
+Houston,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Houston,U.S. House,7,Republican,Gino Bulso,214
+Houston,U.S. House,7,Republican,Jason D. Knight,3
+Houston,U.S. House,7,Republican,Jody Barrett,165
+Houston,U.S. House,7,Republican,Joe Leurs,2
+Houston,U.S. House,7,Republican,Lee Reeves,15
+Houston,U.S. House,7,Republican,Mason Foley,4
+Houston,U.S. House,7,Republican,Matt Van Epps,232
+Houston,U.S. House,7,Republican,Stewart Parks,23
+Houston,U.S. House,7,Republican,Stuart Cooper,9
+Houston,U.S. House,7,Republican,Tres Wittum,2
+Humphreys,U.S. House,7,Democratic,Aftyn Behn,81
+Humphreys,U.S. House,7,Democratic,Bo Mitchell,247
+Humphreys,U.S. House,7,Democratic,Darden Hunter Copeland,189
+Humphreys,U.S. House,7,Democratic,Vincent Dixie,18
+Humphreys,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Humphreys,U.S. House,7,Republican,Gino Bulso,146
+Humphreys,U.S. House,7,Republican,Jason D. Knight,6
+Humphreys,U.S. House,7,Republican,Jody Barrett,368
+Humphreys,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,U.S. House,7,Republican,Lee Reeves,48
+Humphreys,U.S. House,7,Republican,Mason Foley,31
+Humphreys,U.S. House,7,Republican,Matt Van Epps,568
+Humphreys,U.S. House,7,Republican,Stewart Parks,12
+Humphreys,U.S. House,7,Republican,Stuart Cooper,11
+Humphreys,U.S. House,7,Republican,Tres Wittum,2
+Montgomery,U.S. House,7,Democratic,Aftyn Behn,1931
+Montgomery,U.S. House,7,Democratic,Bo Mitchell,1216
+Montgomery,U.S. House,7,Democratic,Darden Hunter Copeland,2146
+Montgomery,U.S. House,7,Democratic,Vincent Dixie,1419
+Montgomery,U.S. House,7,Republican,Adolph Agbéko Dagan,24
+Montgomery,U.S. House,7,Republican,Gino Bulso,915
+Montgomery,U.S. House,7,Republican,Jason D. Knight,215
+Montgomery,U.S. House,7,Republican,Jody Barrett,1148
+Montgomery,U.S. House,7,Republican,Joe Leurs,50
+Montgomery,U.S. House,7,Republican,Lee Reeves,307
+Montgomery,U.S. House,7,Republican,Mason Foley,108
+Montgomery,U.S. House,7,Republican,Matt Van Epps,5837
+Montgomery,U.S. House,7,Republican,Stewart Parks,51
+Montgomery,U.S. House,7,Republican,Stuart Cooper,41
+Montgomery,U.S. House,7,Republican,Tres Wittum,33
+Perry,U.S. House,7,Democratic,Aftyn Behn,15
+Perry,U.S. House,7,Democratic,Bo Mitchell,106
+Perry,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Perry,U.S. House,7,Democratic,Vincent Dixie,2
+Perry,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Perry,U.S. House,7,Republican,Gino Bulso,61
+Perry,U.S. House,7,Republican,Jason D. Knight,4
+Perry,U.S. House,7,Republican,Jody Barrett,167
+Perry,U.S. House,7,Republican,Joe Leurs,0
+Perry,U.S. House,7,Republican,Lee Reeves,13
+Perry,U.S. House,7,Republican,Mason Foley,2
+Perry,U.S. House,7,Republican,Matt Van Epps,230
+Perry,U.S. House,7,Republican,Stewart Parks,18
+Perry,U.S. House,7,Republican,Stuart Cooper,3
+Perry,U.S. House,7,Republican,Tres Wittum,1
+Robertson,U.S. House,7,Democratic,Aftyn Behn,372
+Robertson,U.S. House,7,Democratic,Bo Mitchell,417
+Robertson,U.S. House,7,Democratic,Darden Hunter Copeland,678
+Robertson,U.S. House,7,Democratic,Vincent Dixie,140
+Robertson,U.S. House,7,Republican,Adolph Agbéko Dagan,8
+Robertson,U.S. House,7,Republican,Gino Bulso,503
+Robertson,U.S. House,7,Republican,Jason D. Knight,25
+Robertson,U.S. House,7,Republican,Jody Barrett,628
+Robertson,U.S. House,7,Republican,Joe Leurs,7
+Robertson,U.S. House,7,Republican,Lee Reeves,153
+Robertson,U.S. House,7,Republican,Mason Foley,141
+Robertson,U.S. House,7,Republican,Matt Van Epps,2810
+Robertson,U.S. House,7,Republican,Stewart Parks,69
+Robertson,U.S. House,7,Republican,Stuart Cooper,21
+Robertson,U.S. House,7,Republican,Tres Wittum,13
+Stewart,U.S. House,7,Democratic,Aftyn Behn,56
+Stewart,U.S. House,7,Democratic,Bo Mitchell,80
+Stewart,U.S. House,7,Democratic,Darden Hunter Copeland,174
+Stewart,U.S. House,7,Democratic,Vincent Dixie,14
+Stewart,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Stewart,U.S. House,7,Republican,Gino Bulso,164
+Stewart,U.S. House,7,Republican,Jason D. Knight,16
+Stewart,U.S. House,7,Republican,Jody Barrett,147
+Stewart,U.S. House,7,Republican,Joe Leurs,4
+Stewart,U.S. House,7,Republican,Lee Reeves,34
+Stewart,U.S. House,7,Republican,Mason Foley,6
+Stewart,U.S. House,7,Republican,Matt Van Epps,590
+Stewart,U.S. House,7,Republican,Stewart Parks,40
+Stewart,U.S. House,7,Republican,Stuart Cooper,2
+Stewart,U.S. House,7,Republican,Tres Wittum,2
+Wayne,U.S. House,7,Democratic,Aftyn Behn,15
+Wayne,U.S. House,7,Democratic,Bo Mitchell,56
+Wayne,U.S. House,7,Democratic,Darden Hunter Copeland,76
+Wayne,U.S. House,7,Democratic,Vincent Dixie,7
+Wayne,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,U.S. House,7,Republican,Gino Bulso,69
+Wayne,U.S. House,7,Republican,Jason D. Knight,2
+Wayne,U.S. House,7,Republican,Jody Barrett,268
+Wayne,U.S. House,7,Republican,Joe Leurs,0
+Wayne,U.S. House,7,Republican,Lee Reeves,30
+Wayne,U.S. House,7,Republican,Mason Foley,27
+Wayne,U.S. House,7,Republican,Matt Van Epps,457
+Wayne,U.S. House,7,Republican,Stewart Parks,40
+Wayne,U.S. House,7,Republican,Stuart Cooper,5
+Wayne,U.S. House,7,Republican,Tres Wittum,0
+Williamson,U.S. House,7,Democratic,Aftyn Behn,1323
+Williamson,U.S. House,7,Democratic,Bo Mitchell,739
+Williamson,U.S. House,7,Democratic,Darden Hunter Copeland,1264
+Williamson,U.S. House,7,Democratic,Vincent Dixie,265
+Williamson,U.S. House,7,Republican,Adolph Agbéko Dagan,23
+Williamson,U.S. House,7,Republican,Gino Bulso,731
+Williamson,U.S. House,7,Republican,Jason D. Knight,25
+Williamson,U.S. House,7,Republican,Jody Barrett,1797
+Williamson,U.S. House,7,Republican,Joe Leurs,16
+Williamson,U.S. House,7,Republican,Lee Reeves,828
+Williamson,U.S. House,7,Republican,Mason Foley,408
+Williamson,U.S. House,7,Republican,Matt Van Epps,2394
+Williamson,U.S. House,7,Republican,Stewart Parks,82
+Williamson,U.S. House,7,Republican,Stuart Cooper,76
+Williamson,U.S. House,7,Republican,Tres Wittum,28

--- a/2025/20251007__tn__special__primary__precinct.csv
+++ b/2025/20251007__tn__special__primary__precinct.csv
@@ -1,0 +1,3436 @@
+county,precinct,office,district,party,candidate,votes
+Benton,1 Holladay,U.S. House,7,Democratic,Aftyn Behn,7
+Benton,1 Holladay,U.S. House,7,Democratic,Bo Mitchell,21
+Benton,1 Holladay,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Benton,1 Holladay,U.S. House,7,Democratic,Vincent Dixie,1
+Benton,1 Holladay,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Benton,1 Holladay,U.S. House,7,Republican,Gino Bulso,31
+Benton,1 Holladay,U.S. House,7,Republican,Jason D. Knight,0
+Benton,1 Holladay,U.S. House,7,Republican,Jody Barrett,25
+Benton,1 Holladay,U.S. House,7,Republican,Joe Leurs,0
+Benton,1 Holladay,U.S. House,7,Republican,Lee Reeves,4
+Benton,1 Holladay,U.S. House,7,Republican,Mason Foley,2
+Benton,1 Holladay,U.S. House,7,Republican,Matt Van Epps,105
+Benton,1 Holladay,U.S. House,7,Republican,Stewart Parks,3
+Benton,1 Holladay,U.S. House,7,Republican,Stuart Cooper,1
+Benton,1 Holladay,U.S. House,7,Republican,Tres Wittum,0
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Aftyn Behn,9
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Bo Mitchell,20
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Darden Hunter Copeland,23
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Vincent Dixie,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Gino Bulso,36
+Benton,3 Camden City Hall,U.S. House,7,Republican,Jason D. Knight,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Jody Barrett,33
+Benton,3 Camden City Hall,U.S. House,7,Republican,Joe Leurs,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Lee Reeves,2
+Benton,3 Camden City Hall,U.S. House,7,Republican,Mason Foley,3
+Benton,3 Camden City Hall,U.S. House,7,Republican,Matt Van Epps,45
+Benton,3 Camden City Hall,U.S. House,7,Republican,Stewart Parks,9
+Benton,3 Camden City Hall,U.S. House,7,Republican,Stuart Cooper,0
+Benton,3 Camden City Hall,U.S. House,7,Republican,Tres Wittum,2
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Aftyn Behn,8
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Bo Mitchell,18
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Vincent Dixie,0
+Benton,4 Camden Elementary,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Benton,4 Camden Elementary,U.S. House,7,Republican,Gino Bulso,33
+Benton,4 Camden Elementary,U.S. House,7,Republican,Jason D. Knight,0
+Benton,4 Camden Elementary,U.S. House,7,Republican,Jody Barrett,40
+Benton,4 Camden Elementary,U.S. House,7,Republican,Joe Leurs,0
+Benton,4 Camden Elementary,U.S. House,7,Republican,Lee Reeves,4
+Benton,4 Camden Elementary,U.S. House,7,Republican,Mason Foley,4
+Benton,4 Camden Elementary,U.S. House,7,Republican,Matt Van Epps,82
+Benton,4 Camden Elementary,U.S. House,7,Republican,Stewart Parks,11
+Benton,4 Camden Elementary,U.S. House,7,Republican,Stuart Cooper,3
+Benton,4 Camden Elementary,U.S. House,7,Republican,Tres Wittum,0
+Benton,6 Big Sandy,U.S. House,7,Democratic,Aftyn Behn,12
+Benton,6 Big Sandy,U.S. House,7,Democratic,Bo Mitchell,6
+Benton,6 Big Sandy,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Benton,6 Big Sandy,U.S. House,7,Democratic,Vincent Dixie,1
+Benton,6 Big Sandy,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Benton,6 Big Sandy,U.S. House,7,Republican,Gino Bulso,23
+Benton,6 Big Sandy,U.S. House,7,Republican,Jason D. Knight,1
+Benton,6 Big Sandy,U.S. House,7,Republican,Jody Barrett,34
+Benton,6 Big Sandy,U.S. House,7,Republican,Joe Leurs,0
+Benton,6 Big Sandy,U.S. House,7,Republican,Lee Reeves,7
+Benton,6 Big Sandy,U.S. House,7,Republican,Mason Foley,2
+Benton,6 Big Sandy,U.S. House,7,Republican,Matt Van Epps,104
+Benton,6 Big Sandy,U.S. House,7,Republican,Stewart Parks,2
+Benton,6 Big Sandy,U.S. House,7,Republican,Stuart Cooper,0
+Benton,6 Big Sandy,U.S. House,7,Republican,Tres Wittum,0
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Aftyn Behn,78
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Bo Mitchell,81
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Darden Hunter Copeland,69
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Vincent Dixie,29
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Gino Bulso,35
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Jason D. Knight,9
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Jody Barrett,70
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Joe Leurs,1
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Lee Reeves,13
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Mason Foley,15
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Matt Van Epps,191
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Stewart Parks,10
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Stuart Cooper,4
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Aftyn Behn,44
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Bo Mitchell,67
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Darden Hunter Copeland,63
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Vincent Dixie,13
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Gino Bulso,41
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Jason D. Knight,5
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Jody Barrett,109
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Joe Leurs,6
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Lee Reeves,17
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Mason Foley,24
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Matt Van Epps,287
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Stewart Parks,2
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Stuart Cooper,0
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Aftyn Behn,43
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Bo Mitchell,60
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Darden Hunter Copeland,58
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Vincent Dixie,21
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Gino Bulso,48
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Jason D. Knight,6
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Jody Barrett,129
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Joe Leurs,2
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Lee Reeves,20
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Mason Foley,15
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Matt Van Epps,334
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Stewart Parks,15
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Stuart Cooper,3
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Tres Wittum,4
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Aftyn Behn,25
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Bo Mitchell,40
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Vincent Dixie,10
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Gino Bulso,18
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Jason D. Knight,1
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Jody Barrett,86
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Joe Leurs,2
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Lee Reeves,8
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Mason Foley,2
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Matt Van Epps,206
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Stewart Parks,0
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Stuart Cooper,2
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Aftyn Behn,26
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Bo Mitchell,28
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Darden Hunter Copeland,24
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Vincent Dixie,3
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Gino Bulso,17
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Jason D. Knight,0
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Jody Barrett,51
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Joe Leurs,0
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Lee Reeves,12
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Mason Foley,4
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Matt Van Epps,145
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Stewart Parks,6
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Stuart Cooper,0
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Tres Wittum,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Aftyn Behn,26
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Bo Mitchell,46
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Darden Hunter Copeland,28
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Vincent Dixie,10
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Gino Bulso,12
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Jason D. Knight,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Jody Barrett,37
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Joe Leurs,4
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Lee Reeves,7
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Mason Foley,4
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Matt Van Epps,100
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Stewart Parks,3
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Stuart Cooper,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Tres Wittum,0
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Aftyn Behn,44
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Bo Mitchell,101
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Darden Hunter Copeland,84
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Vincent Dixie,4
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Gino Bulso,26
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Jason D. Knight,0
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Jody Barrett,68
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Joe Leurs,0
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Lee Reeves,18
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Mason Foley,11
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Matt Van Epps,206
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Stewart Parks,5
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Stuart Cooper,1
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Tres Wittum,1
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Aftyn Behn,111
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Bo Mitchell,178
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Darden Hunter Copeland,150
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Vincent Dixie,8
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Gino Bulso,37
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Jason D. Knight,3
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Jody Barrett,131
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Joe Leurs,2
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Lee Reeves,21
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Mason Foley,15
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Matt Van Epps,226
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Stewart Parks,1
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Stuart Cooper,2
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Tres Wittum,3
+Davidson,01-1,U.S. House,7,Democratic,Aftyn Behn,61
+Davidson,01-1,U.S. House,7,Democratic,Bo Mitchell,153
+Davidson,01-1,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Davidson,01-1,U.S. House,7,Democratic,Vincent Dixie,51
+Davidson,01-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-1,U.S. House,7,Republican,Gino Bulso,82
+Davidson,01-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-1,U.S. House,7,Republican,Jody Barrett,33
+Davidson,01-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-1,U.S. House,7,Republican,Lee Reeves,17
+Davidson,01-1,U.S. House,7,Republican,Mason Foley,10
+Davidson,01-1,U.S. House,7,Republican,Matt Van Epps,199
+Davidson,01-1,U.S. House,7,Republican,Stewart Parks,8
+Davidson,01-1,U.S. House,7,Republican,Stuart Cooper,2
+Davidson,01-1,U.S. House,7,Republican,Tres Wittum,4
+Davidson,01-2,U.S. House,7,Democratic,Aftyn Behn,26
+Davidson,01-2,U.S. House,7,Democratic,Bo Mitchell,53
+Davidson,01-2,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Davidson,01-2,U.S. House,7,Democratic,Vincent Dixie,9
+Davidson,01-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-2,U.S. House,7,Republican,Gino Bulso,23
+Davidson,01-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-2,U.S. House,7,Republican,Jody Barrett,18
+Davidson,01-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-2,U.S. House,7,Republican,Lee Reeves,5
+Davidson,01-2,U.S. House,7,Republican,Mason Foley,3
+Davidson,01-2,U.S. House,7,Republican,Matt Van Epps,38
+Davidson,01-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-3,U.S. House,7,Democratic,Aftyn Behn,24
+Davidson,01-3,U.S. House,7,Democratic,Bo Mitchell,31
+Davidson,01-3,U.S. House,7,Democratic,Darden Hunter Copeland,34
+Davidson,01-3,U.S. House,7,Democratic,Vincent Dixie,215
+Davidson,01-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-3,U.S. House,7,Republican,Gino Bulso,8
+Davidson,01-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-3,U.S. House,7,Republican,Jody Barrett,14
+Davidson,01-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-3,U.S. House,7,Republican,Lee Reeves,1
+Davidson,01-3,U.S. House,7,Republican,Mason Foley,2
+Davidson,01-3,U.S. House,7,Republican,Matt Van Epps,30
+Davidson,01-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,01-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-4,U.S. House,7,Democratic,Aftyn Behn,39
+Davidson,01-4,U.S. House,7,Democratic,Bo Mitchell,40
+Davidson,01-4,U.S. House,7,Democratic,Darden Hunter Copeland,32
+Davidson,01-4,U.S. House,7,Democratic,Vincent Dixie,209
+Davidson,01-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-4,U.S. House,7,Republican,Gino Bulso,9
+Davidson,01-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-4,U.S. House,7,Republican,Jody Barrett,8
+Davidson,01-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-4,U.S. House,7,Republican,Lee Reeves,2
+Davidson,01-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,01-4,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,01-4,U.S. House,7,Republican,Stewart Parks,1
+Davidson,01-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-5,U.S. House,7,Democratic,Aftyn Behn,44
+Davidson,01-5,U.S. House,7,Democratic,Bo Mitchell,40
+Davidson,01-5,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Davidson,01-5,U.S. House,7,Democratic,Vincent Dixie,225
+Davidson,01-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-5,U.S. House,7,Republican,Gino Bulso,1
+Davidson,01-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-5,U.S. House,7,Republican,Jody Barrett,3
+Davidson,01-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-5,U.S. House,7,Republican,Lee Reeves,2
+Davidson,01-5,U.S. House,7,Republican,Mason Foley,0
+Davidson,01-5,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,01-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-6,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,01-6,U.S. House,7,Democratic,Bo Mitchell,17
+Davidson,01-6,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Davidson,01-6,U.S. House,7,Democratic,Vincent Dixie,94
+Davidson,01-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-6,U.S. House,7,Republican,Gino Bulso,0
+Davidson,01-6,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-6,U.S. House,7,Republican,Jody Barrett,0
+Davidson,01-6,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-6,U.S. House,7,Republican,Lee Reeves,0
+Davidson,01-6,U.S. House,7,Republican,Mason Foley,0
+Davidson,01-6,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,01-6,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-6,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,01-6,U.S. House,7,Republican,Tres Wittum,0
+Davidson,01-7,U.S. House,7,Democratic,Aftyn Behn,97
+Davidson,01-7,U.S. House,7,Democratic,Bo Mitchell,65
+Davidson,01-7,U.S. House,7,Democratic,Darden Hunter Copeland,85
+Davidson,01-7,U.S. House,7,Democratic,Vincent Dixie,941
+Davidson,01-7,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,01-7,U.S. House,7,Republican,Gino Bulso,4
+Davidson,01-7,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,01-7,U.S. House,7,Republican,Jody Barrett,10
+Davidson,01-7,U.S. House,7,Republican,Joe Leurs,0
+Davidson,01-7,U.S. House,7,Republican,Lee Reeves,2
+Davidson,01-7,U.S. House,7,Republican,Mason Foley,1
+Davidson,01-7,U.S. House,7,Republican,Matt Van Epps,17
+Davidson,01-7,U.S. House,7,Republican,Stewart Parks,0
+Davidson,01-7,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,01-7,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-1,U.S. House,7,Democratic,Aftyn Behn,34
+Davidson,02-1,U.S. House,7,Democratic,Bo Mitchell,17
+Davidson,02-1,U.S. House,7,Democratic,Darden Hunter Copeland,23
+Davidson,02-1,U.S. House,7,Democratic,Vincent Dixie,112
+Davidson,02-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-1,U.S. House,7,Republican,Jody Barrett,2
+Davidson,02-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,02-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,02-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-1,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,02-1,U.S. House,7,Republican,Stewart Parks,2
+Davidson,02-1,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,02-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-2,U.S. House,7,Democratic,Aftyn Behn,46
+Davidson,02-2,U.S. House,7,Democratic,Bo Mitchell,28
+Davidson,02-2,U.S. House,7,Democratic,Darden Hunter Copeland,33
+Davidson,02-2,U.S. House,7,Democratic,Vincent Dixie,174
+Davidson,02-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-2,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-2,U.S. House,7,Republican,Jody Barrett,1
+Davidson,02-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,02-2,U.S. House,7,Republican,Lee Reeves,1
+Davidson,02-2,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-2,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,02-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-2,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,02-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-3,U.S. House,7,Democratic,Aftyn Behn,18
+Davidson,02-3,U.S. House,7,Democratic,Bo Mitchell,19
+Davidson,02-3,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Davidson,02-3,U.S. House,7,Democratic,Vincent Dixie,51
+Davidson,02-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-3,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-3,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,02-3,U.S. House,7,Republican,Jody Barrett,2
+Davidson,02-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,02-3,U.S. House,7,Republican,Lee Reeves,0
+Davidson,02-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-3,U.S. House,7,Republican,Matt Van Epps,1
+Davidson,02-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,02-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,02-4,U.S. House,7,Democratic,Aftyn Behn,75
+Davidson,02-4,U.S. House,7,Democratic,Bo Mitchell,33
+Davidson,02-4,U.S. House,7,Democratic,Darden Hunter Copeland,39
+Davidson,02-4,U.S. House,7,Democratic,Vincent Dixie,146
+Davidson,02-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-4,U.S. House,7,Republican,Gino Bulso,1
+Davidson,02-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-4,U.S. House,7,Republican,Jody Barrett,5
+Davidson,02-4,U.S. House,7,Republican,Joe Leurs,1
+Davidson,02-4,U.S. House,7,Republican,Lee Reeves,3
+Davidson,02-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,02-4,U.S. House,7,Republican,Matt Van Epps,6
+Davidson,02-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,02-4,U.S. House,7,Republican,Tres Wittum,1
+Davidson,02-5,U.S. House,7,Democratic,Aftyn Behn,96
+Davidson,02-5,U.S. House,7,Democratic,Bo Mitchell,73
+Davidson,02-5,U.S. House,7,Democratic,Darden Hunter Copeland,73
+Davidson,02-5,U.S. House,7,Democratic,Vincent Dixie,664
+Davidson,02-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,02-5,U.S. House,7,Republican,Gino Bulso,0
+Davidson,02-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,02-5,U.S. House,7,Republican,Jody Barrett,1
+Davidson,02-5,U.S. House,7,Republican,Joe Leurs,1
+Davidson,02-5,U.S. House,7,Republican,Lee Reeves,2
+Davidson,02-5,U.S. House,7,Republican,Mason Foley,2
+Davidson,02-5,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,02-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,02-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,02-5,U.S. House,7,Republican,Tres Wittum,1
+Davidson,03-1,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,03-1,U.S. House,7,Democratic,Bo Mitchell,0
+Davidson,03-1,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,03-1,U.S. House,7,Democratic,Vincent Dixie,0
+Davidson,03-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,03-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,03-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,03-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,03-1,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,03-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-2,U.S. House,7,Democratic,Aftyn Behn,139
+Davidson,03-2,U.S. House,7,Democratic,Bo Mitchell,62
+Davidson,03-2,U.S. House,7,Democratic,Darden Hunter Copeland,62
+Davidson,03-2,U.S. House,7,Democratic,Vincent Dixie,459
+Davidson,03-2,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,03-2,U.S. House,7,Republican,Gino Bulso,14
+Davidson,03-2,U.S. House,7,Republican,Jason D. Knight,4
+Davidson,03-2,U.S. House,7,Republican,Jody Barrett,21
+Davidson,03-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-2,U.S. House,7,Republican,Lee Reeves,4
+Davidson,03-2,U.S. House,7,Republican,Mason Foley,6
+Davidson,03-2,U.S. House,7,Republican,Matt Van Epps,41
+Davidson,03-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-3,U.S. House,7,Democratic,Aftyn Behn,7
+Davidson,03-3,U.S. House,7,Democratic,Bo Mitchell,9
+Davidson,03-3,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Davidson,03-3,U.S. House,7,Democratic,Vincent Dixie,11
+Davidson,03-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-3,U.S. House,7,Republican,Gino Bulso,1
+Davidson,03-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-3,U.S. House,7,Republican,Jody Barrett,2
+Davidson,03-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-3,U.S. House,7,Republican,Lee Reeves,4
+Davidson,03-3,U.S. House,7,Republican,Mason Foley,5
+Davidson,03-3,U.S. House,7,Republican,Matt Van Epps,8
+Davidson,03-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,03-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-5,U.S. House,7,Democratic,Aftyn Behn,43
+Davidson,03-5,U.S. House,7,Democratic,Bo Mitchell,18
+Davidson,03-5,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Davidson,03-5,U.S. House,7,Democratic,Vincent Dixie,22
+Davidson,03-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-5,U.S. House,7,Republican,Gino Bulso,2
+Davidson,03-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-5,U.S. House,7,Republican,Jody Barrett,8
+Davidson,03-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-5,U.S. House,7,Republican,Lee Reeves,1
+Davidson,03-5,U.S. House,7,Republican,Mason Foley,1
+Davidson,03-5,U.S. House,7,Republican,Matt Van Epps,28
+Davidson,03-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-6,U.S. House,7,Democratic,Aftyn Behn,24
+Davidson,03-6,U.S. House,7,Democratic,Bo Mitchell,19
+Davidson,03-6,U.S. House,7,Democratic,Darden Hunter Copeland,10
+Davidson,03-6,U.S. House,7,Democratic,Vincent Dixie,57
+Davidson,03-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,03-6,U.S. House,7,Republican,Gino Bulso,4
+Davidson,03-6,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,03-6,U.S. House,7,Republican,Jody Barrett,7
+Davidson,03-6,U.S. House,7,Republican,Joe Leurs,0
+Davidson,03-6,U.S. House,7,Republican,Lee Reeves,4
+Davidson,03-6,U.S. House,7,Republican,Mason Foley,4
+Davidson,03-6,U.S. House,7,Republican,Matt Van Epps,23
+Davidson,03-6,U.S. House,7,Republican,Stewart Parks,1
+Davidson,03-6,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,03-6,U.S. House,7,Republican,Tres Wittum,0
+Davidson,03-8,U.S. House,7,Democratic,Aftyn Behn,96
+Davidson,03-8,U.S. House,7,Democratic,Bo Mitchell,36
+Davidson,03-8,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Davidson,03-8,U.S. House,7,Democratic,Vincent Dixie,419
+Davidson,03-8,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Davidson,03-8,U.S. House,7,Republican,Gino Bulso,5
+Davidson,03-8,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,03-8,U.S. House,7,Republican,Jody Barrett,7
+Davidson,03-8,U.S. House,7,Republican,Joe Leurs,1
+Davidson,03-8,U.S. House,7,Republican,Lee Reeves,1
+Davidson,03-8,U.S. House,7,Republican,Mason Foley,3
+Davidson,03-8,U.S. House,7,Republican,Matt Van Epps,11
+Davidson,03-8,U.S. House,7,Republican,Stewart Parks,0
+Davidson,03-8,U.S. House,7,Republican,Stuart Cooper,4
+Davidson,03-8,U.S. House,7,Republican,Tres Wittum,0
+Davidson,05-1,U.S. House,7,Democratic,Aftyn Behn,6
+Davidson,05-1,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,05-1,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Davidson,05-1,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,05-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,05-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,05-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,05-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,05-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,05-1,U.S. House,7,Republican,Lee Reeves,2
+Davidson,05-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,05-1,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,05-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,05-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,05-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-2,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,10-2,U.S. House,7,Democratic,Bo Mitchell,17
+Davidson,10-2,U.S. House,7,Democratic,Darden Hunter Copeland,6
+Davidson,10-2,U.S. House,7,Democratic,Vincent Dixie,3
+Davidson,10-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,10-2,U.S. House,7,Republican,Gino Bulso,9
+Davidson,10-2,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,10-2,U.S. House,7,Republican,Jody Barrett,9
+Davidson,10-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,10-2,U.S. House,7,Republican,Lee Reeves,0
+Davidson,10-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,10-2,U.S. House,7,Republican,Matt Van Epps,30
+Davidson,10-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-2,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,10-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-3,U.S. House,7,Democratic,Aftyn Behn,17
+Davidson,10-3,U.S. House,7,Democratic,Bo Mitchell,46
+Davidson,10-3,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Davidson,10-3,U.S. House,7,Democratic,Vincent Dixie,5
+Davidson,10-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,10-3,U.S. House,7,Republican,Gino Bulso,10
+Davidson,10-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,10-3,U.S. House,7,Republican,Jody Barrett,18
+Davidson,10-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,10-3,U.S. House,7,Republican,Lee Reeves,5
+Davidson,10-3,U.S. House,7,Republican,Mason Foley,1
+Davidson,10-3,U.S. House,7,Republican,Matt Van Epps,64
+Davidson,10-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,10-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-7,U.S. House,7,Democratic,Aftyn Behn,1
+Davidson,10-7,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,10-7,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,10-7,U.S. House,7,Democratic,Vincent Dixie,4
+Davidson,10-7,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,10-7,U.S. House,7,Republican,Gino Bulso,0
+Davidson,10-7,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,10-7,U.S. House,7,Republican,Jody Barrett,0
+Davidson,10-7,U.S. House,7,Republican,Joe Leurs,0
+Davidson,10-7,U.S. House,7,Republican,Lee Reeves,0
+Davidson,10-7,U.S. House,7,Republican,Mason Foley,0
+Davidson,10-7,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,10-7,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-7,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,10-7,U.S. House,7,Republican,Tres Wittum,0
+Davidson,10-9,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,10-9,U.S. House,7,Democratic,Bo Mitchell,31
+Davidson,10-9,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Davidson,10-9,U.S. House,7,Democratic,Vincent Dixie,1
+Davidson,10-9,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,10-9,U.S. House,7,Republican,Gino Bulso,12
+Davidson,10-9,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,10-9,U.S. House,7,Republican,Jody Barrett,11
+Davidson,10-9,U.S. House,7,Republican,Joe Leurs,1
+Davidson,10-9,U.S. House,7,Republican,Lee Reeves,4
+Davidson,10-9,U.S. House,7,Republican,Mason Foley,2
+Davidson,10-9,U.S. House,7,Republican,Matt Van Epps,57
+Davidson,10-9,U.S. House,7,Republican,Stewart Parks,0
+Davidson,10-9,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,10-9,U.S. House,7,Republican,Tres Wittum,0
+Davidson,15-2,U.S. House,7,Democratic,Aftyn Behn,6
+Davidson,15-2,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,15-2,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Davidson,15-2,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,15-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,15-2,U.S. House,7,Republican,Gino Bulso,0
+Davidson,15-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,15-2,U.S. House,7,Republican,Jody Barrett,2
+Davidson,15-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,15-2,U.S. House,7,Republican,Lee Reeves,0
+Davidson,15-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,15-2,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,15-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,15-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,15-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,16-1,U.S. House,7,Democratic,Aftyn Behn,21
+Davidson,16-1,U.S. House,7,Democratic,Bo Mitchell,6
+Davidson,16-1,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Davidson,16-1,U.S. House,7,Democratic,Vincent Dixie,4
+Davidson,16-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,16-1,U.S. House,7,Republican,Gino Bulso,1
+Davidson,16-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,16-1,U.S. House,7,Republican,Jody Barrett,3
+Davidson,16-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,16-1,U.S. House,7,Republican,Lee Reeves,3
+Davidson,16-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,16-1,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,16-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,16-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,16-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,16-3,U.S. House,7,Democratic,Aftyn Behn,10
+Davidson,16-3,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,16-3,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Davidson,16-3,U.S. House,7,Democratic,Vincent Dixie,0
+Davidson,16-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,16-3,U.S. House,7,Republican,Gino Bulso,0
+Davidson,16-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,16-3,U.S. House,7,Republican,Jody Barrett,0
+Davidson,16-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,16-3,U.S. House,7,Republican,Lee Reeves,0
+Davidson,16-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,16-3,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,16-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,16-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,16-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-1,U.S. House,7,Democratic,Aftyn Behn,67
+Davidson,17-1,U.S. House,7,Democratic,Bo Mitchell,30
+Davidson,17-1,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Davidson,17-1,U.S. House,7,Democratic,Vincent Dixie,32
+Davidson,17-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,17-1,U.S. House,7,Republican,Gino Bulso,3
+Davidson,17-1,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-1,U.S. House,7,Republican,Jody Barrett,12
+Davidson,17-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-1,U.S. House,7,Republican,Lee Reeves,1
+Davidson,17-1,U.S. House,7,Republican,Mason Foley,2
+Davidson,17-1,U.S. House,7,Republican,Matt Van Epps,25
+Davidson,17-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,17-1,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,17-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-2,U.S. House,7,Democratic,Aftyn Behn,48
+Davidson,17-2,U.S. House,7,Democratic,Bo Mitchell,32
+Davidson,17-2,U.S. House,7,Democratic,Darden Hunter Copeland,29
+Davidson,17-2,U.S. House,7,Democratic,Vincent Dixie,32
+Davidson,17-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-2,U.S. House,7,Republican,Gino Bulso,0
+Davidson,17-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,17-2,U.S. House,7,Republican,Jody Barrett,4
+Davidson,17-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-2,U.S. House,7,Republican,Lee Reeves,2
+Davidson,17-2,U.S. House,7,Republican,Mason Foley,5
+Davidson,17-2,U.S. House,7,Republican,Matt Van Epps,5
+Davidson,17-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,17-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-3,U.S. House,7,Democratic,Aftyn Behn,12
+Davidson,17-3,U.S. House,7,Democratic,Bo Mitchell,7
+Davidson,17-3,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Davidson,17-3,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,17-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-3,U.S. House,7,Republican,Gino Bulso,0
+Davidson,17-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,17-3,U.S. House,7,Republican,Jody Barrett,0
+Davidson,17-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-3,U.S. House,7,Republican,Lee Reeves,0
+Davidson,17-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-3,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,17-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,17-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-4,U.S. House,7,Democratic,Aftyn Behn,45
+Davidson,17-4,U.S. House,7,Democratic,Bo Mitchell,16
+Davidson,17-4,U.S. House,7,Democratic,Darden Hunter Copeland,15
+Davidson,17-4,U.S. House,7,Democratic,Vincent Dixie,18
+Davidson,17-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-4,U.S. House,7,Republican,Gino Bulso,1
+Davidson,17-4,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-4,U.S. House,7,Republican,Jody Barrett,0
+Davidson,17-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-4,U.S. House,7,Republican,Lee Reeves,2
+Davidson,17-4,U.S. House,7,Republican,Mason Foley,2
+Davidson,17-4,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,17-4,U.S. House,7,Republican,Stewart Parks,1
+Davidson,17-4,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,17-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-5,U.S. House,7,Democratic,Aftyn Behn,7
+Davidson,17-5,U.S. House,7,Democratic,Bo Mitchell,8
+Davidson,17-5,U.S. House,7,Democratic,Darden Hunter Copeland,20
+Davidson,17-5,U.S. House,7,Democratic,Vincent Dixie,13
+Davidson,17-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-5,U.S. House,7,Republican,Gino Bulso,2
+Davidson,17-5,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-5,U.S. House,7,Republican,Jody Barrett,6
+Davidson,17-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-5,U.S. House,7,Republican,Lee Reeves,1
+Davidson,17-5,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-5,U.S. House,7,Republican,Matt Van Epps,17
+Davidson,17-5,U.S. House,7,Republican,Stewart Parks,2
+Davidson,17-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-6,U.S. House,7,Democratic,Aftyn Behn,10
+Davidson,17-6,U.S. House,7,Democratic,Bo Mitchell,6
+Davidson,17-6,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Davidson,17-6,U.S. House,7,Democratic,Vincent Dixie,20
+Davidson,17-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-6,U.S. House,7,Republican,Gino Bulso,1
+Davidson,17-6,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,17-6,U.S. House,7,Republican,Jody Barrett,1
+Davidson,17-6,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-6,U.S. House,7,Republican,Lee Reeves,0
+Davidson,17-6,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-6,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,17-6,U.S. House,7,Republican,Stewart Parks,1
+Davidson,17-6,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-6,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-7,U.S. House,7,Democratic,Aftyn Behn,213
+Davidson,17-7,U.S. House,7,Democratic,Bo Mitchell,78
+Davidson,17-7,U.S. House,7,Democratic,Darden Hunter Copeland,150
+Davidson,17-7,U.S. House,7,Democratic,Vincent Dixie,68
+Davidson,17-7,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,17-7,U.S. House,7,Republican,Gino Bulso,5
+Davidson,17-7,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-7,U.S. House,7,Republican,Jody Barrett,15
+Davidson,17-7,U.S. House,7,Republican,Joe Leurs,0
+Davidson,17-7,U.S. House,7,Republican,Lee Reeves,0
+Davidson,17-7,U.S. House,7,Republican,Mason Foley,4
+Davidson,17-7,U.S. House,7,Republican,Matt Van Epps,43
+Davidson,17-7,U.S. House,7,Republican,Stewart Parks,0
+Davidson,17-7,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-7,U.S. House,7,Republican,Tres Wittum,0
+Davidson,17-8,U.S. House,7,Democratic,Aftyn Behn,109
+Davidson,17-8,U.S. House,7,Democratic,Bo Mitchell,31
+Davidson,17-8,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Davidson,17-8,U.S. House,7,Democratic,Vincent Dixie,31
+Davidson,17-8,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,17-8,U.S. House,7,Republican,Gino Bulso,2
+Davidson,17-8,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,17-8,U.S. House,7,Republican,Jody Barrett,1
+Davidson,17-8,U.S. House,7,Republican,Joe Leurs,1
+Davidson,17-8,U.S. House,7,Republican,Lee Reeves,2
+Davidson,17-8,U.S. House,7,Republican,Mason Foley,0
+Davidson,17-8,U.S. House,7,Republican,Matt Van Epps,12
+Davidson,17-8,U.S. House,7,Republican,Stewart Parks,4
+Davidson,17-8,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,17-8,U.S. House,7,Republican,Tres Wittum,1
+Davidson,18-1,U.S. House,7,Democratic,Aftyn Behn,109
+Davidson,18-1,U.S. House,7,Democratic,Bo Mitchell,88
+Davidson,18-1,U.S. House,7,Democratic,Darden Hunter Copeland,49
+Davidson,18-1,U.S. House,7,Democratic,Vincent Dixie,29
+Davidson,18-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,18-1,U.S. House,7,Republican,Gino Bulso,3
+Davidson,18-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,18-1,U.S. House,7,Republican,Jody Barrett,8
+Davidson,18-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,18-1,U.S. House,7,Republican,Lee Reeves,3
+Davidson,18-1,U.S. House,7,Republican,Mason Foley,2
+Davidson,18-1,U.S. House,7,Republican,Matt Van Epps,16
+Davidson,18-1,U.S. House,7,Republican,Stewart Parks,3
+Davidson,18-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,18-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,18-2,U.S. House,7,Democratic,Aftyn Behn,117
+Davidson,18-2,U.S. House,7,Democratic,Bo Mitchell,70
+Davidson,18-2,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Davidson,18-2,U.S. House,7,Democratic,Vincent Dixie,32
+Davidson,18-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,18-2,U.S. House,7,Republican,Gino Bulso,2
+Davidson,18-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,18-2,U.S. House,7,Republican,Jody Barrett,7
+Davidson,18-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,18-2,U.S. House,7,Republican,Lee Reeves,2
+Davidson,18-2,U.S. House,7,Republican,Mason Foley,2
+Davidson,18-2,U.S. House,7,Republican,Matt Van Epps,19
+Davidson,18-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,18-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,18-2,U.S. House,7,Republican,Tres Wittum,2
+Davidson,18-3,U.S. House,7,Democratic,Aftyn Behn,334
+Davidson,18-3,U.S. House,7,Democratic,Bo Mitchell,334
+Davidson,18-3,U.S. House,7,Democratic,Darden Hunter Copeland,185
+Davidson,18-3,U.S. House,7,Democratic,Vincent Dixie,41
+Davidson,18-3,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Davidson,18-3,U.S. House,7,Republican,Gino Bulso,9
+Davidson,18-3,U.S. House,7,Republican,Jason D. Knight,7
+Davidson,18-3,U.S. House,7,Republican,Jody Barrett,25
+Davidson,18-3,U.S. House,7,Republican,Joe Leurs,2
+Davidson,18-3,U.S. House,7,Republican,Lee Reeves,7
+Davidson,18-3,U.S. House,7,Republican,Mason Foley,12
+Davidson,18-3,U.S. House,7,Republican,Matt Van Epps,50
+Davidson,18-3,U.S. House,7,Republican,Stewart Parks,3
+Davidson,18-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,18-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,19-1,U.S. House,7,Democratic,Aftyn Behn,15
+Davidson,19-1,U.S. House,7,Democratic,Bo Mitchell,1
+Davidson,19-1,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Davidson,19-1,U.S. House,7,Democratic,Vincent Dixie,2
+Davidson,19-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,19-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,19-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,19-1,U.S. House,7,Republican,Jody Barrett,1
+Davidson,19-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,19-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,19-1,U.S. House,7,Republican,Mason Foley,1
+Davidson,19-1,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,19-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,19-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,19-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,19-2,U.S. House,7,Democratic,Aftyn Behn,234
+Davidson,19-2,U.S. House,7,Democratic,Bo Mitchell,54
+Davidson,19-2,U.S. House,7,Democratic,Darden Hunter Copeland,49
+Davidson,19-2,U.S. House,7,Democratic,Vincent Dixie,40
+Davidson,19-2,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Davidson,19-2,U.S. House,7,Republican,Gino Bulso,3
+Davidson,19-2,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,19-2,U.S. House,7,Republican,Jody Barrett,10
+Davidson,19-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,19-2,U.S. House,7,Republican,Lee Reeves,4
+Davidson,19-2,U.S. House,7,Republican,Mason Foley,10
+Davidson,19-2,U.S. House,7,Republican,Matt Van Epps,38
+Davidson,19-2,U.S. House,7,Republican,Stewart Parks,2
+Davidson,19-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,19-2,U.S. House,7,Republican,Tres Wittum,0
+Davidson,19-3,U.S. House,7,Democratic,Aftyn Behn,86
+Davidson,19-3,U.S. House,7,Democratic,Bo Mitchell,41
+Davidson,19-3,U.S. House,7,Democratic,Darden Hunter Copeland,33
+Davidson,19-3,U.S. House,7,Democratic,Vincent Dixie,92
+Davidson,19-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,19-3,U.S. House,7,Republican,Gino Bulso,2
+Davidson,19-3,U.S. House,7,Republican,Jason D. Knight,3
+Davidson,19-3,U.S. House,7,Republican,Jody Barrett,9
+Davidson,19-3,U.S. House,7,Republican,Joe Leurs,2
+Davidson,19-3,U.S. House,7,Republican,Lee Reeves,3
+Davidson,19-3,U.S. House,7,Republican,Mason Foley,3
+Davidson,19-3,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,19-3,U.S. House,7,Republican,Stewart Parks,1
+Davidson,19-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,19-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,19-4,U.S. House,7,Democratic,Aftyn Behn,90
+Davidson,19-4,U.S. House,7,Democratic,Bo Mitchell,24
+Davidson,19-4,U.S. House,7,Democratic,Darden Hunter Copeland,32
+Davidson,19-4,U.S. House,7,Democratic,Vincent Dixie,16
+Davidson,19-4,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,19-4,U.S. House,7,Republican,Gino Bulso,1
+Davidson,19-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,19-4,U.S. House,7,Republican,Jody Barrett,13
+Davidson,19-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,19-4,U.S. House,7,Republican,Lee Reeves,4
+Davidson,19-4,U.S. House,7,Republican,Mason Foley,2
+Davidson,19-4,U.S. House,7,Republican,Matt Van Epps,33
+Davidson,19-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,19-4,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,19-4,U.S. House,7,Republican,Tres Wittum,5
+Davidson,19-5,U.S. House,7,Democratic,Aftyn Behn,120
+Davidson,19-5,U.S. House,7,Democratic,Bo Mitchell,41
+Davidson,19-5,U.S. House,7,Democratic,Darden Hunter Copeland,34
+Davidson,19-5,U.S. House,7,Democratic,Vincent Dixie,21
+Davidson,19-5,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,19-5,U.S. House,7,Republican,Gino Bulso,5
+Davidson,19-5,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,19-5,U.S. House,7,Republican,Jody Barrett,20
+Davidson,19-5,U.S. House,7,Republican,Joe Leurs,1
+Davidson,19-5,U.S. House,7,Republican,Lee Reeves,9
+Davidson,19-5,U.S. House,7,Republican,Mason Foley,4
+Davidson,19-5,U.S. House,7,Republican,Matt Van Epps,41
+Davidson,19-5,U.S. House,7,Republican,Stewart Parks,1
+Davidson,19-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,19-5,U.S. House,7,Republican,Tres Wittum,2
+Davidson,20-1,U.S. House,7,Democratic,Aftyn Behn,26
+Davidson,20-1,U.S. House,7,Democratic,Bo Mitchell,9
+Davidson,20-1,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Davidson,20-1,U.S. House,7,Democratic,Vincent Dixie,6
+Davidson,20-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,20-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,20-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,20-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,20-1,U.S. House,7,Republican,Lee Reeves,2
+Davidson,20-1,U.S. House,7,Republican,Mason Foley,1
+Davidson,20-1,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,20-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,20-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,20-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,20-2,U.S. House,7,Democratic,Aftyn Behn,153
+Davidson,20-2,U.S. House,7,Democratic,Bo Mitchell,86
+Davidson,20-2,U.S. House,7,Democratic,Darden Hunter Copeland,56
+Davidson,20-2,U.S. House,7,Democratic,Vincent Dixie,30
+Davidson,20-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-2,U.S. House,7,Republican,Gino Bulso,4
+Davidson,20-2,U.S. House,7,Republican,Jason D. Knight,2
+Davidson,20-2,U.S. House,7,Republican,Jody Barrett,17
+Davidson,20-2,U.S. House,7,Republican,Joe Leurs,1
+Davidson,20-2,U.S. House,7,Republican,Lee Reeves,1
+Davidson,20-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,20-2,U.S. House,7,Republican,Matt Van Epps,24
+Davidson,20-2,U.S. House,7,Republican,Stewart Parks,0
+Davidson,20-2,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,20-2,U.S. House,7,Republican,Tres Wittum,1
+Davidson,20-3,U.S. House,7,Democratic,Aftyn Behn,251
+Davidson,20-3,U.S. House,7,Democratic,Bo Mitchell,148
+Davidson,20-3,U.S. House,7,Democratic,Darden Hunter Copeland,77
+Davidson,20-3,U.S. House,7,Democratic,Vincent Dixie,48
+Davidson,20-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-3,U.S. House,7,Republican,Gino Bulso,10
+Davidson,20-3,U.S. House,7,Republican,Jason D. Knight,2
+Davidson,20-3,U.S. House,7,Republican,Jody Barrett,29
+Davidson,20-3,U.S. House,7,Republican,Joe Leurs,1
+Davidson,20-3,U.S. House,7,Republican,Lee Reeves,14
+Davidson,20-3,U.S. House,7,Republican,Mason Foley,8
+Davidson,20-3,U.S. House,7,Republican,Matt Van Epps,113
+Davidson,20-3,U.S. House,7,Republican,Stewart Parks,6
+Davidson,20-3,U.S. House,7,Republican,Stuart Cooper,3
+Davidson,20-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,20-5,U.S. House,7,Democratic,Aftyn Behn,68
+Davidson,20-5,U.S. House,7,Democratic,Bo Mitchell,32
+Davidson,20-5,U.S. House,7,Democratic,Darden Hunter Copeland,25
+Davidson,20-5,U.S. House,7,Democratic,Vincent Dixie,17
+Davidson,20-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,20-5,U.S. House,7,Republican,Gino Bulso,2
+Davidson,20-5,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,20-5,U.S. House,7,Republican,Jody Barrett,3
+Davidson,20-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,20-5,U.S. House,7,Republican,Lee Reeves,4
+Davidson,20-5,U.S. House,7,Republican,Mason Foley,4
+Davidson,20-5,U.S. House,7,Republican,Matt Van Epps,23
+Davidson,20-5,U.S. House,7,Republican,Stewart Parks,0
+Davidson,20-5,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,20-5,U.S. House,7,Republican,Tres Wittum,1
+Davidson,21-1,U.S. House,7,Democratic,Aftyn Behn,80
+Davidson,21-1,U.S. House,7,Democratic,Bo Mitchell,53
+Davidson,21-1,U.S. House,7,Democratic,Darden Hunter Copeland,27
+Davidson,21-1,U.S. House,7,Democratic,Vincent Dixie,23
+Davidson,21-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,21-1,U.S. House,7,Republican,Gino Bulso,6
+Davidson,21-1,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,21-1,U.S. House,7,Republican,Jody Barrett,8
+Davidson,21-1,U.S. House,7,Republican,Joe Leurs,1
+Davidson,21-1,U.S. House,7,Republican,Lee Reeves,2
+Davidson,21-1,U.S. House,7,Republican,Mason Foley,3
+Davidson,21-1,U.S. House,7,Republican,Matt Van Epps,20
+Davidson,21-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,21-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,21-2,U.S. House,7,Democratic,Aftyn Behn,55
+Davidson,21-2,U.S. House,7,Democratic,Bo Mitchell,41
+Davidson,21-2,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Davidson,21-2,U.S. House,7,Democratic,Vincent Dixie,128
+Davidson,21-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,21-2,U.S. House,7,Republican,Gino Bulso,2
+Davidson,21-2,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,21-2,U.S. House,7,Republican,Jody Barrett,2
+Davidson,21-2,U.S. House,7,Republican,Joe Leurs,0
+Davidson,21-2,U.S. House,7,Republican,Lee Reeves,3
+Davidson,21-2,U.S. House,7,Republican,Mason Foley,1
+Davidson,21-2,U.S. House,7,Republican,Matt Van Epps,7
+Davidson,21-2,U.S. House,7,Republican,Stewart Parks,1
+Davidson,21-2,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-2,U.S. House,7,Republican,Tres Wittum,1
+Davidson,21-3,U.S. House,7,Democratic,Aftyn Behn,105
+Davidson,21-3,U.S. House,7,Democratic,Bo Mitchell,60
+Davidson,21-3,U.S. House,7,Democratic,Darden Hunter Copeland,72
+Davidson,21-3,U.S. House,7,Democratic,Vincent Dixie,242
+Davidson,21-3,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Davidson,21-3,U.S. House,7,Republican,Gino Bulso,4
+Davidson,21-3,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,21-3,U.S. House,7,Republican,Jody Barrett,4
+Davidson,21-3,U.S. House,7,Republican,Joe Leurs,1
+Davidson,21-3,U.S. House,7,Republican,Lee Reeves,1
+Davidson,21-3,U.S. House,7,Republican,Mason Foley,0
+Davidson,21-3,U.S. House,7,Republican,Matt Van Epps,12
+Davidson,21-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,21-3,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-3,U.S. House,7,Republican,Tres Wittum,1
+Davidson,21-4,U.S. House,7,Democratic,Aftyn Behn,40
+Davidson,21-4,U.S. House,7,Democratic,Bo Mitchell,40
+Davidson,21-4,U.S. House,7,Democratic,Darden Hunter Copeland,25
+Davidson,21-4,U.S. House,7,Democratic,Vincent Dixie,137
+Davidson,21-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,21-4,U.S. House,7,Republican,Gino Bulso,2
+Davidson,21-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,21-4,U.S. House,7,Republican,Jody Barrett,4
+Davidson,21-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,21-4,U.S. House,7,Republican,Lee Reeves,1
+Davidson,21-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,21-4,U.S. House,7,Republican,Matt Van Epps,1
+Davidson,21-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,21-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,21-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-1,U.S. House,7,Democratic,Aftyn Behn,5
+Davidson,24-1,U.S. House,7,Democratic,Bo Mitchell,4
+Davidson,24-1,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,24-1,U.S. House,7,Democratic,Vincent Dixie,9
+Davidson,24-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,24-1,U.S. House,7,Republican,Gino Bulso,0
+Davidson,24-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,24-1,U.S. House,7,Republican,Jody Barrett,0
+Davidson,24-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-1,U.S. House,7,Republican,Lee Reeves,0
+Davidson,24-1,U.S. House,7,Republican,Mason Foley,0
+Davidson,24-1,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,24-1,U.S. House,7,Republican,Stewart Parks,0
+Davidson,24-1,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,24-1,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-3,U.S. House,7,Democratic,Aftyn Behn,96
+Davidson,24-3,U.S. House,7,Democratic,Bo Mitchell,58
+Davidson,24-3,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Davidson,24-3,U.S. House,7,Democratic,Vincent Dixie,20
+Davidson,24-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,24-3,U.S. House,7,Republican,Gino Bulso,1
+Davidson,24-3,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,24-3,U.S. House,7,Republican,Jody Barrett,5
+Davidson,24-3,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-3,U.S. House,7,Republican,Lee Reeves,1
+Davidson,24-3,U.S. House,7,Republican,Mason Foley,2
+Davidson,24-3,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,24-3,U.S. House,7,Republican,Stewart Parks,0
+Davidson,24-3,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,24-3,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-4,U.S. House,7,Democratic,Aftyn Behn,27
+Davidson,24-4,U.S. House,7,Democratic,Bo Mitchell,13
+Davidson,24-4,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Davidson,24-4,U.S. House,7,Democratic,Vincent Dixie,8
+Davidson,24-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,24-4,U.S. House,7,Republican,Gino Bulso,3
+Davidson,24-4,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,24-4,U.S. House,7,Republican,Jody Barrett,0
+Davidson,24-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-4,U.S. House,7,Republican,Lee Reeves,2
+Davidson,24-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,24-4,U.S. House,7,Republican,Matt Van Epps,3
+Davidson,24-4,U.S. House,7,Republican,Stewart Parks,2
+Davidson,24-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,24-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,24-5,U.S. House,7,Democratic,Aftyn Behn,307
+Davidson,24-5,U.S. House,7,Democratic,Bo Mitchell,236
+Davidson,24-5,U.S. House,7,Democratic,Darden Hunter Copeland,122
+Davidson,24-5,U.S. House,7,Democratic,Vincent Dixie,34
+Davidson,24-5,U.S. House,7,Republican,Adolph Agbéko Dagan,4
+Davidson,24-5,U.S. House,7,Republican,Gino Bulso,14
+Davidson,24-5,U.S. House,7,Republican,Jason D. Knight,2
+Davidson,24-5,U.S. House,7,Republican,Jody Barrett,22
+Davidson,24-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,24-5,U.S. House,7,Republican,Lee Reeves,4
+Davidson,24-5,U.S. House,7,Republican,Mason Foley,6
+Davidson,24-5,U.S. House,7,Republican,Matt Van Epps,65
+Davidson,24-5,U.S. House,7,Republican,Stewart Parks,3
+Davidson,24-5,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,24-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,26-1,U.S. House,7,Democratic,Aftyn Behn,52
+Davidson,26-1,U.S. House,7,Democratic,Bo Mitchell,21
+Davidson,26-1,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Davidson,26-1,U.S. House,7,Democratic,Vincent Dixie,7
+Davidson,26-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,26-1,U.S. House,7,Republican,Gino Bulso,3
+Davidson,26-1,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,26-1,U.S. House,7,Republican,Jody Barrett,4
+Davidson,26-1,U.S. House,7,Republican,Joe Leurs,0
+Davidson,26-1,U.S. House,7,Republican,Lee Reeves,1
+Davidson,26-1,U.S. House,7,Republican,Mason Foley,1
+Davidson,26-1,U.S. House,7,Republican,Matt Van Epps,14
+Davidson,26-1,U.S. House,7,Republican,Stewart Parks,3
+Davidson,26-1,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,26-1,U.S. House,7,Republican,Tres Wittum,1
+Davidson,35-4,U.S. House,7,Democratic,Aftyn Behn,19
+Davidson,35-4,U.S. House,7,Democratic,Bo Mitchell,2
+Davidson,35-4,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Davidson,35-4,U.S. House,7,Democratic,Vincent Dixie,3
+Davidson,35-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,35-4,U.S. House,7,Republican,Gino Bulso,0
+Davidson,35-4,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,35-4,U.S. House,7,Republican,Jody Barrett,0
+Davidson,35-4,U.S. House,7,Republican,Joe Leurs,0
+Davidson,35-4,U.S. House,7,Republican,Lee Reeves,0
+Davidson,35-4,U.S. House,7,Republican,Mason Foley,0
+Davidson,35-4,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,35-4,U.S. House,7,Republican,Stewart Parks,0
+Davidson,35-4,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,35-4,U.S. House,7,Republican,Tres Wittum,0
+Davidson,35-5,U.S. House,7,Democratic,Aftyn Behn,74
+Davidson,35-5,U.S. House,7,Democratic,Bo Mitchell,435
+Davidson,35-5,U.S. House,7,Democratic,Darden Hunter Copeland,27
+Davidson,35-5,U.S. House,7,Democratic,Vincent Dixie,17
+Davidson,35-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,35-5,U.S. House,7,Republican,Gino Bulso,42
+Davidson,35-5,U.S. House,7,Republican,Jason D. Knight,1
+Davidson,35-5,U.S. House,7,Republican,Jody Barrett,59
+Davidson,35-5,U.S. House,7,Republican,Joe Leurs,0
+Davidson,35-5,U.S. House,7,Republican,Lee Reeves,19
+Davidson,35-5,U.S. House,7,Republican,Mason Foley,12
+Davidson,35-5,U.S. House,7,Republican,Matt Van Epps,144
+Davidson,35-5,U.S. House,7,Republican,Stewart Parks,3
+Davidson,35-5,U.S. House,7,Republican,Stuart Cooper,1
+Davidson,35-5,U.S. House,7,Republican,Tres Wittum,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Bo Mitchell,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Davidson,All County Precinct,U.S. House,7,Democratic,Vincent Dixie,0
+Davidson,All County Precinct,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Davidson,All County Precinct,U.S. House,7,Republican,Gino Bulso,0
+Davidson,All County Precinct,U.S. House,7,Republican,Jason D. Knight,0
+Davidson,All County Precinct,U.S. House,7,Republican,Jody Barrett,0
+Davidson,All County Precinct,U.S. House,7,Republican,Joe Leurs,0
+Davidson,All County Precinct,U.S. House,7,Republican,Lee Reeves,0
+Davidson,All County Precinct,U.S. House,7,Republican,Mason Foley,0
+Davidson,All County Precinct,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,All County Precinct,U.S. House,7,Republican,Stewart Parks,0
+Davidson,All County Precinct,U.S. House,7,Republican,Stuart Cooper,0
+Davidson,All County Precinct,U.S. House,7,Republican,Tres Wittum,0
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Aftyn Behn,5
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Bo Mitchell,18
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Gino Bulso,9
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Jody Barrett,23
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Joe Leurs,0
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Lee Reeves,3
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Mason Foley,1
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Matt Van Epps,65
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Stewart Parks,7
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Stuart Cooper,1
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Tres Wittum,2
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Aftyn Behn,1
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Bo Mitchell,9
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Gino Bulso,19
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Jody Barrett,12
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Joe Leurs,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Lee Reeves,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Mason Foley,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Matt Van Epps,36
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Stewart Parks,7
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Tres Wittum,1
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,0
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Bo Mitchell,19
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Gino Bulso,11
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Jason D. Knight,2
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Jody Barrett,13
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Joe Leurs,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Lee Reeves,2
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Mason Foley,0
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,41
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Stewart Parks,8
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Stuart Cooper,2
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Tres Wittum,0
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,2
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Bo Mitchell,32
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Vincent Dixie,2
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Gino Bulso,6
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Jason D. Knight,2
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Jody Barrett,10
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Joe Leurs,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Lee Reeves,3
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Mason Foley,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,39
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Stewart Parks,3
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Tres Wittum,0
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,1
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Bo Mitchell,12
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,5-1 Parsons,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,5-1 Parsons,U.S. House,7,Republican,Gino Bulso,10
+Decatur,5-1 Parsons,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,5-1 Parsons,U.S. House,7,Republican,Jody Barrett,15
+Decatur,5-1 Parsons,U.S. House,7,Republican,Joe Leurs,0
+Decatur,5-1 Parsons,U.S. House,7,Republican,Lee Reeves,3
+Decatur,5-1 Parsons,U.S. House,7,Republican,Mason Foley,2
+Decatur,5-1 Parsons,U.S. House,7,Republican,Matt Van Epps,50
+Decatur,5-1 Parsons,U.S. House,7,Republican,Stewart Parks,7
+Decatur,5-1 Parsons,U.S. House,7,Republican,Stuart Cooper,1
+Decatur,5-1 Parsons,U.S. House,7,Republican,Tres Wittum,0
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,2
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Bo Mitchell,8
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Vincent Dixie,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,6-1 Parsons,U.S. House,7,Republican,Gino Bulso,3
+Decatur,6-1 Parsons,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Jody Barrett,9
+Decatur,6-1 Parsons,U.S. House,7,Republican,Joe Leurs,0
+Decatur,6-1 Parsons,U.S. House,7,Republican,Lee Reeves,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Mason Foley,1
+Decatur,6-1 Parsons,U.S. House,7,Republican,Matt Van Epps,32
+Decatur,6-1 Parsons,U.S. House,7,Republican,Stewart Parks,2
+Decatur,6-1 Parsons,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,6-1 Parsons,U.S. House,7,Republican,Tres Wittum,0
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Aftyn Behn,2
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Bo Mitchell,8
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Gino Bulso,7
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Jody Barrett,10
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Joe Leurs,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Lee Reeves,4
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Mason Foley,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Matt Van Epps,57
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Stewart Parks,5
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Tres Wittum,0
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,1
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Bo Mitchell,9
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,8-1 Parsons,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Decatur,8-1 Parsons,U.S. House,7,Republican,Gino Bulso,4
+Decatur,8-1 Parsons,U.S. House,7,Republican,Jason D. Knight,1
+Decatur,8-1 Parsons,U.S. House,7,Republican,Jody Barrett,12
+Decatur,8-1 Parsons,U.S. House,7,Republican,Joe Leurs,1
+Decatur,8-1 Parsons,U.S. House,7,Republican,Lee Reeves,3
+Decatur,8-1 Parsons,U.S. House,7,Republican,Mason Foley,1
+Decatur,8-1 Parsons,U.S. House,7,Republican,Matt Van Epps,62
+Decatur,8-1 Parsons,U.S. House,7,Republican,Stewart Parks,5
+Decatur,8-1 Parsons,U.S. House,7,Republican,Stuart Cooper,3
+Decatur,8-1 Parsons,U.S. House,7,Republican,Tres Wittum,0
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Aftyn Behn,5
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Bo Mitchell,3
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Vincent Dixie,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Decatur,9-1 Beacon,U.S. House,7,Republican,Gino Bulso,3
+Decatur,9-1 Beacon,U.S. House,7,Republican,Jason D. Knight,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Jody Barrett,16
+Decatur,9-1 Beacon,U.S. House,7,Republican,Joe Leurs,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Lee Reeves,8
+Decatur,9-1 Beacon,U.S. House,7,Republican,Mason Foley,1
+Decatur,9-1 Beacon,U.S. House,7,Republican,Matt Van Epps,45
+Decatur,9-1 Beacon,U.S. House,7,Republican,Stewart Parks,14
+Decatur,9-1 Beacon,U.S. House,7,Republican,Stuart Cooper,0
+Decatur,9-1 Beacon,U.S. House,7,Republican,Tres Wittum,1
+Dickson,1-1,U.S. House,7,Democratic,Aftyn Behn,20
+Dickson,1-1,U.S. House,7,Democratic,Bo Mitchell,71
+Dickson,1-1,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Dickson,1-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,1-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,1-1,U.S. House,7,Republican,Gino Bulso,23
+Dickson,1-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,1-1,U.S. House,7,Republican,Jody Barrett,194
+Dickson,1-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,1-1,U.S. House,7,Republican,Lee Reeves,6
+Dickson,1-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,1-1,U.S. House,7,Republican,Matt Van Epps,151
+Dickson,1-1,U.S. House,7,Republican,Stewart Parks,5
+Dickson,1-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,1-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,10-1,U.S. House,7,Democratic,Aftyn Behn,50
+Dickson,10-1,U.S. House,7,Democratic,Bo Mitchell,67
+Dickson,10-1,U.S. House,7,Democratic,Darden Hunter Copeland,41
+Dickson,10-1,U.S. House,7,Democratic,Vincent Dixie,5
+Dickson,10-1,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Dickson,10-1,U.S. House,7,Republican,Gino Bulso,29
+Dickson,10-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,10-1,U.S. House,7,Republican,Jody Barrett,213
+Dickson,10-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,10-1,U.S. House,7,Republican,Lee Reeves,15
+Dickson,10-1,U.S. House,7,Republican,Mason Foley,3
+Dickson,10-1,U.S. House,7,Republican,Matt Van Epps,141
+Dickson,10-1,U.S. House,7,Republican,Stewart Parks,2
+Dickson,10-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,10-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,11-1,U.S. House,7,Democratic,Aftyn Behn,32
+Dickson,11-1,U.S. House,7,Democratic,Bo Mitchell,55
+Dickson,11-1,U.S. House,7,Democratic,Darden Hunter Copeland,43
+Dickson,11-1,U.S. House,7,Democratic,Vincent Dixie,6
+Dickson,11-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,11-1,U.S. House,7,Republican,Gino Bulso,17
+Dickson,11-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,11-1,U.S. House,7,Republican,Jody Barrett,163
+Dickson,11-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,11-1,U.S. House,7,Republican,Lee Reeves,15
+Dickson,11-1,U.S. House,7,Republican,Mason Foley,4
+Dickson,11-1,U.S. House,7,Republican,Matt Van Epps,92
+Dickson,11-1,U.S. House,7,Republican,Stewart Parks,2
+Dickson,11-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,11-1,U.S. House,7,Republican,Tres Wittum,1
+Dickson,12-1,U.S. House,7,Democratic,Aftyn Behn,38
+Dickson,12-1,U.S. House,7,Democratic,Bo Mitchell,75
+Dickson,12-1,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Dickson,12-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,12-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,12-1,U.S. House,7,Republican,Gino Bulso,30
+Dickson,12-1,U.S. House,7,Republican,Jason D. Knight,2
+Dickson,12-1,U.S. House,7,Republican,Jody Barrett,216
+Dickson,12-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,12-1,U.S. House,7,Republican,Lee Reeves,17
+Dickson,12-1,U.S. House,7,Republican,Mason Foley,3
+Dickson,12-1,U.S. House,7,Republican,Matt Van Epps,134
+Dickson,12-1,U.S. House,7,Republican,Stewart Parks,1
+Dickson,12-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,12-1,U.S. House,7,Republican,Tres Wittum,2
+Dickson,2-1,U.S. House,7,Democratic,Aftyn Behn,17
+Dickson,2-1,U.S. House,7,Democratic,Bo Mitchell,38
+Dickson,2-1,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Dickson,2-1,U.S. House,7,Democratic,Vincent Dixie,7
+Dickson,2-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,2-1,U.S. House,7,Republican,Gino Bulso,9
+Dickson,2-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,2-1,U.S. House,7,Republican,Jody Barrett,237
+Dickson,2-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,2-1,U.S. House,7,Republican,Lee Reeves,6
+Dickson,2-1,U.S. House,7,Republican,Mason Foley,6
+Dickson,2-1,U.S. House,7,Republican,Matt Van Epps,129
+Dickson,2-1,U.S. House,7,Republican,Stewart Parks,0
+Dickson,2-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,2-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,3-1,U.S. House,7,Democratic,Aftyn Behn,24
+Dickson,3-1,U.S. House,7,Democratic,Bo Mitchell,48
+Dickson,3-1,U.S. House,7,Democratic,Darden Hunter Copeland,28
+Dickson,3-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,3-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,3-1,U.S. House,7,Republican,Gino Bulso,24
+Dickson,3-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,3-1,U.S. House,7,Republican,Jody Barrett,164
+Dickson,3-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,3-1,U.S. House,7,Republican,Lee Reeves,13
+Dickson,3-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,3-1,U.S. House,7,Republican,Matt Van Epps,153
+Dickson,3-1,U.S. House,7,Republican,Stewart Parks,4
+Dickson,3-1,U.S. House,7,Republican,Stuart Cooper,2
+Dickson,3-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,4-1,U.S. House,7,Democratic,Aftyn Behn,26
+Dickson,4-1,U.S. House,7,Democratic,Bo Mitchell,57
+Dickson,4-1,U.S. House,7,Democratic,Darden Hunter Copeland,24
+Dickson,4-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,4-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,4-1,U.S. House,7,Republican,Gino Bulso,35
+Dickson,4-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,4-1,U.S. House,7,Republican,Jody Barrett,127
+Dickson,4-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,4-1,U.S. House,7,Republican,Lee Reeves,6
+Dickson,4-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,4-1,U.S. House,7,Republican,Matt Van Epps,138
+Dickson,4-1,U.S. House,7,Republican,Stewart Parks,3
+Dickson,4-1,U.S. House,7,Republican,Stuart Cooper,3
+Dickson,4-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,5-1,U.S. House,7,Democratic,Aftyn Behn,25
+Dickson,5-1,U.S. House,7,Democratic,Bo Mitchell,46
+Dickson,5-1,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Dickson,5-1,U.S. House,7,Democratic,Vincent Dixie,0
+Dickson,5-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Dickson,5-1,U.S. House,7,Republican,Gino Bulso,14
+Dickson,5-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,5-1,U.S. House,7,Republican,Jody Barrett,160
+Dickson,5-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,5-1,U.S. House,7,Republican,Lee Reeves,7
+Dickson,5-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,5-1,U.S. House,7,Republican,Matt Van Epps,115
+Dickson,5-1,U.S. House,7,Republican,Stewart Parks,3
+Dickson,5-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,5-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,6-1,U.S. House,7,Democratic,Aftyn Behn,10
+Dickson,6-1,U.S. House,7,Democratic,Bo Mitchell,27
+Dickson,6-1,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Dickson,6-1,U.S. House,7,Democratic,Vincent Dixie,3
+Dickson,6-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,6-1,U.S. House,7,Republican,Gino Bulso,15
+Dickson,6-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,6-1,U.S. House,7,Republican,Jody Barrett,81
+Dickson,6-1,U.S. House,7,Republican,Joe Leurs,1
+Dickson,6-1,U.S. House,7,Republican,Lee Reeves,4
+Dickson,6-1,U.S. House,7,Republican,Mason Foley,1
+Dickson,6-1,U.S. House,7,Republican,Matt Van Epps,49
+Dickson,6-1,U.S. House,7,Republican,Stewart Parks,0
+Dickson,6-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,6-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,6-2,U.S. House,7,Democratic,Aftyn Behn,15
+Dickson,6-2,U.S. House,7,Democratic,Bo Mitchell,43
+Dickson,6-2,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Dickson,6-2,U.S. House,7,Democratic,Vincent Dixie,1
+Dickson,6-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,6-2,U.S. House,7,Republican,Gino Bulso,17
+Dickson,6-2,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,6-2,U.S. House,7,Republican,Jody Barrett,176
+Dickson,6-2,U.S. House,7,Republican,Joe Leurs,0
+Dickson,6-2,U.S. House,7,Republican,Lee Reeves,6
+Dickson,6-2,U.S. House,7,Republican,Mason Foley,1
+Dickson,6-2,U.S. House,7,Republican,Matt Van Epps,113
+Dickson,6-2,U.S. House,7,Republican,Stewart Parks,0
+Dickson,6-2,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,6-2,U.S. House,7,Republican,Tres Wittum,1
+Dickson,7-1,U.S. House,7,Democratic,Aftyn Behn,51
+Dickson,7-1,U.S. House,7,Democratic,Bo Mitchell,40
+Dickson,7-1,U.S. House,7,Democratic,Darden Hunter Copeland,42
+Dickson,7-1,U.S. House,7,Democratic,Vincent Dixie,4
+Dickson,7-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,7-1,U.S. House,7,Republican,Gino Bulso,23
+Dickson,7-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,7-1,U.S. House,7,Republican,Jody Barrett,143
+Dickson,7-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,7-1,U.S. House,7,Republican,Lee Reeves,13
+Dickson,7-1,U.S. House,7,Republican,Mason Foley,3
+Dickson,7-1,U.S. House,7,Republican,Matt Van Epps,92
+Dickson,7-1,U.S. House,7,Republican,Stewart Parks,3
+Dickson,7-1,U.S. House,7,Republican,Stuart Cooper,1
+Dickson,7-1,U.S. House,7,Republican,Tres Wittum,0
+Dickson,8-1,U.S. House,7,Democratic,Aftyn Behn,37
+Dickson,8-1,U.S. House,7,Democratic,Bo Mitchell,50
+Dickson,8-1,U.S. House,7,Democratic,Darden Hunter Copeland,34
+Dickson,8-1,U.S. House,7,Democratic,Vincent Dixie,5
+Dickson,8-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,8-1,U.S. House,7,Republican,Gino Bulso,9
+Dickson,8-1,U.S. House,7,Republican,Jason D. Knight,0
+Dickson,8-1,U.S. House,7,Republican,Jody Barrett,100
+Dickson,8-1,U.S. House,7,Republican,Joe Leurs,0
+Dickson,8-1,U.S. House,7,Republican,Lee Reeves,5
+Dickson,8-1,U.S. House,7,Republican,Mason Foley,1
+Dickson,8-1,U.S. House,7,Republican,Matt Van Epps,49
+Dickson,8-1,U.S. House,7,Republican,Stewart Parks,4
+Dickson,8-1,U.S. House,7,Republican,Stuart Cooper,0
+Dickson,8-1,U.S. House,7,Republican,Tres Wittum,1
+Dickson,9-1,U.S. House,7,Democratic,Aftyn Behn,31
+Dickson,9-1,U.S. House,7,Democratic,Bo Mitchell,67
+Dickson,9-1,U.S. House,7,Democratic,Darden Hunter Copeland,48
+Dickson,9-1,U.S. House,7,Democratic,Vincent Dixie,10
+Dickson,9-1,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Dickson,9-1,U.S. House,7,Republican,Gino Bulso,11
+Dickson,9-1,U.S. House,7,Republican,Jason D. Knight,1
+Dickson,9-1,U.S. House,7,Republican,Jody Barrett,227
+Dickson,9-1,U.S. House,7,Republican,Joe Leurs,2
+Dickson,9-1,U.S. House,7,Republican,Lee Reeves,11
+Dickson,9-1,U.S. House,7,Republican,Mason Foley,2
+Dickson,9-1,U.S. House,7,Republican,Matt Van Epps,148
+Dickson,9-1,U.S. House,7,Republican,Stewart Parks,2
+Dickson,9-1,U.S. House,7,Republican,Stuart Cooper,2
+Dickson,9-1,U.S. House,7,Republican,Tres Wittum,0
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,2
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Bo Mitchell,6
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Darden Hunter Copeland,11
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Gino Bulso,5
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Jody Barrett,61
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Joe Leurs,0
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Lee Reeves,4
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Mason Foley,1
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,28
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Stewart Parks,3
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Tres Wittum,0
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Aftyn Behn,4
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Bo Mitchell,5
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Vincent Dixie,4
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Gino Bulso,9
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Jody Barrett,65
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Joe Leurs,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Lee Reeves,2
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Mason Foley,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Matt Van Epps,41
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Stewart Parks,2
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Tres Wittum,0
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Bo Mitchell,2
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Darden Hunter Copeland,10
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Gino Bulso,5
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Jody Barrett,17
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Joe Leurs,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Lee Reeves,1
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Mason Foley,1
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Matt Van Epps,20
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Stewart Parks,5
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Tres Wittum,0
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Aftyn Behn,5
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Bo Mitchell,14
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Vincent Dixie,2
+Hickman,2-3 East Bank,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,2-3 East Bank,U.S. House,7,Republican,Gino Bulso,29
+Hickman,2-3 East Bank,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,2-3 East Bank,U.S. House,7,Republican,Jody Barrett,71
+Hickman,2-3 East Bank,U.S. House,7,Republican,Joe Leurs,0
+Hickman,2-3 East Bank,U.S. House,7,Republican,Lee Reeves,5
+Hickman,2-3 East Bank,U.S. House,7,Republican,Mason Foley,3
+Hickman,2-3 East Bank,U.S. House,7,Republican,Matt Van Epps,48
+Hickman,2-3 East Bank,U.S. House,7,Republican,Stewart Parks,7
+Hickman,2-3 East Bank,U.S. House,7,Republican,Stuart Cooper,1
+Hickman,2-3 East Bank,U.S. House,7,Republican,Tres Wittum,0
+Hickman,3-1 East CC,U.S. House,7,Democratic,Aftyn Behn,6
+Hickman,3-1 East CC,U.S. House,7,Democratic,Bo Mitchell,23
+Hickman,3-1 East CC,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Hickman,3-1 East CC,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Gino Bulso,18
+Hickman,3-1 East CC,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Jody Barrett,82
+Hickman,3-1 East CC,U.S. House,7,Republican,Joe Leurs,2
+Hickman,3-1 East CC,U.S. House,7,Republican,Lee Reeves,4
+Hickman,3-1 East CC,U.S. House,7,Republican,Mason Foley,4
+Hickman,3-1 East CC,U.S. House,7,Republican,Matt Van Epps,74
+Hickman,3-1 East CC,U.S. House,7,Republican,Stewart Parks,9
+Hickman,3-1 East CC,U.S. House,7,Republican,Stuart Cooper,1
+Hickman,3-1 East CC,U.S. House,7,Republican,Tres Wittum,0
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Aftyn Behn,10
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Bo Mitchell,27
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Gino Bulso,18
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Jason D. Knight,2
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Jody Barrett,161
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Joe Leurs,0
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Lee Reeves,15
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Mason Foley,3
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Matt Van Epps,95
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Stewart Parks,8
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Stuart Cooper,2
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Tres Wittum,2
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Aftyn Behn,4
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Bo Mitchell,10
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Vincent Dixie,2
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Gino Bulso,12
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Jody Barrett,60
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Joe Leurs,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Lee Reeves,4
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Mason Foley,2
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Matt Van Epps,34
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Stewart Parks,3
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Tres Wittum,2
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Bo Mitchell,8
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Gino Bulso,11
+Hickman,5-2 Middle School,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Jody Barrett,40
+Hickman,5-2 Middle School,U.S. House,7,Republican,Joe Leurs,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Lee Reeves,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Mason Foley,1
+Hickman,5-2 Middle School,U.S. House,7,Republican,Matt Van Epps,18
+Hickman,5-2 Middle School,U.S. House,7,Republican,Stewart Parks,3
+Hickman,5-2 Middle School,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,5-2 Middle School,U.S. House,7,Republican,Tres Wittum,0
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Aftyn Behn,2
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Bo Mitchell,8
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Gino Bulso,7
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Jody Barrett,32
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Joe Leurs,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Lee Reeves,0
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Mason Foley,0
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Matt Van Epps,19
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Stewart Parks,2
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Stuart Cooper,1
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Tres Wittum,0
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Aftyn Behn,13
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Bo Mitchell,72
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Vincent Dixie,3
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Gino Bulso,67
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Jason D. Knight,2
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Jody Barrett,269
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Joe Leurs,1
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Lee Reeves,14
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Mason Foley,11
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Matt Van Epps,99
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Stewart Parks,6
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Stuart Cooper,5
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Bo Mitchell,0
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Gino Bulso,3
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Jody Barrett,24
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Lee Reeves,2
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,18
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Stewart Parks,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Bo Mitchell,0
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Gino Bulso,3
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Jody Barrett,30
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Lee Reeves,3
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Matt Van Epps,8
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Stewart Parks,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Aftyn Behn,6
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Bo Mitchell,9
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Darden Hunter Copeland,12
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Vincent Dixie,1
+Hickman,7-3 Brushy,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Gino Bulso,9
+Hickman,7-3 Brushy,U.S. House,7,Republican,Jason D. Knight,1
+Hickman,7-3 Brushy,U.S. House,7,Republican,Jody Barrett,65
+Hickman,7-3 Brushy,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Lee Reeves,3
+Hickman,7-3 Brushy,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Matt Van Epps,50
+Hickman,7-3 Brushy,U.S. House,7,Republican,Stewart Parks,3
+Hickman,7-3 Brushy,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-3 Brushy,U.S. House,7,Republican,Tres Wittum,0
+Hickman,7-4 Coble,U.S. House,7,Democratic,Aftyn Behn,1
+Hickman,7-4 Coble,U.S. House,7,Democratic,Bo Mitchell,6
+Hickman,7-4 Coble,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Hickman,7-4 Coble,U.S. House,7,Democratic,Vincent Dixie,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Gino Bulso,3
+Hickman,7-4 Coble,U.S. House,7,Republican,Jason D. Knight,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Jody Barrett,64
+Hickman,7-4 Coble,U.S. House,7,Republican,Joe Leurs,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Lee Reeves,2
+Hickman,7-4 Coble,U.S. House,7,Republican,Mason Foley,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Matt Van Epps,15
+Hickman,7-4 Coble,U.S. House,7,Republican,Stewart Parks,3
+Hickman,7-4 Coble,U.S. House,7,Republican,Stuart Cooper,0
+Hickman,7-4 Coble,U.S. House,7,Republican,Tres Wittum,0
+Houston,Arlington,U.S. House,7,Democratic,Aftyn Behn,9
+Houston,Arlington,U.S. House,7,Democratic,Bo Mitchell,7
+Houston,Arlington,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Houston,Arlington,U.S. House,7,Democratic,Vincent Dixie,0
+Houston,Arlington,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Arlington,U.S. House,7,Republican,Gino Bulso,26
+Houston,Arlington,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Arlington,U.S. House,7,Republican,Jody Barrett,20
+Houston,Arlington,U.S. House,7,Republican,Joe Leurs,0
+Houston,Arlington,U.S. House,7,Republican,Lee Reeves,5
+Houston,Arlington,U.S. House,7,Republican,Mason Foley,1
+Houston,Arlington,U.S. House,7,Republican,Matt Van Epps,43
+Houston,Arlington,U.S. House,7,Republican,Stewart Parks,4
+Houston,Arlington,U.S. House,7,Republican,Stuart Cooper,0
+Houston,Arlington,U.S. House,7,Republican,Tres Wittum,0
+Houston,Erin,U.S. House,7,Democratic,Aftyn Behn,9
+Houston,Erin,U.S. House,7,Democratic,Bo Mitchell,8
+Houston,Erin,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Houston,Erin,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Erin,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Erin,U.S. House,7,Republican,Gino Bulso,15
+Houston,Erin,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Erin,U.S. House,7,Republican,Jody Barrett,18
+Houston,Erin,U.S. House,7,Republican,Joe Leurs,2
+Houston,Erin,U.S. House,7,Republican,Lee Reeves,1
+Houston,Erin,U.S. House,7,Republican,Mason Foley,0
+Houston,Erin,U.S. House,7,Republican,Matt Van Epps,19
+Houston,Erin,U.S. House,7,Republican,Stewart Parks,5
+Houston,Erin,U.S. House,7,Republican,Stuart Cooper,3
+Houston,Erin,U.S. House,7,Republican,Tres Wittum,0
+Houston,Erin Elementary,U.S. House,7,Democratic,Aftyn Behn,11
+Houston,Erin Elementary,U.S. House,7,Democratic,Bo Mitchell,6
+Houston,Erin Elementary,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Houston,Erin Elementary,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Erin Elementary,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Erin Elementary,U.S. House,7,Republican,Gino Bulso,40
+Houston,Erin Elementary,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Erin Elementary,U.S. House,7,Republican,Jody Barrett,29
+Houston,Erin Elementary,U.S. House,7,Republican,Joe Leurs,0
+Houston,Erin Elementary,U.S. House,7,Republican,Lee Reeves,0
+Houston,Erin Elementary,U.S. House,7,Republican,Mason Foley,0
+Houston,Erin Elementary,U.S. House,7,Republican,Matt Van Epps,19
+Houston,Erin Elementary,U.S. House,7,Republican,Stewart Parks,1
+Houston,Erin Elementary,U.S. House,7,Republican,Stuart Cooper,3
+Houston,Erin Elementary,U.S. House,7,Republican,Tres Wittum,0
+Houston,Griffins Chapel,U.S. House,7,Democratic,Aftyn Behn,7
+Houston,Griffins Chapel,U.S. House,7,Democratic,Bo Mitchell,6
+Houston,Griffins Chapel,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Houston,Griffins Chapel,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Griffins Chapel,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Houston,Griffins Chapel,U.S. House,7,Republican,Gino Bulso,31
+Houston,Griffins Chapel,U.S. House,7,Republican,Jason D. Knight,0
+Houston,Griffins Chapel,U.S. House,7,Republican,Jody Barrett,25
+Houston,Griffins Chapel,U.S. House,7,Republican,Joe Leurs,0
+Houston,Griffins Chapel,U.S. House,7,Republican,Lee Reeves,3
+Houston,Griffins Chapel,U.S. House,7,Republican,Mason Foley,0
+Houston,Griffins Chapel,U.S. House,7,Republican,Matt Van Epps,42
+Houston,Griffins Chapel,U.S. House,7,Republican,Stewart Parks,4
+Houston,Griffins Chapel,U.S. House,7,Republican,Stuart Cooper,1
+Houston,Griffins Chapel,U.S. House,7,Republican,Tres Wittum,0
+Houston,Houston Co Middle,U.S. House,7,Democratic,Aftyn Behn,8
+Houston,Houston Co Middle,U.S. House,7,Democratic,Bo Mitchell,8
+Houston,Houston Co Middle,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Houston,Houston Co Middle,U.S. House,7,Democratic,Vincent Dixie,2
+Houston,Houston Co Middle,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Houston Co Middle,U.S. House,7,Republican,Gino Bulso,31
+Houston,Houston Co Middle,U.S. House,7,Republican,Jason D. Knight,1
+Houston,Houston Co Middle,U.S. House,7,Republican,Jody Barrett,18
+Houston,Houston Co Middle,U.S. House,7,Republican,Joe Leurs,0
+Houston,Houston Co Middle,U.S. House,7,Republican,Lee Reeves,1
+Houston,Houston Co Middle,U.S. House,7,Republican,Mason Foley,0
+Houston,Houston Co Middle,U.S. House,7,Republican,Matt Van Epps,30
+Houston,Houston Co Middle,U.S. House,7,Republican,Stewart Parks,2
+Houston,Houston Co Middle,U.S. House,7,Republican,Stuart Cooper,2
+Houston,Houston Co Middle,U.S. House,7,Republican,Tres Wittum,1
+Houston,Stewart,U.S. House,7,Democratic,Aftyn Behn,5
+Houston,Stewart,U.S. House,7,Democratic,Bo Mitchell,10
+Houston,Stewart,U.S. House,7,Democratic,Darden Hunter Copeland,9
+Houston,Stewart,U.S. House,7,Democratic,Vincent Dixie,0
+Houston,Stewart,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Stewart,U.S. House,7,Republican,Gino Bulso,34
+Houston,Stewart,U.S. House,7,Republican,Jason D. Knight,1
+Houston,Stewart,U.S. House,7,Republican,Jody Barrett,32
+Houston,Stewart,U.S. House,7,Republican,Joe Leurs,0
+Houston,Stewart,U.S. House,7,Republican,Lee Reeves,3
+Houston,Stewart,U.S. House,7,Republican,Mason Foley,1
+Houston,Stewart,U.S. House,7,Republican,Matt Van Epps,46
+Houston,Stewart,U.S. House,7,Republican,Stewart Parks,3
+Houston,Stewart,U.S. House,7,Republican,Stuart Cooper,0
+Houston,Stewart,U.S. House,7,Republican,Tres Wittum,0
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Aftyn Behn,7
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Bo Mitchell,14
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Vincent Dixie,1
+Houston,Tennessee Ridge,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Houston,Tennessee Ridge,U.S. House,7,Republican,Gino Bulso,37
+Houston,Tennessee Ridge,U.S. House,7,Republican,Jason D. Knight,1
+Houston,Tennessee Ridge,U.S. House,7,Republican,Jody Barrett,23
+Houston,Tennessee Ridge,U.S. House,7,Republican,Joe Leurs,0
+Houston,Tennessee Ridge,U.S. House,7,Republican,Lee Reeves,2
+Houston,Tennessee Ridge,U.S. House,7,Republican,Mason Foley,2
+Houston,Tennessee Ridge,U.S. House,7,Republican,Matt Van Epps,33
+Houston,Tennessee Ridge,U.S. House,7,Republican,Stewart Parks,4
+Houston,Tennessee Ridge,U.S. House,7,Republican,Stuart Cooper,0
+Houston,Tennessee Ridge,U.S. House,7,Republican,Tres Wittum,1
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Aftyn Behn,1
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Bo Mitchell,9
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Vincent Dixie,1
+Humphreys,1-1 Jera,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Humphreys,1-1 Jera,U.S. House,7,Republican,Gino Bulso,2
+Humphreys,1-1 Jera,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Jody Barrett,6
+Humphreys,1-1 Jera,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Lee Reeves,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Mason Foley,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Matt Van Epps,20
+Humphreys,1-1 Jera,U.S. House,7,Republican,Stewart Parks,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Stuart Cooper,0
+Humphreys,1-1 Jera,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Aftyn Behn,12
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Bo Mitchell,32
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Vincent Dixie,3
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Gino Bulso,25
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Jody Barrett,67
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Lee Reeves,8
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Mason Foley,6
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Matt Van Epps,74
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Stewart Parks,1
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Stuart Cooper,2
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Tres Wittum,1
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Aftyn Behn,11
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Bo Mitchell,50
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Humphreys,2-3 WFS,U.S. House,7,Democratic,Vincent Dixie,6
+Humphreys,2-3 WFS,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,2-3 WFS,U.S. House,7,Republican,Gino Bulso,17
+Humphreys,2-3 WFS,U.S. House,7,Republican,Jason D. Knight,2
+Humphreys,2-3 WFS,U.S. House,7,Republican,Jody Barrett,45
+Humphreys,2-3 WFS,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,2-3 WFS,U.S. House,7,Republican,Lee Reeves,5
+Humphreys,2-3 WFS,U.S. House,7,Republican,Mason Foley,5
+Humphreys,2-3 WFS,U.S. House,7,Republican,Matt Van Epps,80
+Humphreys,2-3 WFS,U.S. House,7,Republican,Stewart Parks,2
+Humphreys,2-3 WFS,U.S. House,7,Republican,Stuart Cooper,1
+Humphreys,2-3 WFS,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Aftyn Behn,19
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Bo Mitchell,32
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Darden Hunter Copeland,33
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Vincent Dixie,1
+Humphreys,3-4 Apex,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,3-4 Apex,U.S. House,7,Republican,Gino Bulso,27
+Humphreys,3-4 Apex,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,3-4 Apex,U.S. House,7,Republican,Jody Barrett,33
+Humphreys,3-4 Apex,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,3-4 Apex,U.S. House,7,Republican,Lee Reeves,5
+Humphreys,3-4 Apex,U.S. House,7,Republican,Mason Foley,1
+Humphreys,3-4 Apex,U.S. House,7,Republican,Matt Van Epps,47
+Humphreys,3-4 Apex,U.S. House,7,Republican,Stewart Parks,2
+Humphreys,3-4 Apex,U.S. House,7,Republican,Stuart Cooper,3
+Humphreys,3-4 Apex,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Aftyn Behn,12
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Bo Mitchell,26
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Darden Hunter Copeland,22
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Vincent Dixie,2
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Gino Bulso,20
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Jody Barrett,42
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Lee Reeves,2
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Mason Foley,3
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Matt Van Epps,82
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Stewart Parks,0
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Stuart Cooper,1
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Aftyn Behn,6
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Bo Mitchell,45
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Darden Hunter Copeland,40
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Vincent Dixie,3
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Gino Bulso,13
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Jason D. Knight,1
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Jody Barrett,45
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Lee Reeves,13
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Mason Foley,4
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Matt Van Epps,72
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Stewart Parks,3
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Stuart Cooper,2
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Tres Wittum,0
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Aftyn Behn,7
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Bo Mitchell,25
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Darden Hunter Copeland,17
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Vincent Dixie,2
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Gino Bulso,19
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Jason D. Knight,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Jody Barrett,54
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Lee Reeves,8
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Mason Foley,4
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Matt Van Epps,72
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Stewart Parks,0
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Stuart Cooper,2
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Tres Wittum,1
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Aftyn Behn,13
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Bo Mitchell,28
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Vincent Dixie,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Gino Bulso,23
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Jason D. Knight,3
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Jody Barrett,76
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Joe Leurs,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Lee Reeves,7
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Mason Foley,8
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Matt Van Epps,121
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Stewart Parks,4
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Stuart Cooper,0
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Aftyn Behn,44
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Bo Mitchell,23
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Darden Hunter Copeland,88
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Vincent Dixie,48
+Montgomery,10 Minglewood,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,10 Minglewood,U.S. House,7,Republican,Gino Bulso,22
+Montgomery,10 Minglewood,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,10 Minglewood,U.S. House,7,Republican,Jody Barrett,11
+Montgomery,10 Minglewood,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,10 Minglewood,U.S. House,7,Republican,Lee Reeves,10
+Montgomery,10 Minglewood,U.S. House,7,Republican,Mason Foley,1
+Montgomery,10 Minglewood,U.S. House,7,Republican,Matt Van Epps,81
+Montgomery,10 Minglewood,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,10 Minglewood,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,10 Minglewood,U.S. House,7,Republican,Tres Wittum,3
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Aftyn Behn,30
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Bo Mitchell,20
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Vincent Dixie,28
+Montgomery,11A Mosaic,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,11A Mosaic,U.S. House,7,Republican,Gino Bulso,15
+Montgomery,11A Mosaic,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,11A Mosaic,U.S. House,7,Republican,Jody Barrett,10
+Montgomery,11A Mosaic,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,11A Mosaic,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,11A Mosaic,U.S. House,7,Republican,Mason Foley,0
+Montgomery,11A Mosaic,U.S. House,7,Republican,Matt Van Epps,65
+Montgomery,11A Mosaic,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,11A Mosaic,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,11A Mosaic,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,11B Northwest,U.S. House,7,Democratic,Aftyn Behn,50
+Montgomery,11B Northwest,U.S. House,7,Democratic,Bo Mitchell,22
+Montgomery,11B Northwest,U.S. House,7,Democratic,Darden Hunter Copeland,27
+Montgomery,11B Northwest,U.S. House,7,Democratic,Vincent Dixie,28
+Montgomery,11B Northwest,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,11B Northwest,U.S. House,7,Republican,Gino Bulso,15
+Montgomery,11B Northwest,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,11B Northwest,U.S. House,7,Republican,Jody Barrett,11
+Montgomery,11B Northwest,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,11B Northwest,U.S. House,7,Republican,Lee Reeves,6
+Montgomery,11B Northwest,U.S. House,7,Republican,Mason Foley,0
+Montgomery,11B Northwest,U.S. House,7,Republican,Matt Van Epps,71
+Montgomery,11B Northwest,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,11B Northwest,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,11B Northwest,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,12 West Creek,U.S. House,7,Democratic,Aftyn Behn,63
+Montgomery,12 West Creek,U.S. House,7,Democratic,Bo Mitchell,34
+Montgomery,12 West Creek,U.S. House,7,Democratic,Darden Hunter Copeland,85
+Montgomery,12 West Creek,U.S. House,7,Democratic,Vincent Dixie,53
+Montgomery,12 West Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,12 West Creek,U.S. House,7,Republican,Gino Bulso,14
+Montgomery,12 West Creek,U.S. House,7,Republican,Jason D. Knight,3
+Montgomery,12 West Creek,U.S. House,7,Republican,Jody Barrett,13
+Montgomery,12 West Creek,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,12 West Creek,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,12 West Creek,U.S. House,7,Republican,Mason Foley,1
+Montgomery,12 West Creek,U.S. House,7,Republican,Matt Van Epps,76
+Montgomery,12 West Creek,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,12 West Creek,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,12 West Creek,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Aftyn Behn,42
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Bo Mitchell,17
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Darden Hunter Copeland,49
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Vincent Dixie,39
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Gino Bulso,18
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Jody Barrett,14
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Mason Foley,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Matt Van Epps,53
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Aftyn Behn,46
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Bo Mitchell,22
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Vincent Dixie,56
+Montgomery,13B Kenwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,13B Kenwood,U.S. House,7,Republican,Gino Bulso,17
+Montgomery,13B Kenwood,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,13B Kenwood,U.S. House,7,Republican,Jody Barrett,21
+Montgomery,13B Kenwood,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,13B Kenwood,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,13B Kenwood,U.S. House,7,Republican,Mason Foley,6
+Montgomery,13B Kenwood,U.S. House,7,Republican,Matt Van Epps,86
+Montgomery,13B Kenwood,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,13B Kenwood,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,13B Kenwood,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Aftyn Behn,28
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Bo Mitchell,15
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Darden Hunter Copeland,40
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Vincent Dixie,44
+Montgomery,14A St B ELC,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Gino Bulso,9
+Montgomery,14A St B ELC,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,14A St B ELC,U.S. House,7,Republican,Jody Barrett,7
+Montgomery,14A St B ELC,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,14A St B ELC,U.S. House,7,Republican,Mason Foley,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Matt Van Epps,48
+Montgomery,14A St B ELC,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,14A St B ELC,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,14A St B ELC,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,14B First MBC,U.S. House,7,Democratic,Aftyn Behn,64
+Montgomery,14B First MBC,U.S. House,7,Democratic,Bo Mitchell,28
+Montgomery,14B First MBC,U.S. House,7,Democratic,Darden Hunter Copeland,62
+Montgomery,14B First MBC,U.S. House,7,Democratic,Vincent Dixie,36
+Montgomery,14B First MBC,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Gino Bulso,31
+Montgomery,14B First MBC,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,14B First MBC,U.S. House,7,Republican,Jody Barrett,30
+Montgomery,14B First MBC,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Lee Reeves,11
+Montgomery,14B First MBC,U.S. House,7,Republican,Mason Foley,4
+Montgomery,14B First MBC,U.S. House,7,Republican,Matt Van Epps,99
+Montgomery,14B First MBC,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,14B First MBC,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,15A Excell,U.S. House,7,Democratic,Aftyn Behn,77
+Montgomery,15A Excell,U.S. House,7,Democratic,Bo Mitchell,51
+Montgomery,15A Excell,U.S. House,7,Democratic,Darden Hunter Copeland,68
+Montgomery,15A Excell,U.S. House,7,Democratic,Vincent Dixie,29
+Montgomery,15A Excell,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,15A Excell,U.S. House,7,Republican,Gino Bulso,42
+Montgomery,15A Excell,U.S. House,7,Republican,Jason D. Knight,15
+Montgomery,15A Excell,U.S. House,7,Republican,Jody Barrett,58
+Montgomery,15A Excell,U.S. House,7,Republican,Joe Leurs,7
+Montgomery,15A Excell,U.S. House,7,Republican,Lee Reeves,13
+Montgomery,15A Excell,U.S. House,7,Republican,Mason Foley,6
+Montgomery,15A Excell,U.S. House,7,Republican,Matt Van Epps,345
+Montgomery,15A Excell,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,15A Excell,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,15A Excell,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,15B Sango,U.S. House,7,Democratic,Aftyn Behn,55
+Montgomery,15B Sango,U.S. House,7,Democratic,Bo Mitchell,33
+Montgomery,15B Sango,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Montgomery,15B Sango,U.S. House,7,Democratic,Vincent Dixie,29
+Montgomery,15B Sango,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,15B Sango,U.S. House,7,Republican,Gino Bulso,36
+Montgomery,15B Sango,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,15B Sango,U.S. House,7,Republican,Jody Barrett,59
+Montgomery,15B Sango,U.S. House,7,Republican,Joe Leurs,3
+Montgomery,15B Sango,U.S. House,7,Republican,Lee Reeves,12
+Montgomery,15B Sango,U.S. House,7,Republican,Mason Foley,2
+Montgomery,15B Sango,U.S. House,7,Republican,Matt Van Epps,325
+Montgomery,15B Sango,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,15B Sango,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,15B Sango,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Aftyn Behn,41
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Bo Mitchell,27
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Darden Hunter Copeland,47
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Vincent Dixie,41
+Montgomery,16A Ringgold,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,16A Ringgold,U.S. House,7,Republican,Gino Bulso,15
+Montgomery,16A Ringgold,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,16A Ringgold,U.S. House,7,Republican,Jody Barrett,10
+Montgomery,16A Ringgold,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,16A Ringgold,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,16A Ringgold,U.S. House,7,Republican,Mason Foley,1
+Montgomery,16A Ringgold,U.S. House,7,Republican,Matt Van Epps,58
+Montgomery,16A Ringgold,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,16A Ringgold,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,16A Ringgold,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,16B New Providence,U.S. House,7,Democratic,Aftyn Behn,33
+Montgomery,16B New Providence,U.S. House,7,Democratic,Bo Mitchell,22
+Montgomery,16B New Providence,U.S. House,7,Democratic,Darden Hunter Copeland,51
+Montgomery,16B New Providence,U.S. House,7,Democratic,Vincent Dixie,37
+Montgomery,16B New Providence,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,16B New Providence,U.S. House,7,Republican,Gino Bulso,24
+Montgomery,16B New Providence,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,16B New Providence,U.S. House,7,Republican,Jody Barrett,13
+Montgomery,16B New Providence,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,16B New Providence,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,16B New Providence,U.S. House,7,Republican,Mason Foley,1
+Montgomery,16B New Providence,U.S. House,7,Republican,Matt Van Epps,77
+Montgomery,16B New Providence,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,16B New Providence,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,16B New Providence,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,17A Grace,U.S. House,7,Democratic,Aftyn Behn,44
+Montgomery,17A Grace,U.S. House,7,Democratic,Bo Mitchell,14
+Montgomery,17A Grace,U.S. House,7,Democratic,Darden Hunter Copeland,53
+Montgomery,17A Grace,U.S. House,7,Democratic,Vincent Dixie,43
+Montgomery,17A Grace,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,17A Grace,U.S. House,7,Republican,Gino Bulso,17
+Montgomery,17A Grace,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,17A Grace,U.S. House,7,Republican,Jody Barrett,15
+Montgomery,17A Grace,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,17A Grace,U.S. House,7,Republican,Lee Reeves,8
+Montgomery,17A Grace,U.S. House,7,Republican,Mason Foley,0
+Montgomery,17A Grace,U.S. House,7,Republican,Matt Van Epps,76
+Montgomery,17A Grace,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,17A Grace,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,17A Grace,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Aftyn Behn,40
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Bo Mitchell,20
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Darden Hunter Copeland,46
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Vincent Dixie,59
+Montgomery,17B Glenellen,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,17B Glenellen,U.S. House,7,Republican,Gino Bulso,12
+Montgomery,17B Glenellen,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,17B Glenellen,U.S. House,7,Republican,Jody Barrett,12
+Montgomery,17B Glenellen,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,17B Glenellen,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,17B Glenellen,U.S. House,7,Republican,Mason Foley,3
+Montgomery,17B Glenellen,U.S. House,7,Republican,Matt Van Epps,62
+Montgomery,17B Glenellen,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,17B Glenellen,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,17B Glenellen,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Aftyn Behn,39
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Bo Mitchell,27
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Darden Hunter Copeland,43
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Vincent Dixie,62
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Gino Bulso,9
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Jody Barrett,15
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Joe Leurs,4
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Mason Foley,1
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Matt Van Epps,56
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Aftyn Behn,38
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Bo Mitchell,26
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Vincent Dixie,45
+Montgomery,18B Pisgah,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,18B Pisgah,U.S. House,7,Republican,Gino Bulso,11
+Montgomery,18B Pisgah,U.S. House,7,Republican,Jason D. Knight,0
+Montgomery,18B Pisgah,U.S. House,7,Republican,Jody Barrett,10
+Montgomery,18B Pisgah,U.S. House,7,Republican,Joe Leurs,3
+Montgomery,18B Pisgah,U.S. House,7,Republican,Lee Reeves,19
+Montgomery,18B Pisgah,U.S. House,7,Republican,Mason Foley,2
+Montgomery,18B Pisgah,U.S. House,7,Republican,Matt Van Epps,70
+Montgomery,18B Pisgah,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,18B Pisgah,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,18B Pisgah,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,19A Rossview,U.S. House,7,Democratic,Aftyn Behn,64
+Montgomery,19A Rossview,U.S. House,7,Democratic,Bo Mitchell,45
+Montgomery,19A Rossview,U.S. House,7,Democratic,Darden Hunter Copeland,64
+Montgomery,19A Rossview,U.S. House,7,Democratic,Vincent Dixie,70
+Montgomery,19A Rossview,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,19A Rossview,U.S. House,7,Republican,Gino Bulso,32
+Montgomery,19A Rossview,U.S. House,7,Republican,Jason D. Knight,9
+Montgomery,19A Rossview,U.S. House,7,Republican,Jody Barrett,34
+Montgomery,19A Rossview,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,19A Rossview,U.S. House,7,Republican,Lee Reeves,13
+Montgomery,19A Rossview,U.S. House,7,Republican,Mason Foley,6
+Montgomery,19A Rossview,U.S. House,7,Republican,Matt Van Epps,243
+Montgomery,19A Rossview,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,19A Rossview,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,19A Rossview,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Aftyn Behn,38
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Bo Mitchell,17
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Darden Hunter Copeland,58
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Vincent Dixie,27
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Gino Bulso,12
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Jody Barrett,31
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Lee Reeves,7
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Mason Foley,2
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Matt Van Epps,122
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Tres Wittum,2
+Montgomery,1A St B CC,U.S. House,7,Democratic,Aftyn Behn,76
+Montgomery,1A St B CC,U.S. House,7,Democratic,Bo Mitchell,47
+Montgomery,1A St B CC,U.S. House,7,Democratic,Darden Hunter Copeland,86
+Montgomery,1A St B CC,U.S. House,7,Democratic,Vincent Dixie,44
+Montgomery,1A St B CC,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,1A St B CC,U.S. House,7,Republican,Gino Bulso,31
+Montgomery,1A St B CC,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,1A St B CC,U.S. House,7,Republican,Jody Barrett,39
+Montgomery,1A St B CC,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,1A St B CC,U.S. House,7,Republican,Lee Reeves,13
+Montgomery,1A St B CC,U.S. House,7,Republican,Mason Foley,3
+Montgomery,1A St B CC,U.S. House,7,Republican,Matt Van Epps,214
+Montgomery,1A St B CC,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,1A St B CC,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,1A St B CC,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Aftyn Behn,59
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Bo Mitchell,36
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Darden Hunter Copeland,46
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Vincent Dixie,42
+Montgomery,1B St B UMC,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,1B St B UMC,U.S. House,7,Republican,Gino Bulso,29
+Montgomery,1B St B UMC,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,1B St B UMC,U.S. House,7,Republican,Jody Barrett,19
+Montgomery,1B St B UMC,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,1B St B UMC,U.S. House,7,Republican,Lee Reeves,6
+Montgomery,1B St B UMC,U.S. House,7,Republican,Mason Foley,1
+Montgomery,1B St B UMC,U.S. House,7,Republican,Matt Van Epps,122
+Montgomery,1B St B UMC,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,1B St B UMC,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,1B St B UMC,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,20A Northeast,U.S. House,7,Democratic,Aftyn Behn,55
+Montgomery,20A Northeast,U.S. House,7,Democratic,Bo Mitchell,21
+Montgomery,20A Northeast,U.S. House,7,Democratic,Darden Hunter Copeland,76
+Montgomery,20A Northeast,U.S. House,7,Democratic,Vincent Dixie,55
+Montgomery,20A Northeast,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,20A Northeast,U.S. House,7,Republican,Gino Bulso,19
+Montgomery,20A Northeast,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,20A Northeast,U.S. House,7,Republican,Jody Barrett,18
+Montgomery,20A Northeast,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,20A Northeast,U.S. House,7,Republican,Lee Reeves,5
+Montgomery,20A Northeast,U.S. House,7,Republican,Mason Foley,2
+Montgomery,20A Northeast,U.S. House,7,Republican,Matt Van Epps,63
+Montgomery,20A Northeast,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,20A Northeast,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,20A Northeast,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,20B Oakland,U.S. House,7,Democratic,Aftyn Behn,44
+Montgomery,20B Oakland,U.S. House,7,Democratic,Bo Mitchell,18
+Montgomery,20B Oakland,U.S. House,7,Democratic,Darden Hunter Copeland,50
+Montgomery,20B Oakland,U.S. House,7,Democratic,Vincent Dixie,33
+Montgomery,20B Oakland,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Montgomery,20B Oakland,U.S. House,7,Republican,Gino Bulso,11
+Montgomery,20B Oakland,U.S. House,7,Republican,Jason D. Knight,4
+Montgomery,20B Oakland,U.S. House,7,Republican,Jody Barrett,20
+Montgomery,20B Oakland,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,20B Oakland,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,20B Oakland,U.S. House,7,Republican,Mason Foley,1
+Montgomery,20B Oakland,U.S. House,7,Republican,Matt Van Epps,117
+Montgomery,20B Oakland,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,20B Oakland,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,20B Oakland,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Aftyn Behn,88
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Bo Mitchell,58
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Vincent Dixie,24
+Montgomery,21A Hilldale,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,21A Hilldale,U.S. House,7,Republican,Gino Bulso,34
+Montgomery,21A Hilldale,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,21A Hilldale,U.S. House,7,Republican,Jody Barrett,48
+Montgomery,21A Hilldale,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,21A Hilldale,U.S. House,7,Republican,Lee Reeves,20
+Montgomery,21A Hilldale,U.S. House,7,Republican,Mason Foley,10
+Montgomery,21A Hilldale,U.S. House,7,Republican,Matt Van Epps,274
+Montgomery,21A Hilldale,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,21A Hilldale,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,21A Hilldale,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Aftyn Behn,71
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Bo Mitchell,42
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Darden Hunter Copeland,63
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Vincent Dixie,45
+Montgomery,21B Barksdale,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,21B Barksdale,U.S. House,7,Republican,Gino Bulso,12
+Montgomery,21B Barksdale,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,21B Barksdale,U.S. House,7,Republican,Jody Barrett,20
+Montgomery,21B Barksdale,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,21B Barksdale,U.S. House,7,Republican,Mason Foley,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Matt Van Epps,128
+Montgomery,21B Barksdale,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,21B Barksdale,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Aftyn Behn,78
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Bo Mitchell,62
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Darden Hunter Copeland,73
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Vincent Dixie,30
+Montgomery,2A Clarksville,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,2A Clarksville,U.S. House,7,Republican,Gino Bulso,58
+Montgomery,2A Clarksville,U.S. House,7,Republican,Jason D. Knight,10
+Montgomery,2A Clarksville,U.S. House,7,Republican,Jody Barrett,58
+Montgomery,2A Clarksville,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,2A Clarksville,U.S. House,7,Republican,Lee Reeves,10
+Montgomery,2A Clarksville,U.S. House,7,Republican,Mason Foley,17
+Montgomery,2A Clarksville,U.S. House,7,Republican,Matt Van Epps,311
+Montgomery,2A Clarksville,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,2A Clarksville,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,2A Clarksville,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,2B Bible,U.S. House,7,Democratic,Aftyn Behn,78
+Montgomery,2B Bible,U.S. House,7,Democratic,Bo Mitchell,43
+Montgomery,2B Bible,U.S. House,7,Democratic,Darden Hunter Copeland,72
+Montgomery,2B Bible,U.S. House,7,Democratic,Vincent Dixie,37
+Montgomery,2B Bible,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,2B Bible,U.S. House,7,Republican,Gino Bulso,30
+Montgomery,2B Bible,U.S. House,7,Republican,Jason D. Knight,13
+Montgomery,2B Bible,U.S. House,7,Republican,Jody Barrett,48
+Montgomery,2B Bible,U.S. House,7,Republican,Joe Leurs,6
+Montgomery,2B Bible,U.S. House,7,Republican,Lee Reeves,6
+Montgomery,2B Bible,U.S. House,7,Republican,Mason Foley,1
+Montgomery,2B Bible,U.S. House,7,Republican,Matt Van Epps,208
+Montgomery,2B Bible,U.S. House,7,Republican,Stewart Parks,8
+Montgomery,2B Bible,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,2B Bible,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Aftyn Behn,39
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Bo Mitchell,53
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Darden Hunter Copeland,63
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Vincent Dixie,15
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Gino Bulso,33
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Jason D. Knight,4
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Jody Barrett,57
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Lee Reeves,17
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Mason Foley,6
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Matt Van Epps,288
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Stewart Parks,4
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Aftyn Behn,59
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Bo Mitchell,45
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Darden Hunter Copeland,61
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Vincent Dixie,15
+Montgomery,3B Fredonia,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,3B Fredonia,U.S. House,7,Republican,Gino Bulso,37
+Montgomery,3B Fredonia,U.S. House,7,Republican,Jason D. Knight,12
+Montgomery,3B Fredonia,U.S. House,7,Republican,Jody Barrett,77
+Montgomery,3B Fredonia,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,3B Fredonia,U.S. House,7,Republican,Lee Reeves,8
+Montgomery,3B Fredonia,U.S. House,7,Republican,Mason Foley,2
+Montgomery,3B Fredonia,U.S. House,7,Republican,Matt Van Epps,366
+Montgomery,3B Fredonia,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,3B Fredonia,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,3B Fredonia,U.S. House,7,Republican,Tres Wittum,7
+Montgomery,4A MCMS,U.S. House,7,Democratic,Aftyn Behn,53
+Montgomery,4A MCMS,U.S. House,7,Democratic,Bo Mitchell,30
+Montgomery,4A MCMS,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Montgomery,4A MCMS,U.S. House,7,Democratic,Vincent Dixie,6
+Montgomery,4A MCMS,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,4A MCMS,U.S. House,7,Republican,Gino Bulso,52
+Montgomery,4A MCMS,U.S. House,7,Republican,Jason D. Knight,7
+Montgomery,4A MCMS,U.S. House,7,Republican,Jody Barrett,74
+Montgomery,4A MCMS,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,4A MCMS,U.S. House,7,Republican,Lee Reeves,12
+Montgomery,4A MCMS,U.S. House,7,Republican,Mason Foley,4
+Montgomery,4A MCMS,U.S. House,7,Republican,Matt Van Epps,283
+Montgomery,4A MCMS,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,4A MCMS,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,4A MCMS,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Aftyn Behn,77
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Bo Mitchell,34
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Darden Hunter Copeland,59
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Vincent Dixie,37
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Gino Bulso,26
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Jody Barrett,33
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Lee Reeves,10
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Mason Foley,5
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Matt Van Epps,149
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Aftyn Behn,91
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Bo Mitchell,68
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Darden Hunter Copeland,56
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Vincent Dixie,56
+Montgomery,5 Cumberland,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,5 Cumberland,U.S. House,7,Republican,Gino Bulso,19
+Montgomery,5 Cumberland,U.S. House,7,Republican,Jason D. Knight,1
+Montgomery,5 Cumberland,U.S. House,7,Republican,Jody Barrett,21
+Montgomery,5 Cumberland,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,5 Cumberland,U.S. House,7,Republican,Lee Reeves,5
+Montgomery,5 Cumberland,U.S. House,7,Republican,Mason Foley,3
+Montgomery,5 Cumberland,U.S. House,7,Republican,Matt Van Epps,111
+Montgomery,5 Cumberland,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,5 Cumberland,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,5 Cumberland,U.S. House,7,Republican,Tres Wittum,3
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Aftyn Behn,33
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Bo Mitchell,41
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Vincent Dixie,5
+Montgomery,6A Cumberland,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,6A Cumberland,U.S. House,7,Republican,Gino Bulso,32
+Montgomery,6A Cumberland,U.S. House,7,Republican,Jason D. Knight,3
+Montgomery,6A Cumberland,U.S. House,7,Republican,Jody Barrett,37
+Montgomery,6A Cumberland,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,6A Cumberland,U.S. House,7,Republican,Lee Reeves,12
+Montgomery,6A Cumberland,U.S. House,7,Republican,Mason Foley,3
+Montgomery,6A Cumberland,U.S. House,7,Republican,Matt Van Epps,245
+Montgomery,6A Cumberland,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,6A Cumberland,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,6A Cumberland,U.S. House,7,Republican,Tres Wittum,6
+Montgomery,6B Bethel,U.S. House,7,Democratic,Aftyn Behn,17
+Montgomery,6B Bethel,U.S. House,7,Democratic,Bo Mitchell,31
+Montgomery,6B Bethel,U.S. House,7,Democratic,Darden Hunter Copeland,39
+Montgomery,6B Bethel,U.S. House,7,Democratic,Vincent Dixie,6
+Montgomery,6B Bethel,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Montgomery,6B Bethel,U.S. House,7,Republican,Gino Bulso,25
+Montgomery,6B Bethel,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,6B Bethel,U.S. House,7,Republican,Jody Barrett,60
+Montgomery,6B Bethel,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,6B Bethel,U.S. House,7,Republican,Lee Reeves,8
+Montgomery,6B Bethel,U.S. House,7,Republican,Mason Foley,1
+Montgomery,6B Bethel,U.S. House,7,Republican,Matt Van Epps,251
+Montgomery,6B Bethel,U.S. House,7,Republican,Stewart Parks,0
+Montgomery,6B Bethel,U.S. House,7,Republican,Stuart Cooper,3
+Montgomery,6B Bethel,U.S. House,7,Republican,Tres Wittum,2
+Montgomery,7A Liberty,U.S. House,7,Democratic,Aftyn Behn,40
+Montgomery,7A Liberty,U.S. House,7,Democratic,Bo Mitchell,29
+Montgomery,7A Liberty,U.S. House,7,Democratic,Darden Hunter Copeland,50
+Montgomery,7A Liberty,U.S. House,7,Democratic,Vincent Dixie,22
+Montgomery,7A Liberty,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,7A Liberty,U.S. House,7,Republican,Gino Bulso,32
+Montgomery,7A Liberty,U.S. House,7,Republican,Jason D. Knight,8
+Montgomery,7A Liberty,U.S. House,7,Republican,Jody Barrett,29
+Montgomery,7A Liberty,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,7A Liberty,U.S. House,7,Republican,Lee Reeves,5
+Montgomery,7A Liberty,U.S. House,7,Republican,Mason Foley,5
+Montgomery,7A Liberty,U.S. House,7,Republican,Matt Van Epps,173
+Montgomery,7A Liberty,U.S. House,7,Republican,Stewart Parks,2
+Montgomery,7A Liberty,U.S. House,7,Republican,Stuart Cooper,2
+Montgomery,7A Liberty,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Aftyn Behn,32
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Bo Mitchell,23
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Darden Hunter Copeland,35
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Vincent Dixie,12
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Gino Bulso,46
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Jason D. Knight,9
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Jody Barrett,69
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Joe Leurs,1
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Lee Reeves,15
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Mason Foley,5
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Matt Van Epps,300
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Stewart Parks,3
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Tres Wittum,1
+Montgomery,8 Bethel,U.S. House,7,Democratic,Aftyn Behn,38
+Montgomery,8 Bethel,U.S. House,7,Democratic,Bo Mitchell,28
+Montgomery,8 Bethel,U.S. House,7,Democratic,Darden Hunter Copeland,69
+Montgomery,8 Bethel,U.S. House,7,Democratic,Vincent Dixie,33
+Montgomery,8 Bethel,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Gino Bulso,9
+Montgomery,8 Bethel,U.S. House,7,Republican,Jason D. Knight,2
+Montgomery,8 Bethel,U.S. House,7,Republican,Jody Barrett,12
+Montgomery,8 Bethel,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Lee Reeves,1
+Montgomery,8 Bethel,U.S. House,7,Republican,Mason Foley,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Matt Van Epps,64
+Montgomery,8 Bethel,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,8 Bethel,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,8 Bethel,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Aftyn Behn,31
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Bo Mitchell,26
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Darden Hunter Copeland,65
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Vincent Dixie,76
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Gino Bulso,16
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Jason D. Knight,6
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Jody Barrett,20
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Joe Leurs,2
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Lee Reeves,3
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Mason Foley,1
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Matt Van Epps,93
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Stuart Cooper,0
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Tres Wittum,0
+Montgomery,9B St John,U.S. House,7,Democratic,Aftyn Behn,36
+Montgomery,9B St John,U.S. House,7,Democratic,Bo Mitchell,18
+Montgomery,9B St John,U.S. House,7,Democratic,Darden Hunter Copeland,50
+Montgomery,9B St John,U.S. House,7,Democratic,Vincent Dixie,52
+Montgomery,9B St John,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Montgomery,9B St John,U.S. House,7,Republican,Gino Bulso,13
+Montgomery,9B St John,U.S. House,7,Republican,Jason D. Knight,5
+Montgomery,9B St John,U.S. House,7,Republican,Jody Barrett,15
+Montgomery,9B St John,U.S. House,7,Republican,Joe Leurs,0
+Montgomery,9B St John,U.S. House,7,Republican,Lee Reeves,4
+Montgomery,9B St John,U.S. House,7,Republican,Mason Foley,2
+Montgomery,9B St John,U.S. House,7,Republican,Matt Van Epps,64
+Montgomery,9B St John,U.S. House,7,Republican,Stewart Parks,1
+Montgomery,9B St John,U.S. House,7,Republican,Stuart Cooper,1
+Montgomery,9B St John,U.S. House,7,Republican,Tres Wittum,0
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Aftyn Behn,1
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Bo Mitchell,8
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Gino Bulso,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Jason D. Knight,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Jody Barrett,14
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Lee Reeves,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Matt Van Epps,31
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Stewart Parks,3
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Stuart Cooper,1
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Bo Mitchell,2
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Gino Bulso,3
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Jason D. Knight,1
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Jody Barrett,13
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Lee Reeves,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Matt Van Epps,15
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Stewart Parks,0
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Stuart Cooper,1
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,2-1 Pineview,U.S. House,7,Democratic,Aftyn Behn,1
+Perry,2-1 Pineview,U.S. House,7,Democratic,Bo Mitchell,16
+Perry,2-1 Pineview,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Perry,2-1 Pineview,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Gino Bulso,1
+Perry,2-1 Pineview,U.S. House,7,Republican,Jason D. Knight,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Jody Barrett,23
+Perry,2-1 Pineview,U.S. House,7,Republican,Joe Leurs,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Lee Reeves,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Mason Foley,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Matt Van Epps,26
+Perry,2-1 Pineview,U.S. House,7,Republican,Stewart Parks,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Stuart Cooper,0
+Perry,2-1 Pineview,U.S. House,7,Republican,Tres Wittum,0
+Perry,2-2 Pope,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,2-2 Pope,U.S. House,7,Democratic,Bo Mitchell,3
+Perry,2-2 Pope,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Perry,2-2 Pope,U.S. House,7,Democratic,Vincent Dixie,1
+Perry,2-2 Pope,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,2-2 Pope,U.S. House,7,Republican,Gino Bulso,8
+Perry,2-2 Pope,U.S. House,7,Republican,Jason D. Knight,0
+Perry,2-2 Pope,U.S. House,7,Republican,Jody Barrett,7
+Perry,2-2 Pope,U.S. House,7,Republican,Joe Leurs,0
+Perry,2-2 Pope,U.S. House,7,Republican,Lee Reeves,4
+Perry,2-2 Pope,U.S. House,7,Republican,Mason Foley,1
+Perry,2-2 Pope,U.S. House,7,Republican,Matt Van Epps,20
+Perry,2-2 Pope,U.S. House,7,Republican,Stewart Parks,3
+Perry,2-2 Pope,U.S. House,7,Republican,Stuart Cooper,0
+Perry,2-2 Pope,U.S. House,7,Republican,Tres Wittum,0
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Aftyn Behn,4
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Bo Mitchell,19
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Gino Bulso,9
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Jason D. Knight,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Jody Barrett,22
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Lee Reeves,2
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Matt Van Epps,23
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Stewart Parks,3
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Stuart Cooper,1
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Aftyn Behn,1
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Bo Mitchell,5
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Gino Bulso,11
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Jason D. Knight,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Jody Barrett,10
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Joe Leurs,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Lee Reeves,1
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Mason Foley,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Matt Van Epps,19
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Stewart Parks,1
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Stuart Cooper,0
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Tres Wittum,0
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Bo Mitchell,8
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Gino Bulso,4
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Jason D. Knight,1
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Jody Barrett,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Joe Leurs,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Lee Reeves,2
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Mason Foley,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Matt Van Epps,12
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Stewart Parks,1
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Stuart Cooper,0
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Tres Wittum,0
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Aftyn Behn,2
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Bo Mitchell,10
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Darden Hunter Copeland,3
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Gino Bulso,12
+Perry,4-3 Lobelville,U.S. House,7,Republican,Jason D. Knight,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Jody Barrett,17
+Perry,4-3 Lobelville,U.S. House,7,Republican,Joe Leurs,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Lee Reeves,1
+Perry,4-3 Lobelville,U.S. House,7,Republican,Mason Foley,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Matt Van Epps,28
+Perry,4-3 Lobelville,U.S. House,7,Republican,Stewart Parks,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Stuart Cooper,0
+Perry,4-3 Lobelville,U.S. House,7,Republican,Tres Wittum,0
+Perry,5-1 Linden,U.S. House,7,Democratic,Aftyn Behn,0
+Perry,5-1 Linden,U.S. House,7,Democratic,Bo Mitchell,26
+Perry,5-1 Linden,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Perry,5-1 Linden,U.S. House,7,Democratic,Vincent Dixie,1
+Perry,5-1 Linden,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,5-1 Linden,U.S. House,7,Republican,Gino Bulso,7
+Perry,5-1 Linden,U.S. House,7,Republican,Jason D. Knight,1
+Perry,5-1 Linden,U.S. House,7,Republican,Jody Barrett,28
+Perry,5-1 Linden,U.S. House,7,Republican,Joe Leurs,0
+Perry,5-1 Linden,U.S. House,7,Republican,Lee Reeves,1
+Perry,5-1 Linden,U.S. House,7,Republican,Mason Foley,1
+Perry,5-1 Linden,U.S. House,7,Republican,Matt Van Epps,30
+Perry,5-1 Linden,U.S. House,7,Republican,Stewart Parks,3
+Perry,5-1 Linden,U.S. House,7,Republican,Stuart Cooper,0
+Perry,5-1 Linden,U.S. House,7,Republican,Tres Wittum,1
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Aftyn Behn,6
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Bo Mitchell,9
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Vincent Dixie,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Gino Bulso,5
+Perry,6-1 Lobelville,U.S. House,7,Republican,Jason D. Knight,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Jody Barrett,33
+Perry,6-1 Lobelville,U.S. House,7,Republican,Joe Leurs,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Lee Reeves,2
+Perry,6-1 Lobelville,U.S. House,7,Republican,Mason Foley,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Matt Van Epps,26
+Perry,6-1 Lobelville,U.S. House,7,Republican,Stewart Parks,4
+Perry,6-1 Lobelville,U.S. House,7,Republican,Stuart Cooper,0
+Perry,6-1 Lobelville,U.S. House,7,Republican,Tres Wittum,0
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Aftyn Behn,17
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Bo Mitchell,24
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Vincent Dixie,8
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Gino Bulso,48
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Jody Barrett,59
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Joe Leurs,2
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Lee Reeves,6
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Mason Foley,7
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Matt Van Epps,241
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Stewart Parks,4
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Tres Wittum,1
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Aftyn Behn,44
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Bo Mitchell,20
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Darden Hunter Copeland,51
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Vincent Dixie,11
+Robertson,02-1 Woodall,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,02-1 Woodall,U.S. House,7,Republican,Gino Bulso,29
+Robertson,02-1 Woodall,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,02-1 Woodall,U.S. House,7,Republican,Jody Barrett,28
+Robertson,02-1 Woodall,U.S. House,7,Republican,Joe Leurs,2
+Robertson,02-1 Woodall,U.S. House,7,Republican,Lee Reeves,17
+Robertson,02-1 Woodall,U.S. House,7,Republican,Mason Foley,19
+Robertson,02-1 Woodall,U.S. House,7,Republican,Matt Van Epps,182
+Robertson,02-1 Woodall,U.S. House,7,Republican,Stewart Parks,13
+Robertson,02-1 Woodall,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,02-1 Woodall,U.S. House,7,Republican,Tres Wittum,0
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Aftyn Behn,13
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Bo Mitchell,21
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Vincent Dixie,3
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Gino Bulso,21
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Jody Barrett,29
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Joe Leurs,0
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Lee Reeves,2
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Mason Foley,6
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Matt Van Epps,129
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Stewart Parks,8
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Tres Wittum,0
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Aftyn Behn,37
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Bo Mitchell,14
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Vincent Dixie,6
+Robertson,03-2 Heritage,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,03-2 Heritage,U.S. House,7,Republican,Gino Bulso,30
+Robertson,03-2 Heritage,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,03-2 Heritage,U.S. House,7,Republican,Jody Barrett,38
+Robertson,03-2 Heritage,U.S. House,7,Republican,Joe Leurs,0
+Robertson,03-2 Heritage,U.S. House,7,Republican,Lee Reeves,14
+Robertson,03-2 Heritage,U.S. House,7,Republican,Mason Foley,4
+Robertson,03-2 Heritage,U.S. House,7,Republican,Matt Van Epps,180
+Robertson,03-2 Heritage,U.S. House,7,Republican,Stewart Parks,9
+Robertson,03-2 Heritage,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,03-2 Heritage,U.S. House,7,Republican,Tres Wittum,2
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Aftyn Behn,27
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Bo Mitchell,56
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Darden Hunter Copeland,47
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Vincent Dixie,5
+Robertson,04-1 Watauga,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,04-1 Watauga,U.S. House,7,Republican,Gino Bulso,33
+Robertson,04-1 Watauga,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,04-1 Watauga,U.S. House,7,Republican,Jody Barrett,44
+Robertson,04-1 Watauga,U.S. House,7,Republican,Joe Leurs,0
+Robertson,04-1 Watauga,U.S. House,7,Republican,Lee Reeves,11
+Robertson,04-1 Watauga,U.S. House,7,Republican,Mason Foley,25
+Robertson,04-1 Watauga,U.S. House,7,Republican,Matt Van Epps,229
+Robertson,04-1 Watauga,U.S. House,7,Republican,Stewart Parks,2
+Robertson,04-1 Watauga,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,04-1 Watauga,U.S. House,7,Republican,Tres Wittum,3
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Aftyn Behn,23
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Bo Mitchell,31
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Darden Hunter Copeland,60
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Vincent Dixie,4
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Gino Bulso,43
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Jody Barrett,44
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Joe Leurs,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Lee Reeves,12
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Mason Foley,7
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Matt Van Epps,166
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Stewart Parks,2
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Tres Wittum,0
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Aftyn Behn,19
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Bo Mitchell,29
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Vincent Dixie,7
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Gino Bulso,42
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Jody Barrett,49
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Joe Leurs,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Lee Reeves,6
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Mason Foley,9
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Matt Van Epps,172
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Stewart Parks,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Tres Wittum,2
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Aftyn Behn,21
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Bo Mitchell,31
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Darden Hunter Copeland,20
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Vincent Dixie,7
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Gino Bulso,13
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Jody Barrett,39
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Joe Leurs,0
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Lee Reeves,11
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Mason Foley,7
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Matt Van Epps,138
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Stewart Parks,7
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Tres Wittum,0
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Aftyn Behn,11
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Bo Mitchell,23
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Vincent Dixie,3
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Gino Bulso,36
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Jason D. Knight,3
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Jody Barrett,46
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Joe Leurs,0
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Lee Reeves,11
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Mason Foley,9
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Matt Van Epps,244
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Stewart Parks,6
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Stuart Cooper,3
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Tres Wittum,0
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Aftyn Behn,6
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Bo Mitchell,7
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Darden Hunter Copeland,14
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Vincent Dixie,2
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Gino Bulso,10
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Jody Barrett,28
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Joe Leurs,0
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Lee Reeves,2
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Mason Foley,1
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Matt Van Epps,103
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Stewart Parks,3
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Tres Wittum,0
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Aftyn Behn,6
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Bo Mitchell,8
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Vincent Dixie,2
+Robertson,08-1 Krisle,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,08-1 Krisle,U.S. House,7,Republican,Gino Bulso,16
+Robertson,08-1 Krisle,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,08-1 Krisle,U.S. House,7,Republican,Jody Barrett,25
+Robertson,08-1 Krisle,U.S. House,7,Republican,Joe Leurs,1
+Robertson,08-1 Krisle,U.S. House,7,Republican,Lee Reeves,3
+Robertson,08-1 Krisle,U.S. House,7,Republican,Mason Foley,0
+Robertson,08-1 Krisle,U.S. House,7,Republican,Matt Van Epps,84
+Robertson,08-1 Krisle,U.S. House,7,Republican,Stewart Parks,1
+Robertson,08-1 Krisle,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,08-1 Krisle,U.S. House,7,Republican,Tres Wittum,0
+Robertson,08-2 HATS,U.S. House,7,Democratic,Aftyn Behn,7
+Robertson,08-2 HATS,U.S. House,7,Democratic,Bo Mitchell,7
+Robertson,08-2 HATS,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Robertson,08-2 HATS,U.S. House,7,Democratic,Vincent Dixie,1
+Robertson,08-2 HATS,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,08-2 HATS,U.S. House,7,Republican,Gino Bulso,13
+Robertson,08-2 HATS,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,08-2 HATS,U.S. House,7,Republican,Jody Barrett,18
+Robertson,08-2 HATS,U.S. House,7,Republican,Joe Leurs,0
+Robertson,08-2 HATS,U.S. House,7,Republican,Lee Reeves,5
+Robertson,08-2 HATS,U.S. House,7,Republican,Mason Foley,3
+Robertson,08-2 HATS,U.S. House,7,Republican,Matt Van Epps,98
+Robertson,08-2 HATS,U.S. House,7,Republican,Stewart Parks,4
+Robertson,08-2 HATS,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,08-2 HATS,U.S. House,7,Republican,Tres Wittum,0
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Aftyn Behn,13
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Bo Mitchell,7
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Vincent Dixie,2
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Gino Bulso,19
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Jody Barrett,32
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Joe Leurs,0
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Lee Reeves,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Mason Foley,4
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Matt Van Epps,157
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Stewart Parks,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Tres Wittum,0
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Aftyn Behn,28
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Bo Mitchell,27
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Darden Hunter Copeland,84
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Vincent Dixie,16
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Gino Bulso,48
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Jason D. Knight,5
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Jody Barrett,24
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Joe Leurs,0
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Lee Reeves,8
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Mason Foley,16
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Matt Van Epps,164
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Stewart Parks,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Stuart Cooper,3
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Tres Wittum,1
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Aftyn Behn,31
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Bo Mitchell,42
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Darden Hunter Copeland,88
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Vincent Dixie,18
+Robertson,10-1 South Haven,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,10-1 South Haven,U.S. House,7,Republican,Gino Bulso,44
+Robertson,10-1 South Haven,U.S. House,7,Republican,Jason D. Knight,2
+Robertson,10-1 South Haven,U.S. House,7,Republican,Jody Barrett,51
+Robertson,10-1 South Haven,U.S. House,7,Republican,Joe Leurs,0
+Robertson,10-1 South Haven,U.S. House,7,Republican,Lee Reeves,26
+Robertson,10-1 South Haven,U.S. House,7,Republican,Mason Foley,12
+Robertson,10-1 South Haven,U.S. House,7,Republican,Matt Van Epps,257
+Robertson,10-1 South Haven,U.S. House,7,Republican,Stewart Parks,3
+Robertson,10-1 South Haven,U.S. House,7,Republican,Stuart Cooper,2
+Robertson,10-1 South Haven,U.S. House,7,Republican,Tres Wittum,1
+Robertson,11-1 Westside,U.S. House,7,Democratic,Aftyn Behn,50
+Robertson,11-1 Westside,U.S. House,7,Democratic,Bo Mitchell,33
+Robertson,11-1 Westside,U.S. House,7,Democratic,Darden Hunter Copeland,73
+Robertson,11-1 Westside,U.S. House,7,Democratic,Vincent Dixie,13
+Robertson,11-1 Westside,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Robertson,11-1 Westside,U.S. House,7,Republican,Gino Bulso,28
+Robertson,11-1 Westside,U.S. House,7,Republican,Jason D. Knight,3
+Robertson,11-1 Westside,U.S. House,7,Republican,Jody Barrett,53
+Robertson,11-1 Westside,U.S. House,7,Republican,Joe Leurs,1
+Robertson,11-1 Westside,U.S. House,7,Republican,Lee Reeves,9
+Robertson,11-1 Westside,U.S. House,7,Republican,Mason Foley,8
+Robertson,11-1 Westside,U.S. House,7,Republican,Matt Van Epps,200
+Robertson,11-1 Westside,U.S. House,7,Republican,Stewart Parks,3
+Robertson,11-1 Westside,U.S. House,7,Republican,Stuart Cooper,1
+Robertson,11-1 Westside,U.S. House,7,Republican,Tres Wittum,3
+Robertson,11-2 Heads,U.S. House,7,Democratic,Aftyn Behn,2
+Robertson,11-2 Heads,U.S. House,7,Democratic,Bo Mitchell,1
+Robertson,11-2 Heads,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Robertson,11-2 Heads,U.S. House,7,Democratic,Vincent Dixie,1
+Robertson,11-2 Heads,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Gino Bulso,20
+Robertson,11-2 Heads,U.S. House,7,Republican,Jason D. Knight,1
+Robertson,11-2 Heads,U.S. House,7,Republican,Jody Barrett,16
+Robertson,11-2 Heads,U.S. House,7,Republican,Joe Leurs,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Lee Reeves,8
+Robertson,11-2 Heads,U.S. House,7,Republican,Mason Foley,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Matt Van Epps,54
+Robertson,11-2 Heads,U.S. House,7,Republican,Stewart Parks,1
+Robertson,11-2 Heads,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,11-2 Heads,U.S. House,7,Republican,Tres Wittum,0
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Aftyn Behn,17
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Bo Mitchell,36
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Darden Hunter Copeland,52
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Vincent Dixie,31
+Robertson,12-1 Bransford,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Gino Bulso,10
+Robertson,12-1 Bransford,U.S. House,7,Republican,Jason D. Knight,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Jody Barrett,5
+Robertson,12-1 Bransford,U.S. House,7,Republican,Joe Leurs,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Lee Reeves,1
+Robertson,12-1 Bransford,U.S. House,7,Republican,Mason Foley,4
+Robertson,12-1 Bransford,U.S. House,7,Republican,Matt Van Epps,12
+Robertson,12-1 Bransford,U.S. House,7,Republican,Stewart Parks,1
+Robertson,12-1 Bransford,U.S. House,7,Republican,Stuart Cooper,0
+Robertson,12-1 Bransford,U.S. House,7,Republican,Tres Wittum,0
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Bo Mitchell,6
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Darden Hunter Copeland,21
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Vincent Dixie,2
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Gino Bulso,13
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Jason D. Knight,0
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Jody Barrett,13
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Joe Leurs,0
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Lee Reeves,3
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Mason Foley,1
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Matt Van Epps,64
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Stewart Parks,4
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Stuart Cooper,1
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Tres Wittum,0
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Aftyn Behn,7
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Bo Mitchell,4
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Vincent Dixie,2
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Gino Bulso,17
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Jason D. Knight,6
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Jody Barrett,17
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Joe Leurs,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Lee Reeves,3
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Mason Foley,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Matt Van Epps,70
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Stewart Parks,7
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Tres Wittum,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Bo Mitchell,7
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Vincent Dixie,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Gino Bulso,19
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Jason D. Knight,2
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Jody Barrett,37
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Joe Leurs,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Lee Reeves,8
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Mason Foley,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Matt Van Epps,112
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Stewart Parks,7
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Tres Wittum,1
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Aftyn Behn,8
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Bo Mitchell,9
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Darden Hunter Copeland,18
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Vincent Dixie,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Gino Bulso,15
+Stewart,4-1 Church Street,U.S. House,7,Republican,Jason D. Knight,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Jody Barrett,22
+Stewart,4-1 Church Street,U.S. House,7,Republican,Joe Leurs,0
+Stewart,4-1 Church Street,U.S. House,7,Republican,Lee Reeves,3
+Stewart,4-1 Church Street,U.S. House,7,Republican,Mason Foley,1
+Stewart,4-1 Church Street,U.S. House,7,Republican,Matt Van Epps,67
+Stewart,4-1 Church Street,U.S. House,7,Republican,Stewart Parks,3
+Stewart,4-1 Church Street,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,4-1 Church Street,U.S. House,7,Republican,Tres Wittum,0
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Aftyn Behn,5
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Bo Mitchell,16
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Vincent Dixie,2
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Gino Bulso,34
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Jason D. Knight,1
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Jody Barrett,19
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Joe Leurs,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Lee Reeves,8
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Mason Foley,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Matt Van Epps,101
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Stewart Parks,3
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Tres Wittum,1
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Bo Mitchell,25
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Darden Hunter Copeland,36
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Vincent Dixie,5
+Stewart,6-1 Public Library,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,6-1 Public Library,U.S. House,7,Republican,Gino Bulso,27
+Stewart,6-1 Public Library,U.S. House,7,Republican,Jason D. Knight,5
+Stewart,6-1 Public Library,U.S. House,7,Republican,Jody Barrett,27
+Stewart,6-1 Public Library,U.S. House,7,Republican,Joe Leurs,2
+Stewart,6-1 Public Library,U.S. House,7,Republican,Lee Reeves,2
+Stewart,6-1 Public Library,U.S. House,7,Republican,Mason Foley,2
+Stewart,6-1 Public Library,U.S. House,7,Republican,Matt Van Epps,84
+Stewart,6-1 Public Library,U.S. House,7,Republican,Stewart Parks,10
+Stewart,6-1 Public Library,U.S. House,7,Republican,Stuart Cooper,1
+Stewart,6-1 Public Library,U.S. House,7,Republican,Tres Wittum,0
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Aftyn Behn,9
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Bo Mitchell,13
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Darden Hunter Copeland,19
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Vincent Dixie,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Gino Bulso,39
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Jason D. Knight,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Jody Barrett,12
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Joe Leurs,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Lee Reeves,7
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Mason Foley,1
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Matt Van Epps,92
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Stewart Parks,6
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Stuart Cooper,0
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Tres Wittum,0
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Aftyn Behn,5
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Bo Mitchell,15
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Darden Hunter Copeland,20
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Vincent Dixie,1
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Gino Bulso,14
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Jason D. Knight,1
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Jody Barrett,43
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Joe Leurs,0
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Lee Reeves,5
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Mason Foley,2
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Matt Van Epps,66
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Stewart Parks,8
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Tres Wittum,0
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Bo Mitchell,2
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Darden Hunter Copeland,4
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Gino Bulso,2
+Wayne,2-1 Clifton,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Jody Barrett,7
+Wayne,2-1 Clifton,U.S. House,7,Republican,Joe Leurs,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Lee Reeves,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Mason Foley,1
+Wayne,2-1 Clifton,U.S. House,7,Republican,Matt Van Epps,13
+Wayne,2-1 Clifton,U.S. House,7,Republican,Stewart Parks,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,2-1 Clifton,U.S. House,7,Republican,Tres Wittum,0
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Bo Mitchell,1
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Gino Bulso,3
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Jody Barrett,29
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Joe Leurs,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Lee Reeves,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Mason Foley,2
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Matt Van Epps,44
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Stewart Parks,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Tres Wittum,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Bo Mitchell,4
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Vincent Dixie,1
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Gino Bulso,5
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Jody Barrett,22
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Joe Leurs,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Lee Reeves,3
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Mason Foley,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Matt Van Epps,21
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Stewart Parks,6
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Stuart Cooper,2
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Tres Wittum,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Bo Mitchell,4
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Gino Bulso,3
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Jody Barrett,12
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Joe Leurs,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Lee Reeves,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Mason Foley,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Matt Van Epps,21
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Stewart Parks,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Tres Wittum,0
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Aftyn Behn,2
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Bo Mitchell,7
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Vincent Dixie,2
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Gino Bulso,6
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Jody Barrett,14
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Joe Leurs,0
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Lee Reeves,1
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Mason Foley,4
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Matt Van Epps,37
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Stewart Parks,5
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Stuart Cooper,2
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Tres Wittum,0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Bo Mitchell,0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Gino Bulso,3
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Jody Barrett,16
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Joe Leurs,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Lee Reeves,2
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Mason Foley,6
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Matt Van Epps,25
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Stewart Parks,3
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Tres Wittum,0
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Aftyn Behn,2
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Bo Mitchell,1
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Darden Hunter Copeland,8
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Gino Bulso,6
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Jody Barrett,21
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Joe Leurs,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Lee Reeves,3
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Mason Foley,1
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Matt Van Epps,44
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Stewart Parks,2
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Tres Wittum,0
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Bo Mitchell,2
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Darden Hunter Copeland,2
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Vincent Dixie,2
+Wayne,5-2 Lutts,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Gino Bulso,7
+Wayne,5-2 Lutts,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Jody Barrett,5
+Wayne,5-2 Lutts,U.S. House,7,Republican,Joe Leurs,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Lee Reeves,1
+Wayne,5-2 Lutts,U.S. House,7,Republican,Mason Foley,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Matt Van Epps,24
+Wayne,5-2 Lutts,U.S. House,7,Republican,Stewart Parks,3
+Wayne,5-2 Lutts,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,5-2 Lutts,U.S. House,7,Republican,Tres Wittum,0
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Bo Mitchell,6
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Darden Hunter Copeland,1
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Vincent Dixie,1
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Gino Bulso,5
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Jody Barrett,11
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Joe Leurs,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Lee Reeves,1
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Mason Foley,1
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Matt Van Epps,14
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Stewart Parks,4
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Tres Wittum,0
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Aftyn Behn,1
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Bo Mitchell,2
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Gino Bulso,1
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Jody Barrett,14
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Joe Leurs,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Lee Reeves,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Mason Foley,1
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Matt Van Epps,27
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Stewart Parks,1
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Tres Wittum,0
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Bo Mitchell,1
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Darden Hunter Copeland,7
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Gino Bulso,5
+Wayne,6-2 South Gate,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Jody Barrett,40
+Wayne,6-2 South Gate,U.S. House,7,Republican,Joe Leurs,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Lee Reeves,9
+Wayne,6-2 South Gate,U.S. House,7,Republican,Mason Foley,7
+Wayne,6-2 South Gate,U.S. House,7,Republican,Matt Van Epps,41
+Wayne,6-2 South Gate,U.S. House,7,Republican,Stewart Parks,2
+Wayne,6-2 South Gate,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,6-2 South Gate,U.S. House,7,Republican,Tres Wittum,0
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Aftyn Behn,0
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Bo Mitchell,5
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Gino Bulso,3
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Jason D. Knight,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Jody Barrett,14
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Joe Leurs,0
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Lee Reeves,1
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Mason Foley,1
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Matt Van Epps,33
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Stewart Parks,3
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Stuart Cooper,1
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Tres Wittum,0
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Aftyn Behn,2
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Bo Mitchell,6
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Darden Hunter Copeland,0
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Vincent Dixie,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Gino Bulso,6
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Jason D. Knight,1
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Jody Barrett,20
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Joe Leurs,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Lee Reeves,3
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Mason Foley,1
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Matt Van Epps,47
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Stewart Parks,3
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Stuart Cooper,0
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Tres Wittum,0
+Williamson,1-1,U.S. House,7,Democratic,Aftyn Behn,79
+Williamson,1-1,U.S. House,7,Democratic,Bo Mitchell,83
+Williamson,1-1,U.S. House,7,Democratic,Darden Hunter Copeland,78
+Williamson,1-1,U.S. House,7,Democratic,Vincent Dixie,16
+Williamson,1-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,1-1,U.S. House,7,Republican,Gino Bulso,62
+Williamson,1-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,1-1,U.S. House,7,Republican,Jody Barrett,116
+Williamson,1-1,U.S. House,7,Republican,Joe Leurs,0
+Williamson,1-1,U.S. House,7,Republican,Lee Reeves,99
+Williamson,1-1,U.S. House,7,Republican,Mason Foley,67
+Williamson,1-1,U.S. House,7,Republican,Matt Van Epps,249
+Williamson,1-1,U.S. House,7,Republican,Stewart Parks,21
+Williamson,1-1,U.S. House,7,Republican,Stuart Cooper,5
+Williamson,1-1,U.S. House,7,Republican,Tres Wittum,5
+Williamson,1-5,U.S. House,7,Democratic,Aftyn Behn,35
+Williamson,1-5,U.S. House,7,Democratic,Bo Mitchell,19
+Williamson,1-5,U.S. House,7,Democratic,Darden Hunter Copeland,37
+Williamson,1-5,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,1-5,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,1-5,U.S. House,7,Republican,Gino Bulso,15
+Williamson,1-5,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,1-5,U.S. House,7,Republican,Jody Barrett,72
+Williamson,1-5,U.S. House,7,Republican,Joe Leurs,0
+Williamson,1-5,U.S. House,7,Republican,Lee Reeves,29
+Williamson,1-5,U.S. House,7,Republican,Mason Foley,13
+Williamson,1-5,U.S. House,7,Republican,Matt Van Epps,106
+Williamson,1-5,U.S. House,7,Republican,Stewart Parks,4
+Williamson,1-5,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,1-5,U.S. House,7,Republican,Tres Wittum,0
+Williamson,1-6,U.S. House,7,Democratic,Aftyn Behn,55
+Williamson,1-6,U.S. House,7,Democratic,Bo Mitchell,73
+Williamson,1-6,U.S. House,7,Democratic,Darden Hunter Copeland,48
+Williamson,1-6,U.S. House,7,Democratic,Vincent Dixie,5
+Williamson,1-6,U.S. House,7,Republican,Adolph Agbéko Dagan,5
+Williamson,1-6,U.S. House,7,Republican,Gino Bulso,31
+Williamson,1-6,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,1-6,U.S. House,7,Republican,Jody Barrett,119
+Williamson,1-6,U.S. House,7,Republican,Joe Leurs,3
+Williamson,1-6,U.S. House,7,Republican,Lee Reeves,112
+Williamson,1-6,U.S. House,7,Republican,Mason Foley,49
+Williamson,1-6,U.S. House,7,Republican,Matt Van Epps,193
+Williamson,1-6,U.S. House,7,Republican,Stewart Parks,28
+Williamson,1-6,U.S. House,7,Republican,Stuart Cooper,5
+Williamson,1-6,U.S. House,7,Republican,Tres Wittum,1
+Williamson,10-1,U.S. House,7,Democratic,Aftyn Behn,131
+Williamson,10-1,U.S. House,7,Democratic,Bo Mitchell,68
+Williamson,10-1,U.S. House,7,Democratic,Darden Hunter Copeland,119
+Williamson,10-1,U.S. House,7,Democratic,Vincent Dixie,14
+Williamson,10-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,10-1,U.S. House,7,Republican,Gino Bulso,54
+Williamson,10-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,10-1,U.S. House,7,Republican,Jody Barrett,87
+Williamson,10-1,U.S. House,7,Republican,Joe Leurs,1
+Williamson,10-1,U.S. House,7,Republican,Lee Reeves,24
+Williamson,10-1,U.S. House,7,Republican,Mason Foley,22
+Williamson,10-1,U.S. House,7,Republican,Matt Van Epps,116
+Williamson,10-1,U.S. House,7,Republican,Stewart Parks,4
+Williamson,10-1,U.S. House,7,Republican,Stuart Cooper,3
+Williamson,10-1,U.S. House,7,Republican,Tres Wittum,1
+Williamson,10-2,U.S. House,7,Democratic,Aftyn Behn,93
+Williamson,10-2,U.S. House,7,Democratic,Bo Mitchell,34
+Williamson,10-2,U.S. House,7,Democratic,Darden Hunter Copeland,69
+Williamson,10-2,U.S. House,7,Democratic,Vincent Dixie,8
+Williamson,10-2,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Williamson,10-2,U.S. House,7,Republican,Gino Bulso,38
+Williamson,10-2,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,10-2,U.S. House,7,Republican,Jody Barrett,81
+Williamson,10-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-2,U.S. House,7,Republican,Lee Reeves,47
+Williamson,10-2,U.S. House,7,Republican,Mason Foley,10
+Williamson,10-2,U.S. House,7,Republican,Matt Van Epps,93
+Williamson,10-2,U.S. House,7,Republican,Stewart Parks,0
+Williamson,10-2,U.S. House,7,Republican,Stuart Cooper,6
+Williamson,10-2,U.S. House,7,Republican,Tres Wittum,3
+Williamson,10-3,U.S. House,7,Democratic,Aftyn Behn,6
+Williamson,10-3,U.S. House,7,Democratic,Bo Mitchell,3
+Williamson,10-3,U.S. House,7,Democratic,Darden Hunter Copeland,6
+Williamson,10-3,U.S. House,7,Democratic,Vincent Dixie,2
+Williamson,10-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,10-3,U.S. House,7,Republican,Gino Bulso,9
+Williamson,10-3,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,10-3,U.S. House,7,Republican,Jody Barrett,8
+Williamson,10-3,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-3,U.S. House,7,Republican,Lee Reeves,1
+Williamson,10-3,U.S. House,7,Republican,Mason Foley,2
+Williamson,10-3,U.S. House,7,Republican,Matt Van Epps,14
+Williamson,10-3,U.S. House,7,Republican,Stewart Parks,0
+Williamson,10-3,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,10-3,U.S. House,7,Republican,Tres Wittum,0
+Williamson,10-4,U.S. House,7,Democratic,Aftyn Behn,72
+Williamson,10-4,U.S. House,7,Democratic,Bo Mitchell,24
+Williamson,10-4,U.S. House,7,Democratic,Darden Hunter Copeland,56
+Williamson,10-4,U.S. House,7,Democratic,Vincent Dixie,15
+Williamson,10-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,10-4,U.S. House,7,Republican,Gino Bulso,37
+Williamson,10-4,U.S. House,7,Republican,Jason D. Knight,3
+Williamson,10-4,U.S. House,7,Republican,Jody Barrett,52
+Williamson,10-4,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-4,U.S. House,7,Republican,Lee Reeves,7
+Williamson,10-4,U.S. House,7,Republican,Mason Foley,24
+Williamson,10-4,U.S. House,7,Republican,Matt Van Epps,78
+Williamson,10-4,U.S. House,7,Republican,Stewart Parks,1
+Williamson,10-4,U.S. House,7,Republican,Stuart Cooper,3
+Williamson,10-4,U.S. House,7,Republican,Tres Wittum,3
+Williamson,10-5,U.S. House,7,Democratic,Aftyn Behn,76
+Williamson,10-5,U.S. House,7,Democratic,Bo Mitchell,30
+Williamson,10-5,U.S. House,7,Democratic,Darden Hunter Copeland,59
+Williamson,10-5,U.S. House,7,Democratic,Vincent Dixie,22
+Williamson,10-5,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,10-5,U.S. House,7,Republican,Gino Bulso,18
+Williamson,10-5,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,10-5,U.S. House,7,Republican,Jody Barrett,53
+Williamson,10-5,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-5,U.S. House,7,Republican,Lee Reeves,24
+Williamson,10-5,U.S. House,7,Republican,Mason Foley,14
+Williamson,10-5,U.S. House,7,Republican,Matt Van Epps,46
+Williamson,10-5,U.S. House,7,Republican,Stewart Parks,0
+Williamson,10-5,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,10-5,U.S. House,7,Republican,Tres Wittum,2
+Williamson,10-6,U.S. House,7,Democratic,Aftyn Behn,27
+Williamson,10-6,U.S. House,7,Democratic,Bo Mitchell,22
+Williamson,10-6,U.S. House,7,Democratic,Darden Hunter Copeland,25
+Williamson,10-6,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,10-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,10-6,U.S. House,7,Republican,Gino Bulso,37
+Williamson,10-6,U.S. House,7,Republican,Jason D. Knight,3
+Williamson,10-6,U.S. House,7,Republican,Jody Barrett,59
+Williamson,10-6,U.S. House,7,Republican,Joe Leurs,0
+Williamson,10-6,U.S. House,7,Republican,Lee Reeves,20
+Williamson,10-6,U.S. House,7,Republican,Mason Foley,7
+Williamson,10-6,U.S. House,7,Republican,Matt Van Epps,76
+Williamson,10-6,U.S. House,7,Republican,Stewart Parks,3
+Williamson,10-6,U.S. House,7,Republican,Stuart Cooper,1
+Williamson,10-6,U.S. House,7,Republican,Tres Wittum,2
+Williamson,11-1,U.S. House,7,Democratic,Aftyn Behn,150
+Williamson,11-1,U.S. House,7,Democratic,Bo Mitchell,62
+Williamson,11-1,U.S. House,7,Democratic,Darden Hunter Copeland,118
+Williamson,11-1,U.S. House,7,Democratic,Vincent Dixie,20
+Williamson,11-1,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Williamson,11-1,U.S. House,7,Republican,Gino Bulso,32
+Williamson,11-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,11-1,U.S. House,7,Republican,Jody Barrett,134
+Williamson,11-1,U.S. House,7,Republican,Joe Leurs,2
+Williamson,11-1,U.S. House,7,Republican,Lee Reeves,92
+Williamson,11-1,U.S. House,7,Republican,Mason Foley,59
+Williamson,11-1,U.S. House,7,Republican,Matt Van Epps,198
+Williamson,11-1,U.S. House,7,Republican,Stewart Parks,1
+Williamson,11-1,U.S. House,7,Republican,Stuart Cooper,16
+Williamson,11-1,U.S. House,7,Republican,Tres Wittum,0
+Williamson,11-2,U.S. House,7,Democratic,Aftyn Behn,7
+Williamson,11-2,U.S. House,7,Democratic,Bo Mitchell,2
+Williamson,11-2,U.S. House,7,Democratic,Darden Hunter Copeland,5
+Williamson,11-2,U.S. House,7,Democratic,Vincent Dixie,0
+Williamson,11-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,11-2,U.S. House,7,Republican,Gino Bulso,3
+Williamson,11-2,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,11-2,U.S. House,7,Republican,Jody Barrett,3
+Williamson,11-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,11-2,U.S. House,7,Republican,Lee Reeves,1
+Williamson,11-2,U.S. House,7,Republican,Mason Foley,1
+Williamson,11-2,U.S. House,7,Republican,Matt Van Epps,15
+Williamson,11-2,U.S. House,7,Republican,Stewart Parks,0
+Williamson,11-2,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,11-2,U.S. House,7,Republican,Tres Wittum,0
+Williamson,11-3,U.S. House,7,Democratic,Aftyn Behn,33
+Williamson,11-3,U.S. House,7,Democratic,Bo Mitchell,10
+Williamson,11-3,U.S. House,7,Democratic,Darden Hunter Copeland,30
+Williamson,11-3,U.S. House,7,Democratic,Vincent Dixie,3
+Williamson,11-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,11-3,U.S. House,7,Republican,Gino Bulso,15
+Williamson,11-3,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,11-3,U.S. House,7,Republican,Jody Barrett,60
+Williamson,11-3,U.S. House,7,Republican,Joe Leurs,0
+Williamson,11-3,U.S. House,7,Republican,Lee Reeves,10
+Williamson,11-3,U.S. House,7,Republican,Mason Foley,10
+Williamson,11-3,U.S. House,7,Republican,Matt Van Epps,73
+Williamson,11-3,U.S. House,7,Republican,Stewart Parks,3
+Williamson,11-3,U.S. House,7,Republican,Stuart Cooper,4
+Williamson,11-3,U.S. House,7,Republican,Tres Wittum,1
+Williamson,11-4,U.S. House,7,Democratic,Aftyn Behn,59
+Williamson,11-4,U.S. House,7,Democratic,Bo Mitchell,32
+Williamson,11-4,U.S. House,7,Democratic,Darden Hunter Copeland,53
+Williamson,11-4,U.S. House,7,Democratic,Vincent Dixie,43
+Williamson,11-4,U.S. House,7,Republican,Adolph Agbéko Dagan,4
+Williamson,11-4,U.S. House,7,Republican,Gino Bulso,28
+Williamson,11-4,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,11-4,U.S. House,7,Republican,Jody Barrett,59
+Williamson,11-4,U.S. House,7,Republican,Joe Leurs,1
+Williamson,11-4,U.S. House,7,Republican,Lee Reeves,28
+Williamson,11-4,U.S. House,7,Republican,Mason Foley,14
+Williamson,11-4,U.S. House,7,Republican,Matt Van Epps,88
+Williamson,11-4,U.S. House,7,Republican,Stewart Parks,3
+Williamson,11-4,U.S. House,7,Republican,Stuart Cooper,1
+Williamson,11-4,U.S. House,7,Republican,Tres Wittum,0
+Williamson,11-5,U.S. House,7,Democratic,Aftyn Behn,58
+Williamson,11-5,U.S. House,7,Democratic,Bo Mitchell,44
+Williamson,11-5,U.S. House,7,Democratic,Darden Hunter Copeland,74
+Williamson,11-5,U.S. House,7,Democratic,Vincent Dixie,35
+Williamson,11-5,U.S. House,7,Republican,Adolph Agbéko Dagan,2
+Williamson,11-5,U.S. House,7,Republican,Gino Bulso,32
+Williamson,11-5,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,11-5,U.S. House,7,Republican,Jody Barrett,104
+Williamson,11-5,U.S. House,7,Republican,Joe Leurs,1
+Williamson,11-5,U.S. House,7,Republican,Lee Reeves,44
+Williamson,11-5,U.S. House,7,Republican,Mason Foley,16
+Williamson,11-5,U.S. House,7,Republican,Matt Van Epps,152
+Williamson,11-5,U.S. House,7,Republican,Stewart Parks,6
+Williamson,11-5,U.S. House,7,Republican,Stuart Cooper,2
+Williamson,11-5,U.S. House,7,Republican,Tres Wittum,1
+Williamson,12-1,U.S. House,7,Democratic,Aftyn Behn,137
+Williamson,12-1,U.S. House,7,Democratic,Bo Mitchell,47
+Williamson,12-1,U.S. House,7,Democratic,Darden Hunter Copeland,106
+Williamson,12-1,U.S. House,7,Democratic,Vincent Dixie,18
+Williamson,12-1,U.S. House,7,Republican,Adolph Agbéko Dagan,3
+Williamson,12-1,U.S. House,7,Republican,Gino Bulso,48
+Williamson,12-1,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,12-1,U.S. House,7,Republican,Jody Barrett,162
+Williamson,12-1,U.S. House,7,Republican,Joe Leurs,4
+Williamson,12-1,U.S. House,7,Republican,Lee Reeves,47
+Williamson,12-1,U.S. House,7,Republican,Mason Foley,30
+Williamson,12-1,U.S. House,7,Republican,Matt Van Epps,204
+Williamson,12-1,U.S. House,7,Republican,Stewart Parks,0
+Williamson,12-1,U.S. House,7,Republican,Stuart Cooper,12
+Williamson,12-1,U.S. House,7,Republican,Tres Wittum,1
+Williamson,2-1,U.S. House,7,Democratic,Aftyn Behn,45
+Williamson,2-1,U.S. House,7,Democratic,Bo Mitchell,29
+Williamson,2-1,U.S. House,7,Democratic,Darden Hunter Copeland,31
+Williamson,2-1,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,2-1,U.S. House,7,Republican,Adolph Agbéko Dagan,1
+Williamson,2-1,U.S. House,7,Republican,Gino Bulso,27
+Williamson,2-1,U.S. House,7,Republican,Jason D. Knight,3
+Williamson,2-1,U.S. House,7,Republican,Jody Barrett,48
+Williamson,2-1,U.S. House,7,Republican,Joe Leurs,1
+Williamson,2-1,U.S. House,7,Republican,Lee Reeves,21
+Williamson,2-1,U.S. House,7,Republican,Mason Foley,14
+Williamson,2-1,U.S. House,7,Republican,Matt Van Epps,107
+Williamson,2-1,U.S. House,7,Republican,Stewart Parks,0
+Williamson,2-1,U.S. House,7,Republican,Stuart Cooper,1
+Williamson,2-1,U.S. House,7,Republican,Tres Wittum,2
+Williamson,7-2,U.S. House,7,Democratic,Aftyn Behn,6
+Williamson,7-2,U.S. House,7,Democratic,Bo Mitchell,5
+Williamson,7-2,U.S. House,7,Democratic,Darden Hunter Copeland,13
+Williamson,7-2,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,7-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,7-2,U.S. House,7,Republican,Gino Bulso,7
+Williamson,7-2,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,7-2,U.S. House,7,Republican,Jody Barrett,6
+Williamson,7-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,7-2,U.S. House,7,Republican,Lee Reeves,6
+Williamson,7-2,U.S. House,7,Republican,Mason Foley,1
+Williamson,7-2,U.S. House,7,Republican,Matt Van Epps,11
+Williamson,7-2,U.S. House,7,Republican,Stewart Parks,0
+Williamson,7-2,U.S. House,7,Republican,Stuart Cooper,0
+Williamson,7-2,U.S. House,7,Republican,Tres Wittum,2
+Williamson,8-2,U.S. House,7,Democratic,Aftyn Behn,70
+Williamson,8-2,U.S. House,7,Democratic,Bo Mitchell,27
+Williamson,8-2,U.S. House,7,Democratic,Darden Hunter Copeland,52
+Williamson,8-2,U.S. House,7,Democratic,Vincent Dixie,5
+Williamson,8-2,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,8-2,U.S. House,7,Republican,Gino Bulso,92
+Williamson,8-2,U.S. House,7,Republican,Jason D. Knight,1
+Williamson,8-2,U.S. House,7,Republican,Jody Barrett,47
+Williamson,8-2,U.S. House,7,Republican,Joe Leurs,0
+Williamson,8-2,U.S. House,7,Republican,Lee Reeves,22
+Williamson,8-2,U.S. House,7,Republican,Mason Foley,6
+Williamson,8-2,U.S. House,7,Republican,Matt Van Epps,90
+Williamson,8-2,U.S. House,7,Republican,Stewart Parks,3
+Williamson,8-2,U.S. House,7,Republican,Stuart Cooper,2
+Williamson,8-2,U.S. House,7,Republican,Tres Wittum,0
+Williamson,8-4,U.S. House,7,Democratic,Aftyn Behn,49
+Williamson,8-4,U.S. House,7,Democratic,Bo Mitchell,37
+Williamson,8-4,U.S. House,7,Democratic,Darden Hunter Copeland,52
+Williamson,8-4,U.S. House,7,Democratic,Vincent Dixie,16
+Williamson,8-4,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,8-4,U.S. House,7,Republican,Gino Bulso,74
+Williamson,8-4,U.S. House,7,Republican,Jason D. Knight,2
+Williamson,8-4,U.S. House,7,Republican,Jody Barrett,47
+Williamson,8-4,U.S. House,7,Republican,Joe Leurs,0
+Williamson,8-4,U.S. House,7,Republican,Lee Reeves,14
+Williamson,8-4,U.S. House,7,Republican,Mason Foley,18
+Williamson,8-4,U.S. House,7,Republican,Matt Van Epps,138
+Williamson,8-4,U.S. House,7,Republican,Stewart Parks,0
+Williamson,8-4,U.S. House,7,Republican,Stuart Cooper,5
+Williamson,8-4,U.S. House,7,Republican,Tres Wittum,1
+Williamson,9-3,U.S. House,7,Democratic,Aftyn Behn,56
+Williamson,9-3,U.S. House,7,Democratic,Bo Mitchell,30
+Williamson,9-3,U.S. House,7,Democratic,Darden Hunter Copeland,131
+Williamson,9-3,U.S. House,7,Democratic,Vincent Dixie,6
+Williamson,9-3,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,9-3,U.S. House,7,Republican,Gino Bulso,28
+Williamson,9-3,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,9-3,U.S. House,7,Republican,Jody Barrett,319
+Williamson,9-3,U.S. House,7,Republican,Joe Leurs,2
+Williamson,9-3,U.S. House,7,Republican,Lee Reeves,104
+Williamson,9-3,U.S. House,7,Republican,Mason Foley,19
+Williamson,9-3,U.S. House,7,Republican,Matt Van Epps,184
+Williamson,9-3,U.S. House,7,Republican,Stewart Parks,0
+Williamson,9-3,U.S. House,7,Republican,Stuart Cooper,2
+Williamson,9-3,U.S. House,7,Republican,Tres Wittum,3
+Williamson,9-6,U.S. House,7,Democratic,Aftyn Behn,79
+Williamson,9-6,U.S. House,7,Democratic,Bo Mitchell,58
+Williamson,9-6,U.S. House,7,Democratic,Darden Hunter Copeland,102
+Williamson,9-6,U.S. House,7,Democratic,Vincent Dixie,13
+Williamson,9-6,U.S. House,7,Republican,Adolph Agbéko Dagan,0
+Williamson,9-6,U.S. House,7,Republican,Gino Bulso,44
+Williamson,9-6,U.S. House,7,Republican,Jason D. Knight,0
+Williamson,9-6,U.S. House,7,Republican,Jody Barrett,161
+Williamson,9-6,U.S. House,7,Republican,Joe Leurs,1
+Williamson,9-6,U.S. House,7,Republican,Lee Reeves,76
+Williamson,9-6,U.S. House,7,Republican,Mason Foley,12
+Williamson,9-6,U.S. House,7,Republican,Matt Van Epps,163
+Williamson,9-6,U.S. House,7,Republican,Stewart Parks,5
+Williamson,9-6,U.S. House,7,Republican,Stuart Cooper,8
+Williamson,9-6,U.S. House,7,Republican,Tres Wittum,0

--- a/2025/20251202__tn__special__general__county.csv
+++ b/2025/20251202__tn__special__general__county.csv
@@ -1,0 +1,85 @@
+county,office,district,party,candidate,votes
+Benton,U.S. House,7,Democratic,Aftyn Behn,470
+Benton,U.S. House,7,Republican,Matt Van Epps,1724
+Benton,U.S. House,7,Independent,Bobby Dodge,7
+Benton,U.S. House,7,Independent,Jon Thorp,16
+Benton,U.S. House,7,Independent,Robert James Sutherby,6
+Benton,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Cheatham,U.S. House,7,Democratic,Aftyn Behn,3910
+Cheatham,U.S. House,7,Republican,Matt Van Epps,7917
+Cheatham,U.S. House,7,Independent,Bobby Dodge,13
+Cheatham,U.S. House,7,Independent,Jon Thorp,63
+Cheatham,U.S. House,7,Independent,Robert James Sutherby,6
+Cheatham,U.S. House,7,Independent,"Teresa ""Terri"" Christie",38
+Davidson,U.S. House,7,Democratic,Aftyn Behn,32990
+Davidson,U.S. House,7,Republican,Matt Van Epps,9163
+Davidson,U.S. House,7,Independent,Bobby Dodge,46
+Davidson,U.S. House,7,Independent,Jon Thorp,135
+Davidson,U.S. House,7,Independent,Robert James Sutherby,27
+Davidson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",122
+Decatur,U.S. House,7,Democratic,Aftyn Behn,486
+Decatur,U.S. House,7,Republican,Matt Van Epps,1970
+Decatur,U.S. House,7,Independent,Bobby Dodge,2
+Decatur,U.S. House,7,Independent,Jon Thorp,13
+Decatur,U.S. House,7,Independent,Robert James Sutherby,3
+Decatur,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Dickson,U.S. House,7,Democratic,Aftyn Behn,3812
+Dickson,U.S. House,7,Republican,Matt Van Epps,9169
+Dickson,U.S. House,7,Independent,Bobby Dodge,17
+Dickson,U.S. House,7,Independent,Jon Thorp,75
+Dickson,U.S. House,7,Independent,Robert James Sutherby,8
+Dickson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",30
+Hickman,U.S. House,7,Democratic,Aftyn Behn,1157
+Hickman,U.S. House,7,Republican,Matt Van Epps,3883
+Hickman,U.S. House,7,Independent,Bobby Dodge,11
+Hickman,U.S. House,7,Independent,Jon Thorp,34
+Hickman,U.S. House,7,Independent,Robert James Sutherby,3
+Hickman,U.S. House,7,Independent,"Teresa ""Terri"" Christie",28
+Houston,U.S. House,7,Democratic,Aftyn Behn,506
+Houston,U.S. House,7,Republican,Matt Van Epps,1408
+Houston,U.S. House,7,Independent,Bobby Dodge,1
+Houston,U.S. House,7,Independent,Jon Thorp,11
+Houston,U.S. House,7,Independent,Robert James Sutherby,3
+Houston,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Humphreys,U.S. House,7,Democratic,Aftyn Behn,1159
+Humphreys,U.S. House,7,Republican,Matt Van Epps,3035
+Humphreys,U.S. House,7,Independent,Bobby Dodge,9
+Humphreys,U.S. House,7,Independent,Jon Thorp,29
+Humphreys,U.S. House,7,Independent,Robert James Sutherby,1
+Humphreys,U.S. House,7,Independent,"Teresa ""Terri"" Christie",17
+Montgomery,U.S. House,7,Democratic,Aftyn Behn,19552
+Montgomery,U.S. House,7,Republican,Matt Van Epps,22997
+Montgomery,U.S. House,7,Independent,Bobby Dodge,44
+Montgomery,U.S. House,7,Independent,Jon Thorp,254
+Montgomery,U.S. House,7,Independent,Robert James Sutherby,34
+Montgomery,U.S. House,7,Independent,"Teresa ""Terri"" Christie",237
+Perry,U.S. House,7,Democratic,Aftyn Behn,364
+Perry,U.S. House,7,Republican,Matt Van Epps,1274
+Perry,U.S. House,7,Independent,Bobby Dodge,1
+Perry,U.S. House,7,Independent,Jon Thorp,16
+Perry,U.S. House,7,Independent,Robert James Sutherby,2
+Perry,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,U.S. House,7,Democratic,Aftyn Behn,4911
+Robertson,U.S. House,7,Republican,Matt Van Epps,12608
+Robertson,U.S. House,7,Independent,Bobby Dodge,23
+Robertson,U.S. House,7,Independent,Jon Thorp,130
+Robertson,U.S. House,7,Independent,Robert James Sutherby,14
+Robertson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",54
+Stewart,U.S. House,7,Democratic,Aftyn Behn,767
+Stewart,U.S. House,7,Republican,Matt Van Epps,2588
+Stewart,U.S. House,7,Independent,Bobby Dodge,2
+Stewart,U.S. House,7,Independent,Jon Thorp,23
+Stewart,U.S. House,7,Independent,Robert James Sutherby,3
+Stewart,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Wayne,U.S. House,7,Democratic,Aftyn Behn,417
+Wayne,U.S. House,7,Republican,Matt Van Epps,2412
+Wayne,U.S. House,7,Independent,Bobby Dodge,4
+Wayne,U.S. House,7,Independent,Jon Thorp,9
+Wayne,U.S. House,7,Independent,Robert James Sutherby,3
+Wayne,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Williamson,U.S. House,7,Democratic,Aftyn Behn,10608
+Williamson,U.S. House,7,Republican,Matt Van Epps,16886
+Williamson,U.S. House,7,Independent,Bobby Dodge,18
+Williamson,U.S. House,7,Independent,Jon Thorp,124
+Williamson,U.S. House,7,Independent,Robert James Sutherby,16
+Williamson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",41

--- a/2025/20251202__tn__special__general__precinct.csv
+++ b/2025/20251202__tn__special__general__precinct.csv
@@ -1,0 +1,1375 @@
+county,precinct,office,district,party,candidate,votes
+Benton,1 Holladay,U.S. House,7,Democratic,Aftyn Behn,102
+Benton,1 Holladay,U.S. House,7,Republican,Matt Van Epps,455
+Benton,1 Holladay,U.S. House,7,Independent,Bobby Dodge,1
+Benton,1 Holladay,U.S. House,7,Independent,Jon Thorp,7
+Benton,1 Holladay,U.S. House,7,Independent,Robert James Sutherby,0
+Benton,1 Holladay,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Benton,3 Camden City Hall,U.S. House,7,Democratic,Aftyn Behn,112
+Benton,3 Camden City Hall,U.S. House,7,Republican,Matt Van Epps,359
+Benton,3 Camden City Hall,U.S. House,7,Independent,Bobby Dodge,3
+Benton,3 Camden City Hall,U.S. House,7,Independent,Jon Thorp,4
+Benton,3 Camden City Hall,U.S. House,7,Independent,Robert James Sutherby,1
+Benton,3 Camden City Hall,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Benton,4 Camden Elementary,U.S. House,7,Democratic,Aftyn Behn,131
+Benton,4 Camden Elementary,U.S. House,7,Republican,Matt Van Epps,453
+Benton,4 Camden Elementary,U.S. House,7,Independent,Bobby Dodge,0
+Benton,4 Camden Elementary,U.S. House,7,Independent,Jon Thorp,2
+Benton,4 Camden Elementary,U.S. House,7,Independent,Robert James Sutherby,1
+Benton,4 Camden Elementary,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Benton,6 Big Sandy,U.S. House,7,Democratic,Aftyn Behn,125
+Benton,6 Big Sandy,U.S. House,7,Republican,Matt Van Epps,457
+Benton,6 Big Sandy,U.S. House,7,Independent,Bobby Dodge,3
+Benton,6 Big Sandy,U.S. House,7,Independent,Jon Thorp,3
+Benton,6 Big Sandy,U.S. House,7,Independent,Robert James Sutherby,4
+Benton,6 Big Sandy,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Cheatham,1-1 Sycamore Square,U.S. House,7,Democratic,Aftyn Behn,616
+Cheatham,1-1 Sycamore Square,U.S. House,7,Republican,Matt Van Epps,819
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,Bobby Dodge,2
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,Jon Thorp,5
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,1-1 Sycamore Square,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Cheatham,2-1 East Cheatham,U.S. House,7,Democratic,Aftyn Behn,492
+Cheatham,2-1 East Cheatham,U.S. House,7,Republican,Matt Van Epps,1339
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,Bobby Dodge,3
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,Jon Thorp,7
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,Robert James Sutherby,0
+Cheatham,2-1 East Cheatham,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Cheatham,3-1 Pleasant View,U.S. House,7,Democratic,Aftyn Behn,600
+Cheatham,3-1 Pleasant View,U.S. House,7,Republican,Matt Van Epps,1616
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,Bobby Dodge,2
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,Jon Thorp,15
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,3-1 Pleasant View,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Cheatham,4-1 West Cheatham,U.S. House,7,Democratic,Aftyn Behn,265
+Cheatham,4-1 West Cheatham,U.S. House,7,Republican,Matt Van Epps,913
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,Bobby Dodge,1
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,Jon Thorp,10
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,4-1 West Cheatham,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Cheatham,4-3 Sycamore,U.S. House,7,Democratic,Aftyn Behn,193
+Cheatham,4-3 Sycamore,U.S. House,7,Republican,Matt Van Epps,632
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,Bobby Dodge,0
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,Jon Thorp,3
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,Robert James Sutherby,1
+Cheatham,4-3 Sycamore,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Democratic,Aftyn Behn,226
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Republican,Matt Van Epps,436
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,Bobby Dodge,2
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,Jon Thorp,4
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,Robert James Sutherby,0
+Cheatham,5-1 AC Church of Christ,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Cheatham,5-2 Pegram,U.S. House,7,Democratic,Aftyn Behn,550
+Cheatham,5-2 Pegram,U.S. House,7,Republican,Matt Van Epps,829
+Cheatham,5-2 Pegram,U.S. House,7,Independent,Bobby Dodge,0
+Cheatham,5-2 Pegram,U.S. House,7,Independent,Jon Thorp,6
+Cheatham,5-2 Pegram,U.S. House,7,Independent,Robert James Sutherby,2
+Cheatham,5-2 Pegram,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Cheatham,6-1 Harpeth,U.S. House,7,Democratic,Aftyn Behn,968
+Cheatham,6-1 Harpeth,U.S. House,7,Republican,Matt Van Epps,1333
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,Bobby Dodge,3
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,Jon Thorp,13
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,Robert James Sutherby,0
+Cheatham,6-1 Harpeth,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,01-1,U.S. House,7,Democratic,Aftyn Behn,589
+Davidson,01-1,U.S. House,7,Republican,Matt Van Epps,903
+Davidson,01-1,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,01-1,U.S. House,7,Independent,Jon Thorp,6
+Davidson,01-1,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,01-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,01-2,U.S. House,7,Democratic,Aftyn Behn,217
+Davidson,01-2,U.S. House,7,Republican,Matt Van Epps,234
+Davidson,01-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-2,U.S. House,7,Independent,Jon Thorp,5
+Davidson,01-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,01-3,U.S. House,7,Democratic,Aftyn Behn,445
+Davidson,01-3,U.S. House,7,Republican,Matt Van Epps,140
+Davidson,01-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,01-3,U.S. House,7,Independent,Jon Thorp,1
+Davidson,01-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,01-4,U.S. House,7,Democratic,Aftyn Behn,632
+Davidson,01-4,U.S. House,7,Republican,Matt Van Epps,87
+Davidson,01-4,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-4,U.S. House,7,Independent,Jon Thorp,2
+Davidson,01-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,01-5,U.S. House,7,Democratic,Aftyn Behn,684
+Davidson,01-5,U.S. House,7,Republican,Matt Van Epps,37
+Davidson,01-5,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,01-5,U.S. House,7,Independent,Jon Thorp,5
+Davidson,01-5,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,01-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,01-6,U.S. House,7,Democratic,Aftyn Behn,194
+Davidson,01-6,U.S. House,7,Republican,Matt Van Epps,18
+Davidson,01-6,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-6,U.S. House,7,Independent,Jon Thorp,0
+Davidson,01-6,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,01-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,01-7,U.S. House,7,Democratic,Aftyn Behn,1869
+Davidson,01-7,U.S. House,7,Republican,Matt Van Epps,101
+Davidson,01-7,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,01-7,U.S. House,7,Independent,Jon Thorp,1
+Davidson,01-7,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,01-7,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Davidson,02-1,U.S. House,7,Democratic,Aftyn Behn,339
+Davidson,02-1,U.S. House,7,Republican,Matt Van Epps,34
+Davidson,02-1,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,02-1,U.S. House,7,Independent,Jon Thorp,1
+Davidson,02-1,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,02-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,02-2,U.S. House,7,Democratic,Aftyn Behn,629
+Davidson,02-2,U.S. House,7,Republican,Matt Van Epps,33
+Davidson,02-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,02-2,U.S. House,7,Independent,Jon Thorp,0
+Davidson,02-2,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,02-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Davidson,02-3,U.S. House,7,Democratic,Aftyn Behn,273
+Davidson,02-3,U.S. House,7,Republican,Matt Van Epps,29
+Davidson,02-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,02-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,02-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,02-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,02-4,U.S. House,7,Democratic,Aftyn Behn,788
+Davidson,02-4,U.S. House,7,Republican,Matt Van Epps,103
+Davidson,02-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,02-4,U.S. House,7,Independent,Jon Thorp,0
+Davidson,02-4,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,02-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",8
+Davidson,02-5,U.S. House,7,Democratic,Aftyn Behn,1620
+Davidson,02-5,U.S. House,7,Republican,Matt Van Epps,84
+Davidson,02-5,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,02-5,U.S. House,7,Independent,Jon Thorp,3
+Davidson,02-5,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,02-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Davidson,03-1,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,03-1,U.S. House,7,Republican,Matt Van Epps,2
+Davidson,03-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,03-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,03-2,U.S. House,7,Democratic,Aftyn Behn,1534
+Davidson,03-2,U.S. House,7,Republican,Matt Van Epps,271
+Davidson,03-2,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,03-2,U.S. House,7,Independent,Jon Thorp,2
+Davidson,03-2,U.S. House,7,Independent,Robert James Sutherby,3
+Davidson,03-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Davidson,03-3,U.S. House,7,Democratic,Aftyn Behn,61
+Davidson,03-3,U.S. House,7,Republican,Matt Van Epps,53
+Davidson,03-3,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-3,U.S. House,7,Independent,Jon Thorp,1
+Davidson,03-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,03-5,U.S. House,7,Democratic,Aftyn Behn,231
+Davidson,03-5,U.S. House,7,Republican,Matt Van Epps,82
+Davidson,03-5,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-5,U.S. House,7,Independent,Jon Thorp,2
+Davidson,03-5,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,03-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,03-6,U.S. House,7,Democratic,Aftyn Behn,236
+Davidson,03-6,U.S. House,7,Republican,Matt Van Epps,93
+Davidson,03-6,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,03-6,U.S. House,7,Independent,Jon Thorp,0
+Davidson,03-6,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,03-8,U.S. House,7,Democratic,Aftyn Behn,1303
+Davidson,03-8,U.S. House,7,Republican,Matt Van Epps,78
+Davidson,03-8,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,03-8,U.S. House,7,Independent,Jon Thorp,3
+Davidson,03-8,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,03-8,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,05-1,U.S. House,7,Democratic,Aftyn Behn,40
+Davidson,05-1,U.S. House,7,Republican,Matt Van Epps,13
+Davidson,05-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,05-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,05-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,05-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-2,U.S. House,7,Democratic,Aftyn Behn,82
+Davidson,10-2,U.S. House,7,Republican,Matt Van Epps,154
+Davidson,10-2,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,10-2,U.S. House,7,Independent,Jon Thorp,1
+Davidson,10-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,10-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-3,U.S. House,7,Democratic,Aftyn Behn,169
+Davidson,10-3,U.S. House,7,Republican,Matt Van Epps,232
+Davidson,10-3,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,10-3,U.S. House,7,Independent,Jon Thorp,2
+Davidson,10-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,10-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-7,U.S. House,7,Democratic,Aftyn Behn,23
+Davidson,10-7,U.S. House,7,Republican,Matt Van Epps,9
+Davidson,10-7,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,10-7,U.S. House,7,Independent,Jon Thorp,0
+Davidson,10-7,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,10-7,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,10-9,U.S. House,7,Democratic,Aftyn Behn,93
+Davidson,10-9,U.S. House,7,Republican,Matt Van Epps,233
+Davidson,10-9,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,10-9,U.S. House,7,Independent,Jon Thorp,2
+Davidson,10-9,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,10-9,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,15-2,U.S. House,7,Democratic,Aftyn Behn,44
+Davidson,15-2,U.S. House,7,Republican,Matt Van Epps,10
+Davidson,15-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,15-2,U.S. House,7,Independent,Jon Thorp,0
+Davidson,15-2,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,15-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,16-1,U.S. House,7,Democratic,Aftyn Behn,183
+Davidson,16-1,U.S. House,7,Republican,Matt Van Epps,56
+Davidson,16-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,16-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,16-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,16-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,16-3,U.S. House,7,Democratic,Aftyn Behn,50
+Davidson,16-3,U.S. House,7,Republican,Matt Van Epps,17
+Davidson,16-3,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,16-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,16-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,16-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,17-1,U.S. House,7,Democratic,Aftyn Behn,477
+Davidson,17-1,U.S. House,7,Republican,Matt Van Epps,211
+Davidson,17-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,17-1,U.S. House,7,Independent,Jon Thorp,2
+Davidson,17-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,17-2,U.S. House,7,Democratic,Aftyn Behn,374
+Davidson,17-2,U.S. House,7,Republican,Matt Van Epps,78
+Davidson,17-2,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,17-2,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,17-3,U.S. House,7,Democratic,Aftyn Behn,80
+Davidson,17-3,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,17-3,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,17-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,17-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,17-4,U.S. House,7,Democratic,Aftyn Behn,383
+Davidson,17-4,U.S. House,7,Republican,Matt Van Epps,89
+Davidson,17-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,17-4,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-4,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,17-5,U.S. House,7,Democratic,Aftyn Behn,102
+Davidson,17-5,U.S. House,7,Republican,Matt Van Epps,55
+Davidson,17-5,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,17-5,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-5,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Davidson,17-6,U.S. House,7,Democratic,Aftyn Behn,94
+Davidson,17-6,U.S. House,7,Republican,Matt Van Epps,6
+Davidson,17-6,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,17-6,U.S. House,7,Independent,Jon Thorp,0
+Davidson,17-6,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,17-7,U.S. House,7,Democratic,Aftyn Behn,1328
+Davidson,17-7,U.S. House,7,Republican,Matt Van Epps,284
+Davidson,17-7,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,17-7,U.S. House,7,Independent,Jon Thorp,2
+Davidson,17-7,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,17-7,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,17-8,U.S. House,7,Democratic,Aftyn Behn,595
+Davidson,17-8,U.S. House,7,Republican,Matt Van Epps,135
+Davidson,17-8,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,17-8,U.S. House,7,Independent,Jon Thorp,1
+Davidson,17-8,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,17-8,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,18-1,U.S. House,7,Democratic,Aftyn Behn,732
+Davidson,18-1,U.S. House,7,Republican,Matt Van Epps,102
+Davidson,18-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,18-1,U.S. House,7,Independent,Jon Thorp,2
+Davidson,18-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,18-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,18-2,U.S. House,7,Democratic,Aftyn Behn,700
+Davidson,18-2,U.S. House,7,Republican,Matt Van Epps,170
+Davidson,18-2,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,18-2,U.S. House,7,Independent,Jon Thorp,4
+Davidson,18-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,18-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,18-3,U.S. House,7,Democratic,Aftyn Behn,2200
+Davidson,18-3,U.S. House,7,Republican,Matt Van Epps,369
+Davidson,18-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,18-3,U.S. House,7,Independent,Jon Thorp,10
+Davidson,18-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,18-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Davidson,19-1,U.S. House,7,Democratic,Aftyn Behn,111
+Davidson,19-1,U.S. House,7,Republican,Matt Van Epps,47
+Davidson,19-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,19-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,19-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,19-2,U.S. House,7,Democratic,Aftyn Behn,1209
+Davidson,19-2,U.S. House,7,Republican,Matt Van Epps,339
+Davidson,19-2,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,19-2,U.S. House,7,Independent,Jon Thorp,5
+Davidson,19-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,19-3,U.S. House,7,Democratic,Aftyn Behn,698
+Davidson,19-3,U.S. House,7,Republican,Matt Van Epps,111
+Davidson,19-3,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,19-3,U.S. House,7,Independent,Jon Thorp,0
+Davidson,19-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,19-4,U.S. House,7,Democratic,Aftyn Behn,658
+Davidson,19-4,U.S. House,7,Republican,Matt Van Epps,349
+Davidson,19-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,19-4,U.S. House,7,Independent,Jon Thorp,6
+Davidson,19-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,19-5,U.S. House,7,Democratic,Aftyn Behn,793
+Davidson,19-5,U.S. House,7,Republican,Matt Van Epps,443
+Davidson,19-5,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,19-5,U.S. House,7,Independent,Jon Thorp,3
+Davidson,19-5,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,19-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,20-1,U.S. House,7,Democratic,Aftyn Behn,157
+Davidson,20-1,U.S. House,7,Republican,Matt Van Epps,72
+Davidson,20-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,20-1,U.S. House,7,Independent,Jon Thorp,2
+Davidson,20-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,20-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,20-2,U.S. House,7,Democratic,Aftyn Behn,1155
+Davidson,20-2,U.S. House,7,Republican,Matt Van Epps,394
+Davidson,20-2,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,20-2,U.S. House,7,Independent,Jon Thorp,6
+Davidson,20-2,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,20-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Davidson,20-3,U.S. House,7,Democratic,Aftyn Behn,1547
+Davidson,20-3,U.S. House,7,Republican,Matt Van Epps,711
+Davidson,20-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,20-3,U.S. House,7,Independent,Jon Thorp,21
+Davidson,20-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,20-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Davidson,20-5,U.S. House,7,Democratic,Aftyn Behn,437
+Davidson,20-5,U.S. House,7,Republican,Matt Van Epps,125
+Davidson,20-5,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,20-5,U.S. House,7,Independent,Jon Thorp,0
+Davidson,20-5,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,20-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,21-1,U.S. House,7,Democratic,Aftyn Behn,528
+Davidson,21-1,U.S. House,7,Republican,Matt Van Epps,139
+Davidson,21-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,21-1,U.S. House,7,Independent,Jon Thorp,4
+Davidson,21-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,21-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,21-2,U.S. House,7,Democratic,Aftyn Behn,564
+Davidson,21-2,U.S. House,7,Republican,Matt Van Epps,80
+Davidson,21-2,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,21-2,U.S. House,7,Independent,Jon Thorp,0
+Davidson,21-2,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,21-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,21-3,U.S. House,7,Democratic,Aftyn Behn,1085
+Davidson,21-3,U.S. House,7,Republican,Matt Van Epps,149
+Davidson,21-3,U.S. House,7,Independent,Bobby Dodge,3
+Davidson,21-3,U.S. House,7,Independent,Jon Thorp,5
+Davidson,21-3,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,21-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Davidson,21-4,U.S. House,7,Democratic,Aftyn Behn,600
+Davidson,21-4,U.S. House,7,Republican,Matt Van Epps,58
+Davidson,21-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,21-4,U.S. House,7,Independent,Jon Thorp,0
+Davidson,21-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,21-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Davidson,24-1,U.S. House,7,Democratic,Aftyn Behn,24
+Davidson,24-1,U.S. House,7,Republican,Matt Van Epps,4
+Davidson,24-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,24-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,24-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,24-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,24-3,U.S. House,7,Democratic,Aftyn Behn,594
+Davidson,24-3,U.S. House,7,Republican,Matt Van Epps,128
+Davidson,24-3,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,24-3,U.S. House,7,Independent,Jon Thorp,2
+Davidson,24-3,U.S. House,7,Independent,Robert James Sutherby,1
+Davidson,24-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,24-4,U.S. House,7,Democratic,Aftyn Behn,204
+Davidson,24-4,U.S. House,7,Republican,Matt Van Epps,34
+Davidson,24-4,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,24-4,U.S. House,7,Independent,Jon Thorp,1
+Davidson,24-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,24-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,24-5,U.S. House,7,Democratic,Aftyn Behn,1770
+Davidson,24-5,U.S. House,7,Republican,Matt Van Epps,427
+Davidson,24-5,U.S. House,7,Independent,Bobby Dodge,1
+Davidson,24-5,U.S. House,7,Independent,Jon Thorp,6
+Davidson,24-5,U.S. House,7,Independent,Robert James Sutherby,2
+Davidson,24-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Davidson,26-1,U.S. House,7,Democratic,Aftyn Behn,349
+Davidson,26-1,U.S. House,7,Republican,Matt Van Epps,117
+Davidson,26-1,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,26-1,U.S. House,7,Independent,Jon Thorp,0
+Davidson,26-1,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,26-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,35-4,U.S. House,7,Democratic,Aftyn Behn,89
+Davidson,35-4,U.S. House,7,Republican,Matt Van Epps,29
+Davidson,35-4,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,35-4,U.S. House,7,Independent,Jon Thorp,0
+Davidson,35-4,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,35-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Davidson,35-5,U.S. House,7,Democratic,Aftyn Behn,1025
+Davidson,35-5,U.S. House,7,Republican,Matt Van Epps,798
+Davidson,35-5,U.S. House,7,Independent,Bobby Dodge,2
+Davidson,35-5,U.S. House,7,Independent,Jon Thorp,13
+Davidson,35-5,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,35-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Davidson,All County Precinct,U.S. House,7,Democratic,Aftyn Behn,0
+Davidson,All County Precinct,U.S. House,7,Republican,Matt Van Epps,0
+Davidson,All County Precinct,U.S. House,7,Independent,Bobby Dodge,0
+Davidson,All County Precinct,U.S. House,7,Independent,Jon Thorp,0
+Davidson,All County Precinct,U.S. House,7,Independent,Robert James Sutherby,0
+Davidson,All County Precinct,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,1-1 Dunbar,U.S. House,7,Democratic,Aftyn Behn,69
+Decatur,1-1 Dunbar,U.S. House,7,Republican,Matt Van Epps,270
+Decatur,1-1 Dunbar,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,1-1 Dunbar,U.S. House,7,Independent,Jon Thorp,0
+Decatur,1-1 Dunbar,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,1-1 Dunbar,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,2-1 Scotts Hill,U.S. House,7,Democratic,Aftyn Behn,43
+Decatur,2-1 Scotts Hill,U.S. House,7,Republican,Matt Van Epps,212
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,Jon Thorp,1
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,2-1 Scotts Hill,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,3-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,61
+Decatur,3-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,219
+Decatur,3-1 Decaturville,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,3-1 Decaturville,U.S. House,7,Independent,Jon Thorp,2
+Decatur,3-1 Decaturville,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,3-1 Decaturville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,4-1 Decaturville,U.S. House,7,Democratic,Aftyn Behn,89
+Decatur,4-1 Decaturville,U.S. House,7,Republican,Matt Van Epps,189
+Decatur,4-1 Decaturville,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,4-1 Decaturville,U.S. House,7,Independent,Jon Thorp,0
+Decatur,4-1 Decaturville,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,4-1 Decaturville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Decatur,5-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,56
+Decatur,5-1 Parsons,U.S. House,7,Republican,Matt Van Epps,182
+Decatur,5-1 Parsons,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,5-1 Parsons,U.S. House,7,Independent,Jon Thorp,2
+Decatur,5-1 Parsons,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,5-1 Parsons,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,6-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,44
+Decatur,6-1 Parsons,U.S. House,7,Republican,Matt Van Epps,164
+Decatur,6-1 Parsons,U.S. House,7,Independent,Bobby Dodge,1
+Decatur,6-1 Parsons,U.S. House,7,Independent,Jon Thorp,3
+Decatur,6-1 Parsons,U.S. House,7,Independent,Robert James Sutherby,0
+Decatur,6-1 Parsons,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,7-1 Crossroads,U.S. House,7,Democratic,Aftyn Behn,52
+Decatur,7-1 Crossroads,U.S. House,7,Republican,Matt Van Epps,249
+Decatur,7-1 Crossroads,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,7-1 Crossroads,U.S. House,7,Independent,Jon Thorp,1
+Decatur,7-1 Crossroads,U.S. House,7,Independent,Robert James Sutherby,1
+Decatur,7-1 Crossroads,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Decatur,8-1 Parsons,U.S. House,7,Democratic,Aftyn Behn,37
+Decatur,8-1 Parsons,U.S. House,7,Republican,Matt Van Epps,242
+Decatur,8-1 Parsons,U.S. House,7,Independent,Bobby Dodge,1
+Decatur,8-1 Parsons,U.S. House,7,Independent,Jon Thorp,2
+Decatur,8-1 Parsons,U.S. House,7,Independent,Robert James Sutherby,1
+Decatur,8-1 Parsons,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Decatur,9-1 Beacon,U.S. House,7,Democratic,Aftyn Behn,35
+Decatur,9-1 Beacon,U.S. House,7,Republican,Matt Van Epps,243
+Decatur,9-1 Beacon,U.S. House,7,Independent,Bobby Dodge,0
+Decatur,9-1 Beacon,U.S. House,7,Independent,Jon Thorp,2
+Decatur,9-1 Beacon,U.S. House,7,Independent,Robert James Sutherby,1
+Decatur,9-1 Beacon,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Dickson,1-1,U.S. House,7,Democratic,Aftyn Behn,301
+Dickson,1-1,U.S. House,7,Republican,Matt Van Epps,831
+Dickson,1-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,1-1,U.S. House,7,Independent,Jon Thorp,3
+Dickson,1-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,1-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Dickson,10-1,U.S. House,7,Democratic,Aftyn Behn,399
+Dickson,10-1,U.S. House,7,Republican,Matt Van Epps,844
+Dickson,10-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,10-1,U.S. House,7,Independent,Jon Thorp,10
+Dickson,10-1,U.S. House,7,Independent,Robert James Sutherby,2
+Dickson,10-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Dickson,11-1,U.S. House,7,Democratic,Aftyn Behn,358
+Dickson,11-1,U.S. House,7,Republican,Matt Van Epps,594
+Dickson,11-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,11-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,11-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,11-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Dickson,12-1,U.S. House,7,Democratic,Aftyn Behn,409
+Dickson,12-1,U.S. House,7,Republican,Matt Van Epps,950
+Dickson,12-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,12-1,U.S. House,7,Independent,Jon Thorp,9
+Dickson,12-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,12-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,2-1,U.S. House,7,Democratic,Aftyn Behn,259
+Dickson,2-1,U.S. House,7,Republican,Matt Van Epps,814
+Dickson,2-1,U.S. House,7,Independent,Bobby Dodge,0
+Dickson,2-1,U.S. House,7,Independent,Jon Thorp,4
+Dickson,2-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,2-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Dickson,3-1,U.S. House,7,Democratic,Aftyn Behn,233
+Dickson,3-1,U.S. House,7,Republican,Matt Van Epps,888
+Dickson,3-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,3-1,U.S. House,7,Independent,Jon Thorp,7
+Dickson,3-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,3-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,4-1,U.S. House,7,Democratic,Aftyn Behn,240
+Dickson,4-1,U.S. House,7,Republican,Matt Van Epps,742
+Dickson,4-1,U.S. House,7,Independent,Bobby Dodge,3
+Dickson,4-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,4-1,U.S. House,7,Independent,Robert James Sutherby,2
+Dickson,4-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Dickson,5-1,U.S. House,7,Democratic,Aftyn Behn,275
+Dickson,5-1,U.S. House,7,Republican,Matt Van Epps,673
+Dickson,5-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,5-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,5-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,5-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,6-1,U.S. House,7,Democratic,Aftyn Behn,151
+Dickson,6-1,U.S. House,7,Republican,Matt Van Epps,340
+Dickson,6-1,U.S. House,7,Independent,Bobby Dodge,0
+Dickson,6-1,U.S. House,7,Independent,Jon Thorp,2
+Dickson,6-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,6-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Dickson,6-2,U.S. House,7,Democratic,Aftyn Behn,224
+Dickson,6-2,U.S. House,7,Republican,Matt Van Epps,694
+Dickson,6-2,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,6-2,U.S. House,7,Independent,Jon Thorp,4
+Dickson,6-2,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,6-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,7-1,U.S. House,7,Democratic,Aftyn Behn,328
+Dickson,7-1,U.S. House,7,Republican,Matt Van Epps,685
+Dickson,7-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,7-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,7-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,7-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Dickson,8-1,U.S. House,7,Democratic,Aftyn Behn,288
+Dickson,8-1,U.S. House,7,Republican,Matt Van Epps,408
+Dickson,8-1,U.S. House,7,Independent,Bobby Dodge,1
+Dickson,8-1,U.S. House,7,Independent,Jon Thorp,5
+Dickson,8-1,U.S. House,7,Independent,Robert James Sutherby,1
+Dickson,8-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Dickson,9-1,U.S. House,7,Democratic,Aftyn Behn,347
+Dickson,9-1,U.S. House,7,Republican,Matt Van Epps,706
+Dickson,9-1,U.S. House,7,Independent,Bobby Dodge,2
+Dickson,9-1,U.S. House,7,Independent,Jon Thorp,11
+Dickson,9-1,U.S. House,7,Independent,Robert James Sutherby,0
+Dickson,9-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Hickman,1-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,66
+Hickman,1-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,215
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,Jon Thorp,2
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,1-1 Nunnelly,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Hickman,1-2 Pinewood,U.S. House,7,Democratic,Aftyn Behn,67
+Hickman,1-2 Pinewood,U.S. House,7,Republican,Matt Van Epps,254
+Hickman,1-2 Pinewood,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,1-2 Pinewood,U.S. House,7,Independent,Jon Thorp,1
+Hickman,1-2 Pinewood,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,1-2 Pinewood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,2-2 Fairfield,U.S. House,7,Democratic,Aftyn Behn,29
+Hickman,2-2 Fairfield,U.S. House,7,Republican,Matt Van Epps,116
+Hickman,2-2 Fairfield,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,2-2 Fairfield,U.S. House,7,Independent,Jon Thorp,2
+Hickman,2-2 Fairfield,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,2-2 Fairfield,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Hickman,2-3 East Bank,U.S. House,7,Democratic,Aftyn Behn,138
+Hickman,2-3 East Bank,U.S. House,7,Republican,Matt Van Epps,402
+Hickman,2-3 East Bank,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,2-3 East Bank,U.S. House,7,Independent,Jon Thorp,2
+Hickman,2-3 East Bank,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,2-3 East Bank,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Hickman,3-1 East CC,U.S. House,7,Democratic,Aftyn Behn,135
+Hickman,3-1 East CC,U.S. House,7,Republican,Matt Van Epps,428
+Hickman,3-1 East CC,U.S. House,7,Independent,Bobby Dodge,2
+Hickman,3-1 East CC,U.S. House,7,Independent,Jon Thorp,4
+Hickman,3-1 East CC,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,3-1 East CC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Hickman,4-1 Lake Benson,U.S. House,7,Democratic,Aftyn Behn,193
+Hickman,4-1 Lake Benson,U.S. House,7,Republican,Matt Van Epps,664
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,Bobby Dodge,2
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,Jon Thorp,1
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,Robert James Sutherby,1
+Hickman,4-1 Lake Benson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Democratic,Aftyn Behn,66
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Republican,Matt Van Epps,259
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,Jon Thorp,5
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,5-1 Mt. Pleasant,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Hickman,5-2 Middle School,U.S. House,7,Democratic,Aftyn Behn,50
+Hickman,5-2 Middle School,U.S. House,7,Republican,Matt Van Epps,153
+Hickman,5-2 Middle School,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,5-2 Middle School,U.S. House,7,Independent,Jon Thorp,3
+Hickman,5-2 Middle School,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,5-2 Middle School,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,5-3 Shady Grove,U.S. House,7,Democratic,Aftyn Behn,68
+Hickman,5-3 Shady Grove,U.S. House,7,Republican,Matt Van Epps,186
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,Jon Thorp,0
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,5-3 Shady Grove,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Hickman,6-1 Justice Center,U.S. House,7,Democratic,Aftyn Behn,204
+Hickman,6-1 Justice Center,U.S. House,7,Republican,Matt Van Epps,559
+Hickman,6-1 Justice Center,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,6-1 Justice Center,U.S. House,7,Independent,Jon Thorp,3
+Hickman,6-1 Justice Center,U.S. House,7,Independent,Robert James Sutherby,1
+Hickman,6-1 Justice Center,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Hickman,7-1 Nunnelly,U.S. House,7,Democratic,Aftyn Behn,19
+Hickman,7-1 Nunnelly,U.S. House,7,Republican,Matt Van Epps,112
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,Bobby Dodge,0
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,Jon Thorp,3
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,7-1 Nunnelly,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Hickman,7-2 Pleasantville,U.S. House,7,Democratic,Aftyn Behn,8
+Hickman,7-2 Pleasantville,U.S. House,7,Republican,Matt Van Epps,86
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,Jon Thorp,1
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,7-2 Pleasantville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,7-3 Brushy,U.S. House,7,Democratic,Aftyn Behn,94
+Hickman,7-3 Brushy,U.S. House,7,Republican,Matt Van Epps,292
+Hickman,7-3 Brushy,U.S. House,7,Independent,Bobby Dodge,2
+Hickman,7-3 Brushy,U.S. House,7,Independent,Jon Thorp,0
+Hickman,7-3 Brushy,U.S. House,7,Independent,Robert James Sutherby,0
+Hickman,7-3 Brushy,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Hickman,7-4 Coble,U.S. House,7,Democratic,Aftyn Behn,20
+Hickman,7-4 Coble,U.S. House,7,Republican,Matt Van Epps,157
+Hickman,7-4 Coble,U.S. House,7,Independent,Bobby Dodge,1
+Hickman,7-4 Coble,U.S. House,7,Independent,Jon Thorp,7
+Hickman,7-4 Coble,U.S. House,7,Independent,Robert James Sutherby,1
+Hickman,7-4 Coble,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Houston,Arlington,U.S. House,7,Democratic,Aftyn Behn,85
+Houston,Arlington,U.S. House,7,Republican,Matt Van Epps,245
+Houston,Arlington,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Arlington,U.S. House,7,Independent,Jon Thorp,0
+Houston,Arlington,U.S. House,7,Independent,Robert James Sutherby,1
+Houston,Arlington,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Houston,Erin,U.S. House,7,Democratic,Aftyn Behn,62
+Houston,Erin,U.S. House,7,Republican,Matt Van Epps,125
+Houston,Erin,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Erin,U.S. House,7,Independent,Jon Thorp,3
+Houston,Erin,U.S. House,7,Independent,Robert James Sutherby,2
+Houston,Erin,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Houston,Erin Elementary,U.S. House,7,Democratic,Aftyn Behn,75
+Houston,Erin Elementary,U.S. House,7,Republican,Matt Van Epps,187
+Houston,Erin Elementary,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Erin Elementary,U.S. House,7,Independent,Jon Thorp,1
+Houston,Erin Elementary,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Erin Elementary,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Houston,Griffins Chapel,U.S. House,7,Democratic,Aftyn Behn,64
+Houston,Griffins Chapel,U.S. House,7,Republican,Matt Van Epps,246
+Houston,Griffins Chapel,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Griffins Chapel,U.S. House,7,Independent,Jon Thorp,1
+Houston,Griffins Chapel,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Griffins Chapel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Houston,Houston Co Middle,U.S. House,7,Democratic,Aftyn Behn,70
+Houston,Houston Co Middle,U.S. House,7,Republican,Matt Van Epps,195
+Houston,Houston Co Middle,U.S. House,7,Independent,Bobby Dodge,1
+Houston,Houston Co Middle,U.S. House,7,Independent,Jon Thorp,0
+Houston,Houston Co Middle,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Houston Co Middle,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Houston,Stewart,U.S. House,7,Democratic,Aftyn Behn,68
+Houston,Stewart,U.S. House,7,Republican,Matt Van Epps,223
+Houston,Stewart,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Stewart,U.S. House,7,Independent,Jon Thorp,3
+Houston,Stewart,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Stewart,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Houston,Tennessee Ridge,U.S. House,7,Democratic,Aftyn Behn,82
+Houston,Tennessee Ridge,U.S. House,7,Republican,Matt Van Epps,187
+Houston,Tennessee Ridge,U.S. House,7,Independent,Bobby Dodge,0
+Houston,Tennessee Ridge,U.S. House,7,Independent,Jon Thorp,3
+Houston,Tennessee Ridge,U.S. House,7,Independent,Robert James Sutherby,0
+Houston,Tennessee Ridge,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,1-1 Jera,U.S. House,7,Democratic,Aftyn Behn,34
+Humphreys,1-1 Jera,U.S. House,7,Republican,Matt Van Epps,68
+Humphreys,1-1 Jera,U.S. House,7,Independent,Bobby Dodge,0
+Humphreys,1-1 Jera,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,1-1 Jera,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,1-1 Jera,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,1-2 Compassion Church,U.S. House,7,Democratic,Aftyn Behn,165
+Humphreys,1-2 Compassion Church,U.S. House,7,Republican,Matt Van Epps,454
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,Bobby Dodge,2
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,1-2 Compassion Church,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Humphreys,2-3 WCN,U.S. House,7,Democratic,Aftyn Behn,163
+Humphreys,2-3 WCN,U.S. House,7,Republican,Matt Van Epps,361
+Humphreys,2-3 WCN,U.S. House,7,Independent,Bobby Dodge,1
+Humphreys,2-3 WCN,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,2-3 WCN,U.S. House,7,Independent,Robert James Sutherby,1
+Humphreys,2-3 WCN,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Humphreys,3-4 Apex,U.S. House,7,Democratic,Aftyn Behn,153
+Humphreys,3-4 Apex,U.S. House,7,Republican,Matt Van Epps,268
+Humphreys,3-4 Apex,U.S. House,7,Independent,Bobby Dodge,1
+Humphreys,3-4 Apex,U.S. House,7,Independent,Jon Thorp,4
+Humphreys,3-4 Apex,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,3-4 Apex,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Humphreys,4-5 Woodland,U.S. House,7,Democratic,Aftyn Behn,170
+Humphreys,4-5 Woodland,U.S. House,7,Republican,Matt Van Epps,449
+Humphreys,4-5 Woodland,U.S. House,7,Independent,Bobby Dodge,2
+Humphreys,4-5 Woodland,U.S. House,7,Independent,Jon Thorp,2
+Humphreys,4-5 Woodland,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,4-5 Woodland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,5-6 Wildwood,U.S. House,7,Democratic,Aftyn Behn,185
+Humphreys,5-6 Wildwood,U.S. House,7,Republican,Matt Van Epps,430
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,Bobby Dodge,1
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,Jon Thorp,1
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,5-6 Wildwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Humphreys,6-7 South McEwen,U.S. House,7,Democratic,Aftyn Behn,135
+Humphreys,6-7 South McEwen,U.S. House,7,Republican,Matt Van Epps,440
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,Bobby Dodge,2
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,Jon Thorp,4
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,6-7 South McEwen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Humphreys,7-8 North McEwen,U.S. House,7,Democratic,Aftyn Behn,154
+Humphreys,7-8 North McEwen,U.S. House,7,Republican,Matt Van Epps,565
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,Bobby Dodge,0
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,Jon Thorp,12
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,Robert James Sutherby,0
+Humphreys,7-8 North McEwen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,10 Minglewood,U.S. House,7,Democratic,Aftyn Behn,528
+Montgomery,10 Minglewood,U.S. House,7,Republican,Matt Van Epps,325
+Montgomery,10 Minglewood,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,10 Minglewood,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,10 Minglewood,U.S. House,7,Independent,Robert James Sutherby,3
+Montgomery,10 Minglewood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",12
+Montgomery,11A Mosaic,U.S. House,7,Democratic,Aftyn Behn,308
+Montgomery,11A Mosaic,U.S. House,7,Republican,Matt Van Epps,326
+Montgomery,11A Mosaic,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,11A Mosaic,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,11A Mosaic,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,11A Mosaic,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Montgomery,11B Northwest,U.S. House,7,Democratic,Aftyn Behn,402
+Montgomery,11B Northwest,U.S. House,7,Republican,Matt Van Epps,293
+Montgomery,11B Northwest,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,11B Northwest,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,11B Northwest,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,11B Northwest,U.S. House,7,Independent,"Teresa ""Terri"" Christie",8
+Montgomery,12 West Creek,U.S. House,7,Democratic,Aftyn Behn,801
+Montgomery,12 West Creek,U.S. House,7,Republican,Matt Van Epps,398
+Montgomery,12 West Creek,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,12 West Creek,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,12 West Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,12 West Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Montgomery,13A Byrns Darden,U.S. House,7,Democratic,Aftyn Behn,439
+Montgomery,13A Byrns Darden,U.S. House,7,Republican,Matt Van Epps,208
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,Jon Thorp,3
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,13A Byrns Darden,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,13B Kenwood,U.S. House,7,Democratic,Aftyn Behn,504
+Montgomery,13B Kenwood,U.S. House,7,Republican,Matt Van Epps,298
+Montgomery,13B Kenwood,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,13B Kenwood,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,13B Kenwood,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,13B Kenwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Montgomery,14A St B ELC,U.S. House,7,Democratic,Aftyn Behn,472
+Montgomery,14A St B ELC,U.S. House,7,Republican,Matt Van Epps,213
+Montgomery,14A St B ELC,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,14A St B ELC,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,14A St B ELC,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,14A St B ELC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,14B First MBC,U.S. House,7,Democratic,Aftyn Behn,483
+Montgomery,14B First MBC,U.S. House,7,Republican,Matt Van Epps,430
+Montgomery,14B First MBC,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,14B First MBC,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,14B First MBC,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,14B First MBC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,15A Excell,U.S. House,7,Democratic,Aftyn Behn,702
+Montgomery,15A Excell,U.S. House,7,Republican,Matt Van Epps,1258
+Montgomery,15A Excell,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,15A Excell,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,15A Excell,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,15A Excell,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,15B Sango,U.S. House,7,Democratic,Aftyn Behn,537
+Montgomery,15B Sango,U.S. House,7,Republican,Matt Van Epps,1188
+Montgomery,15B Sango,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,15B Sango,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,15B Sango,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,15B Sango,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,16A Ringgold,U.S. House,7,Democratic,Aftyn Behn,476
+Montgomery,16A Ringgold,U.S. House,7,Republican,Matt Van Epps,269
+Montgomery,16A Ringgold,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,16A Ringgold,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,16A Ringgold,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,16A Ringgold,U.S. House,7,Independent,"Teresa ""Terri"" Christie",8
+Montgomery,16B New Providence,U.S. House,7,Democratic,Aftyn Behn,392
+Montgomery,16B New Providence,U.S. House,7,Republican,Matt Van Epps,302
+Montgomery,16B New Providence,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,16B New Providence,U.S. House,7,Independent,Jon Thorp,3
+Montgomery,16B New Providence,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,16B New Providence,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,17A Grace,U.S. House,7,Democratic,Aftyn Behn,531
+Montgomery,17A Grace,U.S. House,7,Republican,Matt Van Epps,372
+Montgomery,17A Grace,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,17A Grace,U.S. House,7,Independent,Jon Thorp,2
+Montgomery,17A Grace,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,17A Grace,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,17B Glenellen,U.S. House,7,Democratic,Aftyn Behn,526
+Montgomery,17B Glenellen,U.S. House,7,Republican,Matt Van Epps,380
+Montgomery,17B Glenellen,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,17B Glenellen,U.S. House,7,Independent,Jon Thorp,8
+Montgomery,17B Glenellen,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,17B Glenellen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",9
+Montgomery,18A Barkers Mill,U.S. House,7,Democratic,Aftyn Behn,592
+Montgomery,18A Barkers Mill,U.S. House,7,Republican,Matt Van Epps,299
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,18A Barkers Mill,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Montgomery,18B Pisgah,U.S. House,7,Democratic,Aftyn Behn,476
+Montgomery,18B Pisgah,U.S. House,7,Republican,Matt Van Epps,340
+Montgomery,18B Pisgah,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,18B Pisgah,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,18B Pisgah,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,18B Pisgah,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,19A Rossview,U.S. House,7,Democratic,Aftyn Behn,742
+Montgomery,19A Rossview,U.S. House,7,Republican,Matt Van Epps,986
+Montgomery,19A Rossview,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,19A Rossview,U.S. House,7,Independent,Jon Thorp,13
+Montgomery,19A Rossview,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,19A Rossview,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,19B South Guthrie,U.S. House,7,Democratic,Aftyn Behn,452
+Montgomery,19B South Guthrie,U.S. House,7,Republican,Matt Van Epps,539
+Montgomery,19B South Guthrie,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,19B South Guthrie,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,19B South Guthrie,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,19B South Guthrie,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,1A St B CC,U.S. House,7,Democratic,Aftyn Behn,659
+Montgomery,1A St B CC,U.S. House,7,Republican,Matt Van Epps,734
+Montgomery,1A St B CC,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,1A St B CC,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,1A St B CC,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,1A St B CC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Montgomery,1B St B UMC,U.S. House,7,Democratic,Aftyn Behn,556
+Montgomery,1B St B UMC,U.S. House,7,Republican,Matt Van Epps,559
+Montgomery,1B St B UMC,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,1B St B UMC,U.S. House,7,Independent,Jon Thorp,9
+Montgomery,1B St B UMC,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,1B St B UMC,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,20A Northeast,U.S. House,7,Democratic,Aftyn Behn,567
+Montgomery,20A Northeast,U.S. House,7,Republican,Matt Van Epps,374
+Montgomery,20A Northeast,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,20A Northeast,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,20A Northeast,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,20A Northeast,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,20B Oakland,U.S. House,7,Democratic,Aftyn Behn,429
+Montgomery,20B Oakland,U.S. House,7,Republican,Matt Van Epps,425
+Montgomery,20B Oakland,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,20B Oakland,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,20B Oakland,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,20B Oakland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,21A Hilldale,U.S. House,7,Democratic,Aftyn Behn,565
+Montgomery,21A Hilldale,U.S. House,7,Republican,Matt Van Epps,843
+Montgomery,21A Hilldale,U.S. House,7,Independent,Bobby Dodge,4
+Montgomery,21A Hilldale,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,21A Hilldale,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,21A Hilldale,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Montgomery,21B Barksdale,U.S. House,7,Democratic,Aftyn Behn,506
+Montgomery,21B Barksdale,U.S. House,7,Republican,Matt Van Epps,425
+Montgomery,21B Barksdale,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,21B Barksdale,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,21B Barksdale,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,21B Barksdale,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,2A Clarksville,U.S. House,7,Democratic,Aftyn Behn,653
+Montgomery,2A Clarksville,U.S. House,7,Republican,Matt Van Epps,1045
+Montgomery,2A Clarksville,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,2A Clarksville,U.S. House,7,Independent,Jon Thorp,14
+Montgomery,2A Clarksville,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,2A Clarksville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Montgomery,2B Bible,U.S. House,7,Democratic,Aftyn Behn,750
+Montgomery,2B Bible,U.S. House,7,Republican,Matt Van Epps,881
+Montgomery,2B Bible,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,2B Bible,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,2B Bible,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,2B Bible,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Montgomery,3A East Montgomery,U.S. House,7,Democratic,Aftyn Behn,517
+Montgomery,3A East Montgomery,U.S. House,7,Republican,Matt Van Epps,1140
+Montgomery,3A East Montgomery,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,3A East Montgomery,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,3A East Montgomery,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,3A East Montgomery,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,3B Fredonia,U.S. House,7,Democratic,Aftyn Behn,488
+Montgomery,3B Fredonia,U.S. House,7,Republican,Matt Van Epps,1334
+Montgomery,3B Fredonia,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,3B Fredonia,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,3B Fredonia,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,3B Fredonia,U.S. House,7,Independent,"Teresa ""Terri"" Christie",10
+Montgomery,4A MCMS,U.S. House,7,Democratic,Aftyn Behn,328
+Montgomery,4A MCMS,U.S. House,7,Republican,Matt Van Epps,1052
+Montgomery,4A MCMS,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,4A MCMS,U.S. House,7,Independent,Jon Thorp,8
+Montgomery,4A MCMS,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,4A MCMS,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,4B WR Event Center,U.S. House,7,Democratic,Aftyn Behn,568
+Montgomery,4B WR Event Center,U.S. House,7,Republican,Matt Van Epps,613
+Montgomery,4B WR Event Center,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,4B WR Event Center,U.S. House,7,Independent,Jon Thorp,7
+Montgomery,4B WR Event Center,U.S. House,7,Independent,Robert James Sutherby,3
+Montgomery,4B WR Event Center,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,5 Cumberland,U.S. House,7,Democratic,Aftyn Behn,696
+Montgomery,5 Cumberland,U.S. House,7,Republican,Matt Van Epps,348
+Montgomery,5 Cumberland,U.S. House,7,Independent,Bobby Dodge,4
+Montgomery,5 Cumberland,U.S. House,7,Independent,Jon Thorp,5
+Montgomery,5 Cumberland,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,5 Cumberland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,6A Cumberland,U.S. House,7,Democratic,Aftyn Behn,313
+Montgomery,6A Cumberland,U.S. House,7,Republican,Matt Van Epps,888
+Montgomery,6A Cumberland,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,6A Cumberland,U.S. House,7,Independent,Jon Thorp,8
+Montgomery,6A Cumberland,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,6A Cumberland,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,6B Bethel,U.S. House,7,Democratic,Aftyn Behn,279
+Montgomery,6B Bethel,U.S. House,7,Republican,Matt Van Epps,1054
+Montgomery,6B Bethel,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,6B Bethel,U.S. House,7,Independent,Jon Thorp,10
+Montgomery,6B Bethel,U.S. House,7,Independent,Robert James Sutherby,1
+Montgomery,6B Bethel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Montgomery,7A Liberty,U.S. House,7,Democratic,Aftyn Behn,409
+Montgomery,7A Liberty,U.S. House,7,Republican,Matt Van Epps,687
+Montgomery,7A Liberty,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,7A Liberty,U.S. House,7,Independent,Jon Thorp,12
+Montgomery,7A Liberty,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,7A Liberty,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Montgomery,7B Woodlawn,U.S. House,7,Democratic,Aftyn Behn,283
+Montgomery,7B Woodlawn,U.S. House,7,Republican,Matt Van Epps,1118
+Montgomery,7B Woodlawn,U.S. House,7,Independent,Bobby Dodge,0
+Montgomery,7B Woodlawn,U.S. House,7,Independent,Jon Thorp,12
+Montgomery,7B Woodlawn,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,7B Woodlawn,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Montgomery,8 Bethel,U.S. House,7,Democratic,Aftyn Behn,542
+Montgomery,8 Bethel,U.S. House,7,Republican,Matt Van Epps,298
+Montgomery,8 Bethel,U.S. House,7,Independent,Bobby Dodge,1
+Montgomery,8 Bethel,U.S. House,7,Independent,Jon Thorp,4
+Montgomery,8 Bethel,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,8 Bethel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Montgomery,9A Hazelwood,U.S. House,7,Democratic,Aftyn Behn,622
+Montgomery,9A Hazelwood,U.S. House,7,Republican,Matt Van Epps,474
+Montgomery,9A Hazelwood,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,9A Hazelwood,U.S. House,7,Independent,Jon Thorp,1
+Montgomery,9A Hazelwood,U.S. House,7,Independent,Robert James Sutherby,2
+Montgomery,9A Hazelwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Montgomery,9B St John,U.S. House,7,Democratic,Aftyn Behn,459
+Montgomery,9B St John,U.S. House,7,Republican,Matt Van Epps,281
+Montgomery,9B St John,U.S. House,7,Independent,Bobby Dodge,2
+Montgomery,9B St John,U.S. House,7,Independent,Jon Thorp,6
+Montgomery,9B St John,U.S. House,7,Independent,Robert James Sutherby,0
+Montgomery,9B St John,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Perry,1-1 Cedar Creek,U.S. House,7,Democratic,Aftyn Behn,35
+Perry,1-1 Cedar Creek,U.S. House,7,Republican,Matt Van Epps,130
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,Bobby Dodge,0
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,Jon Thorp,2
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,1-1 Cedar Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,1-2 Marsh Creek,U.S. House,7,Democratic,Aftyn Behn,12
+Perry,1-2 Marsh Creek,U.S. House,7,Republican,Matt Van Epps,89
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,Bobby Dodge,0
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,Jon Thorp,0
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,1-2 Marsh Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,2-1 Pineview,U.S. House,7,Democratic,Aftyn Behn,50
+Perry,2-1 Pineview,U.S. House,7,Republican,Matt Van Epps,146
+Perry,2-1 Pineview,U.S. House,7,Independent,Bobby Dodge,0
+Perry,2-1 Pineview,U.S. House,7,Independent,Jon Thorp,1
+Perry,2-1 Pineview,U.S. House,7,Independent,Robert James Sutherby,1
+Perry,2-1 Pineview,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,2-2 Pope,U.S. House,7,Democratic,Aftyn Behn,22
+Perry,2-2 Pope,U.S. House,7,Republican,Matt Van Epps,115
+Perry,2-2 Pope,U.S. House,7,Independent,Bobby Dodge,0
+Perry,2-2 Pope,U.S. House,7,Independent,Jon Thorp,1
+Perry,2-2 Pope,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,2-2 Pope,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,3-1 Coon Creek,U.S. House,7,Democratic,Aftyn Behn,47
+Perry,3-1 Coon Creek,U.S. House,7,Republican,Matt Van Epps,163
+Perry,3-1 Coon Creek,U.S. House,7,Independent,Bobby Dodge,0
+Perry,3-1 Coon Creek,U.S. House,7,Independent,Jon Thorp,4
+Perry,3-1 Coon Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,3-1 Coon Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Perry,3-2 Flatwoods,U.S. House,7,Democratic,Aftyn Behn,29
+Perry,3-2 Flatwoods,U.S. House,7,Republican,Matt Van Epps,99
+Perry,3-2 Flatwoods,U.S. House,7,Independent,Bobby Dodge,0
+Perry,3-2 Flatwoods,U.S. House,7,Independent,Jon Thorp,1
+Perry,3-2 Flatwoods,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,3-2 Flatwoods,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,4-1 Brush Creek,U.S. House,7,Democratic,Aftyn Behn,23
+Perry,4-1 Brush Creek,U.S. House,7,Republican,Matt Van Epps,56
+Perry,4-1 Brush Creek,U.S. House,7,Independent,Bobby Dodge,1
+Perry,4-1 Brush Creek,U.S. House,7,Independent,Jon Thorp,0
+Perry,4-1 Brush Creek,U.S. House,7,Independent,Robert James Sutherby,1
+Perry,4-1 Brush Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,4-3 Lobelville,U.S. House,7,Democratic,Aftyn Behn,29
+Perry,4-3 Lobelville,U.S. House,7,Republican,Matt Van Epps,145
+Perry,4-3 Lobelville,U.S. House,7,Independent,Bobby Dodge,0
+Perry,4-3 Lobelville,U.S. House,7,Independent,Jon Thorp,1
+Perry,4-3 Lobelville,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,4-3 Lobelville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Perry,5-1 Linden,U.S. House,7,Democratic,Aftyn Behn,65
+Perry,5-1 Linden,U.S. House,7,Republican,Matt Van Epps,148
+Perry,5-1 Linden,U.S. House,7,Independent,Bobby Dodge,0
+Perry,5-1 Linden,U.S. House,7,Independent,Jon Thorp,4
+Perry,5-1 Linden,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,5-1 Linden,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Perry,6-1 Lobelville,U.S. House,7,Democratic,Aftyn Behn,52
+Perry,6-1 Lobelville,U.S. House,7,Republican,Matt Van Epps,183
+Perry,6-1 Lobelville,U.S. House,7,Independent,Bobby Dodge,0
+Perry,6-1 Lobelville,U.S. House,7,Independent,Jon Thorp,2
+Perry,6-1 Lobelville,U.S. House,7,Independent,Robert James Sutherby,0
+Perry,6-1 Lobelville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,01-1 East Robertson,U.S. House,7,Democratic,Aftyn Behn,306
+Robertson,01-1 East Robertson,U.S. House,7,Republican,Matt Van Epps,1202
+Robertson,01-1 East Robertson,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,01-1 East Robertson,U.S. House,7,Independent,Jon Thorp,13
+Robertson,01-1 East Robertson,U.S. House,7,Independent,Robert James Sutherby,3
+Robertson,01-1 East Robertson,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,02-1 Woodall,U.S. House,7,Democratic,Aftyn Behn,463
+Robertson,02-1 Woodall,U.S. House,7,Republican,Matt Van Epps,1011
+Robertson,02-1 Woodall,U.S. House,7,Independent,Bobby Dodge,3
+Robertson,02-1 Woodall,U.S. House,7,Independent,Jon Thorp,11
+Robertson,02-1 Woodall,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,02-1 Woodall,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,03-1 Ebenezer,U.S. House,7,Democratic,Aftyn Behn,150
+Robertson,03-1 Ebenezer,U.S. House,7,Republican,Matt Van Epps,556
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,Jon Thorp,4
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,03-1 Ebenezer,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,03-2 Heritage,U.S. House,7,Democratic,Aftyn Behn,354
+Robertson,03-2 Heritage,U.S. House,7,Republican,Matt Van Epps,986
+Robertson,03-2 Heritage,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,03-2 Heritage,U.S. House,7,Independent,Jon Thorp,10
+Robertson,03-2 Heritage,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,03-2 Heritage,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Robertson,04-1 Watauga,U.S. House,7,Democratic,Aftyn Behn,429
+Robertson,04-1 Watauga,U.S. House,7,Republican,Matt Van Epps,1098
+Robertson,04-1 Watauga,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,04-1 Watauga,U.S. House,7,Independent,Jon Thorp,10
+Robertson,04-1 Watauga,U.S. House,7,Independent,Robert James Sutherby,2
+Robertson,04-1 Watauga,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Robertson,05-1 Greenbrier,U.S. House,7,Democratic,Aftyn Behn,343
+Robertson,05-1 Greenbrier,U.S. House,7,Republican,Matt Van Epps,893
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,Jon Thorp,12
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,05-1 Greenbrier,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,06-1 Coopertown,U.S. House,7,Democratic,Aftyn Behn,265
+Robertson,06-1 Coopertown,U.S. House,7,Republican,Matt Van Epps,808
+Robertson,06-1 Coopertown,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,06-1 Coopertown,U.S. House,7,Independent,Jon Thorp,10
+Robertson,06-1 Coopertown,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,06-1 Coopertown,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,06-2 Mt. Sharon,U.S. House,7,Democratic,Aftyn Behn,174
+Robertson,06-2 Mt. Sharon,U.S. House,7,Republican,Matt Van Epps,601
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,Jon Thorp,9
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,06-2 Mt. Sharon,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Robertson,07-1 Jo Byrns,U.S. House,7,Democratic,Aftyn Behn,243
+Robertson,07-1 Jo Byrns,U.S. House,7,Republican,Matt Van Epps,1013
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,Bobby Dodge,4
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,Jon Thorp,10
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,07-1 Jo Byrns,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Robertson,07-2 Stroudsville,U.S. House,7,Democratic,Aftyn Behn,89
+Robertson,07-2 Stroudsville,U.S. House,7,Republican,Matt Van Epps,369
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,Jon Thorp,3
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,07-2 Stroudsville,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,08-1 Krisle,U.S. House,7,Democratic,Aftyn Behn,75
+Robertson,08-1 Krisle,U.S. House,7,Republican,Matt Van Epps,353
+Robertson,08-1 Krisle,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,08-1 Krisle,U.S. House,7,Independent,Jon Thorp,8
+Robertson,08-1 Krisle,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,08-1 Krisle,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,08-2 HATS,U.S. House,7,Democratic,Aftyn Behn,78
+Robertson,08-2 HATS,U.S. House,7,Republican,Matt Van Epps,391
+Robertson,08-2 HATS,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,08-2 HATS,U.S. House,7,Independent,Jon Thorp,0
+Robertson,08-2 HATS,U.S. House,7,Independent,Robert James Sutherby,0
+Robertson,08-2 HATS,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Robertson,08-3 Owens Chapel,U.S. House,7,Democratic,Aftyn Behn,116
+Robertson,08-3 Owens Chapel,U.S. House,7,Republican,Matt Van Epps,607
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,Jon Thorp,5
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,08-3 Owens Chapel,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Robertson,09-1 Fair Assoc.,U.S. House,7,Democratic,Aftyn Behn,426
+Robertson,09-1 Fair Assoc.,U.S. House,7,Republican,Matt Van Epps,625
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,Bobby Dodge,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,Jon Thorp,4
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,09-1 Fair Assoc.,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Robertson,10-1 South Haven,U.S. House,7,Democratic,Aftyn Behn,519
+Robertson,10-1 South Haven,U.S. House,7,Republican,Matt Van Epps,934
+Robertson,10-1 South Haven,U.S. House,7,Independent,Bobby Dodge,3
+Robertson,10-1 South Haven,U.S. House,7,Independent,Jon Thorp,10
+Robertson,10-1 South Haven,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,10-1 South Haven,U.S. House,7,Independent,"Teresa ""Terri"" Christie",7
+Robertson,11-1 Westside,U.S. House,7,Democratic,Aftyn Behn,478
+Robertson,11-1 Westside,U.S. House,7,Republican,Matt Van Epps,796
+Robertson,11-1 Westside,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,11-1 Westside,U.S. House,7,Independent,Jon Thorp,8
+Robertson,11-1 Westside,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,11-1 Westside,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Robertson,11-2 Heads,U.S. House,7,Democratic,Aftyn Behn,42
+Robertson,11-2 Heads,U.S. House,7,Republican,Matt Van Epps,272
+Robertson,11-2 Heads,U.S. House,7,Independent,Bobby Dodge,2
+Robertson,11-2 Heads,U.S. House,7,Independent,Jon Thorp,0
+Robertson,11-2 Heads,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,11-2 Heads,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Robertson,12-1 Bransford,U.S. House,7,Democratic,Aftyn Behn,361
+Robertson,12-1 Bransford,U.S. House,7,Republican,Matt Van Epps,93
+Robertson,12-1 Bransford,U.S. House,7,Independent,Bobby Dodge,0
+Robertson,12-1 Bransford,U.S. House,7,Independent,Jon Thorp,3
+Robertson,12-1 Bransford,U.S. House,7,Independent,Robert James Sutherby,1
+Robertson,12-1 Bransford,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Stewart,1-1 Indian Mound,U.S. House,7,Democratic,Aftyn Behn,98
+Stewart,1-1 Indian Mound,U.S. House,7,Republican,Matt Van Epps,315
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,Jon Thorp,2
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,1-1 Indian Mound,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Stewart,2-1 Big Rock,U.S. House,7,Democratic,Aftyn Behn,100
+Stewart,2-1 Big Rock,U.S. House,7,Republican,Matt Van Epps,328
+Stewart,2-1 Big Rock,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,2-1 Big Rock,U.S. House,7,Independent,Jon Thorp,2
+Stewart,2-1 Big Rock,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,2-1 Big Rock,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Stewart,3-1 Bumpus Mills,U.S. House,7,Democratic,Aftyn Behn,102
+Stewart,3-1 Bumpus Mills,U.S. House,7,Republican,Matt Van Epps,413
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,Bobby Dodge,1
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,Jon Thorp,2
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,3-1 Bumpus Mills,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Stewart,4-1 Church Street,U.S. House,7,Democratic,Aftyn Behn,101
+Stewart,4-1 Church Street,U.S. House,7,Republican,Matt Van Epps,298
+Stewart,4-1 Church Street,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,4-1 Church Street,U.S. House,7,Independent,Jon Thorp,5
+Stewart,4-1 Church Street,U.S. House,7,Independent,Robert James Sutherby,1
+Stewart,4-1 Church Street,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Stewart,5-1 Visitors Center,U.S. House,7,Democratic,Aftyn Behn,125
+Stewart,5-1 Visitors Center,U.S. House,7,Republican,Matt Van Epps,442
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,Bobby Dodge,1
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,Jon Thorp,5
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,Robert James Sutherby,2
+Stewart,5-1 Visitors Center,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Stewart,6-1 Public Library,U.S. House,7,Democratic,Aftyn Behn,134
+Stewart,6-1 Public Library,U.S. House,7,Republican,Matt Van Epps,402
+Stewart,6-1 Public Library,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,6-1 Public Library,U.S. House,7,Independent,Jon Thorp,4
+Stewart,6-1 Public Library,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,6-1 Public Library,U.S. House,7,Independent,"Teresa ""Terri"" Christie",4
+Stewart,7-1 Cumberland City,U.S. House,7,Democratic,Aftyn Behn,107
+Stewart,7-1 Cumberland City,U.S. House,7,Republican,Matt Van Epps,390
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,Bobby Dodge,0
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,Jon Thorp,3
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,Robert James Sutherby,0
+Stewart,7-1 Cumberland City,U.S. House,7,Independent,"Teresa ""Terri"" Christie",3
+Wayne,1-1 Waynesboro,U.S. House,7,Democratic,Aftyn Behn,76
+Wayne,1-1 Waynesboro,U.S. House,7,Republican,Matt Van Epps,318
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,Jon Thorp,2
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,1-1 Waynesboro,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,2-1 Clifton,U.S. House,7,Democratic,Aftyn Behn,22
+Wayne,2-1 Clifton,U.S. House,7,Republican,Matt Van Epps,73
+Wayne,2-1 Clifton,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,2-1 Clifton,U.S. House,7,Independent,Jon Thorp,0
+Wayne,2-1 Clifton,U.S. House,7,Independent,Robert James Sutherby,1
+Wayne,2-1 Clifton,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,3-1 Beech Creek,U.S. House,7,Democratic,Aftyn Behn,18
+Wayne,3-1 Beech Creek,U.S. House,7,Republican,Matt Van Epps,150
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,Jon Thorp,0
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,3-1 Beech Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,3-2 Crazy Horse,U.S. House,7,Democratic,Aftyn Behn,32
+Wayne,3-2 Crazy Horse,U.S. House,7,Republican,Matt Van Epps,166
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,Jon Thorp,1
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,3-2 Crazy Horse,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,3-3 Eagle Creek,U.S. House,7,Democratic,Aftyn Behn,15
+Wayne,3-3 Eagle Creek,U.S. House,7,Republican,Matt Van Epps,89
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,Jon Thorp,1
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,3-3 Eagle Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,4-1 Collinwood,U.S. House,7,Democratic,Aftyn Behn,45
+Wayne,4-1 Collinwood,U.S. House,7,Republican,Matt Van Epps,228
+Wayne,4-1 Collinwood,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,4-1 Collinwood,U.S. House,7,Independent,Jon Thorp,1
+Wayne,4-1 Collinwood,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,4-1 Collinwood,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,4-2 Shawnettee,U.S. House,7,Democratic,Aftyn Behn,16
+Wayne,4-2 Shawnettee,U.S. House,7,Republican,Matt Van Epps,124
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,Jon Thorp,0
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,Robert James Sutherby,1
+Wayne,4-2 Shawnettee,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,5-1 Big Cypress,U.S. House,7,Democratic,Aftyn Behn,33
+Wayne,5-1 Big Cypress,U.S. House,7,Republican,Matt Van Epps,187
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,Jon Thorp,0
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,5-1 Big Cypress,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,5-2 Lutts,U.S. House,7,Democratic,Aftyn Behn,20
+Wayne,5-2 Lutts,U.S. House,7,Republican,Matt Van Epps,115
+Wayne,5-2 Lutts,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,5-2 Lutts,U.S. House,7,Independent,Jon Thorp,1
+Wayne,5-2 Lutts,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,5-2 Lutts,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,5-3 Woodmen,U.S. House,7,Democratic,Aftyn Behn,18
+Wayne,5-3 Woodmen,U.S. House,7,Republican,Matt Van Epps,99
+Wayne,5-3 Woodmen,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,5-3 Woodmen,U.S. House,7,Independent,Jon Thorp,0
+Wayne,5-3 Woodmen,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,5-3 Woodmen,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,6-1 Holly Creek,U.S. House,7,Democratic,Aftyn Behn,24
+Wayne,6-1 Holly Creek,U.S. House,7,Republican,Matt Van Epps,133
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,Jon Thorp,1
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,6-1 Holly Creek,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,6-2 South Gate,U.S. House,7,Democratic,Aftyn Behn,34
+Wayne,6-2 South Gate,U.S. House,7,Republican,Matt Van Epps,319
+Wayne,6-2 South Gate,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,6-2 South Gate,U.S. House,7,Independent,Jon Thorp,2
+Wayne,6-2 South Gate,U.S. House,7,Independent,Robert James Sutherby,1
+Wayne,6-2 South Gate,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Wayne,7-1 Buffalo River,U.S. House,7,Democratic,Aftyn Behn,36
+Wayne,7-1 Buffalo River,U.S. House,7,Republican,Matt Van Epps,152
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,Bobby Dodge,0
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,Jon Thorp,0
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,7-1 Buffalo River,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Wayne,7-2 Ovilla,U.S. House,7,Democratic,Aftyn Behn,28
+Wayne,7-2 Ovilla,U.S. House,7,Republican,Matt Van Epps,259
+Wayne,7-2 Ovilla,U.S. House,7,Independent,Bobby Dodge,1
+Wayne,7-2 Ovilla,U.S. House,7,Independent,Jon Thorp,0
+Wayne,7-2 Ovilla,U.S. House,7,Independent,Robert James Sutherby,0
+Wayne,7-2 Ovilla,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,1-1,U.S. House,7,Democratic,Aftyn Behn,656
+Williamson,1-1,U.S. House,7,Republican,Matt Van Epps,1507
+Williamson,1-1,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,1-1,U.S. House,7,Independent,Jon Thorp,13
+Williamson,1-1,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,1-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",11
+Williamson,1-5,U.S. House,7,Democratic,Aftyn Behn,253
+Williamson,1-5,U.S. House,7,Republican,Matt Van Epps,665
+Williamson,1-5,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,1-5,U.S. House,7,Independent,Jon Thorp,5
+Williamson,1-5,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,1-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,1-6,U.S. House,7,Democratic,Aftyn Behn,641
+Williamson,1-6,U.S. House,7,Republican,Matt Van Epps,1389
+Williamson,1-6,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,1-6,U.S. House,7,Independent,Jon Thorp,19
+Williamson,1-6,U.S. House,7,Independent,Robert James Sutherby,2
+Williamson,1-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",6
+Williamson,10-1,U.S. House,7,Democratic,Aftyn Behn,884
+Williamson,10-1,U.S. House,7,Republican,Matt Van Epps,854
+Williamson,10-1,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-1,U.S. House,7,Independent,Jon Thorp,4
+Williamson,10-1,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,10-2,U.S. House,7,Democratic,Aftyn Behn,589
+Williamson,10-2,U.S. House,7,Republican,Matt Van Epps,692
+Williamson,10-2,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,10-2,U.S. House,7,Independent,Jon Thorp,1
+Williamson,10-2,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,10-3,U.S. House,7,Democratic,Aftyn Behn,51
+Williamson,10-3,U.S. House,7,Republican,Matt Van Epps,70
+Williamson,10-3,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-3,U.S. House,7,Independent,Jon Thorp,1
+Williamson,10-3,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,10-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,10-4,U.S. House,7,Democratic,Aftyn Behn,554
+Williamson,10-4,U.S. House,7,Republican,Matt Van Epps,547
+Williamson,10-4,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-4,U.S. House,7,Independent,Jon Thorp,9
+Williamson,10-4,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,10-5,U.S. House,7,Democratic,Aftyn Behn,577
+Williamson,10-5,U.S. House,7,Republican,Matt Van Epps,415
+Williamson,10-5,U.S. House,7,Independent,Bobby Dodge,3
+Williamson,10-5,U.S. House,7,Independent,Jon Thorp,5
+Williamson,10-5,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,10-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,10-6,U.S. House,7,Democratic,Aftyn Behn,265
+Williamson,10-6,U.S. House,7,Republican,Matt Van Epps,491
+Williamson,10-6,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,10-6,U.S. House,7,Independent,Jon Thorp,7
+Williamson,10-6,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,10-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,11-1,U.S. House,7,Democratic,Aftyn Behn,985
+Williamson,11-1,U.S. House,7,Republican,Matt Van Epps,1450
+Williamson,11-1,U.S. House,7,Independent,Bobby Dodge,2
+Williamson,11-1,U.S. House,7,Independent,Jon Thorp,13
+Williamson,11-1,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,11-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Williamson,11-2,U.S. House,7,Democratic,Aftyn Behn,57
+Williamson,11-2,U.S. House,7,Republican,Matt Van Epps,78
+Williamson,11-2,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,11-2,U.S. House,7,Independent,Jon Thorp,0
+Williamson,11-2,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,11-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,11-3,U.S. House,7,Democratic,Aftyn Behn,289
+Williamson,11-3,U.S. House,7,Republican,Matt Van Epps,604
+Williamson,11-3,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,11-3,U.S. House,7,Independent,Jon Thorp,5
+Williamson,11-3,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,11-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,11-4,U.S. House,7,Democratic,Aftyn Behn,549
+Williamson,11-4,U.S. House,7,Republican,Matt Van Epps,471
+Williamson,11-4,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,11-4,U.S. House,7,Independent,Jon Thorp,2
+Williamson,11-4,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,11-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,11-5,U.S. House,7,Democratic,Aftyn Behn,579
+Williamson,11-5,U.S. House,7,Republican,Matt Van Epps,1023
+Williamson,11-5,U.S. House,7,Independent,Bobby Dodge,1
+Williamson,11-5,U.S. House,7,Independent,Jon Thorp,3
+Williamson,11-5,U.S. House,7,Independent,Robert James Sutherby,2
+Williamson,11-5,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,12-1,U.S. House,7,Democratic,Aftyn Behn,955
+Williamson,12-1,U.S. House,7,Republican,Matt Van Epps,1282
+Williamson,12-1,U.S. House,7,Independent,Bobby Dodge,2
+Williamson,12-1,U.S. House,7,Independent,Jon Thorp,2
+Williamson,12-1,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,12-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,2-1,U.S. House,7,Democratic,Aftyn Behn,373
+Williamson,2-1,U.S. House,7,Republican,Matt Van Epps,863
+Williamson,2-1,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,2-1,U.S. House,7,Independent,Jon Thorp,5
+Williamson,2-1,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,2-1,U.S. House,7,Independent,"Teresa ""Terri"" Christie",2
+Williamson,7-2,U.S. House,7,Democratic,Aftyn Behn,109
+Williamson,7-2,U.S. House,7,Republican,Matt Van Epps,82
+Williamson,7-2,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,7-2,U.S. House,7,Independent,Jon Thorp,1
+Williamson,7-2,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,7-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,8-2,U.S. House,7,Democratic,Aftyn Behn,462
+Williamson,8-2,U.S. House,7,Republican,Matt Van Epps,722
+Williamson,8-2,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,8-2,U.S. House,7,Independent,Jon Thorp,3
+Williamson,8-2,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,8-2,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1
+Williamson,8-4,U.S. House,7,Democratic,Aftyn Behn,463
+Williamson,8-4,U.S. House,7,Republican,Matt Van Epps,744
+Williamson,8-4,U.S. House,7,Independent,Bobby Dodge,0
+Williamson,8-4,U.S. House,7,Independent,Jon Thorp,7
+Williamson,8-4,U.S. House,7,Independent,Robert James Sutherby,0
+Williamson,8-4,U.S. House,7,Independent,"Teresa ""Terri"" Christie",5
+Williamson,9-3,U.S. House,7,Democratic,Aftyn Behn,625
+Williamson,9-3,U.S. House,7,Republican,Matt Van Epps,1726
+Williamson,9-3,U.S. House,7,Independent,Bobby Dodge,2
+Williamson,9-3,U.S. House,7,Independent,Jon Thorp,11
+Williamson,9-3,U.S. House,7,Independent,Robert James Sutherby,1
+Williamson,9-3,U.S. House,7,Independent,"Teresa ""Terri"" Christie",0
+Williamson,9-6,U.S. House,7,Democratic,Aftyn Behn,692
+Williamson,9-6,U.S. House,7,Republican,Matt Van Epps,1211
+Williamson,9-6,U.S. House,7,Independent,Bobby Dodge,5
+Williamson,9-6,U.S. House,7,Independent,Jon Thorp,8
+Williamson,9-6,U.S. House,7,Independent,Robert James Sutherby,3
+Williamson,9-6,U.S. House,7,Independent,"Teresa ""Terri"" Christie",1

--- a/2026/20260505__tn__primary__county.csv
+++ b/2026/20260505__tn__primary__county.csv
@@ -1,0 +1,65 @@
+county,office,district,party,candidate,votes
+Carter,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Public Defender,1 (unexpired term),Republican,Bill Donaldson,2896
+Carter,Public Defender,1 (unexpired term),Republican,Melanie Sellers,3374
+Cheatham,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,2779
+Cocke,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,4763
+Cocke,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,4314
+Davidson,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,9930
+Davidson,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,14670
+Davidson,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,15817
+Davidson,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,15033
+Davidson,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,14384
+Davidson,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,12943
+Davidson,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,Public Defender,20,Democratic,Martesha Johnson,36735
+Davidson,Public Defender,20,Republican,No Candidate Qualified,0
+Dickson,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,3420
+Giles,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,2010
+Grainger,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,1952
+Hamilton,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,9649
+Hickman,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",630
+Houston,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,270
+Humphreys,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,176
+Jefferson,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,5568
+Jefferson,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,5145
+Johnson,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,Public Defender,1 (unexpired term),Republican,Bill Donaldson,1185
+Johnson,Public Defender,1 (unexpired term),Republican,Melanie Sellers,1231
+Knox,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,35076
+Lewis,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",2204
+Montgomery,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,4934
+Perry,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",160
+Robertson,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,4989
+Sevier,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,10626
+Sevier,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,10528
+Stewart,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,208
+Sumner,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,6646
+Sumner,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,5365
+Sumner,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,District Attorney General,18 (unexpired term),Republican,Thomas Dean,10196
+Unicoi,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Public Defender,1 (unexpired term),Republican,Bill Donaldson,1621
+Unicoi,Public Defender,1 (unexpired term),Republican,Melanie Sellers,1398
+Washington,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,Public Defender,1 (unexpired term),Republican,Bill Donaldson,3491
+Washington,Public Defender,1 (unexpired term),Republican,Melanie Sellers,3431

--- a/2026/20260505__tn__primary__precinct.csv
+++ b/2026/20260505__tn__primary__precinct.csv
@@ -1,0 +1,3009 @@
+county,precinct,office,district,party,candidate,votes
+Carter,Central,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Central,Public Defender,1 (unexpired term),Republican,Bill Donaldson,113
+Carter,Central,Public Defender,1 (unexpired term),Republican,Melanie Sellers,173
+Carter,Courthouse,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Courthouse,Public Defender,1 (unexpired term),Republican,Bill Donaldson,174
+Carter,Courthouse,Public Defender,1 (unexpired term),Republican,Melanie Sellers,239
+Carter,Eastside,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Eastside,Public Defender,1 (unexpired term),Republican,Bill Donaldson,143
+Carter,Eastside,Public Defender,1 (unexpired term),Republican,Melanie Sellers,159
+Carter,Elk Mills,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Elk Mills,Public Defender,1 (unexpired term),Republican,Bill Donaldson,45
+Carter,Elk Mills,Public Defender,1 (unexpired term),Republican,Melanie Sellers,21
+Carter,Gap Creek,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Gap Creek,Public Defender,1 (unexpired term),Republican,Bill Donaldson,166
+Carter,Gap Creek,Public Defender,1 (unexpired term),Republican,Melanie Sellers,183
+Carter,Hampton,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Hampton,Public Defender,1 (unexpired term),Republican,Bill Donaldson,152
+Carter,Hampton,Public Defender,1 (unexpired term),Republican,Melanie Sellers,171
+Carter,Happy Valley,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Happy Valley,Public Defender,1 (unexpired term),Republican,Bill Donaldson,209
+Carter,Happy Valley,Public Defender,1 (unexpired term),Republican,Melanie Sellers,226
+Carter,Harold McCormick,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Harold McCormick,Public Defender,1 (unexpired term),Republican,Bill Donaldson,74
+Carter,Harold McCormick,Public Defender,1 (unexpired term),Republican,Melanie Sellers,109
+Carter,High School,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,High School,Public Defender,1 (unexpired term),Republican,Bill Donaldson,122
+Carter,High School,Public Defender,1 (unexpired term),Republican,Melanie Sellers,201
+Carter,Hunter,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Hunter,Public Defender,1 (unexpired term),Republican,Bill Donaldson,203
+Carter,Hunter,Public Defender,1 (unexpired term),Republican,Melanie Sellers,291
+Carter,Keenburg,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Keenburg,Public Defender,1 (unexpired term),Republican,Bill Donaldson,107
+Carter,Keenburg,Public Defender,1 (unexpired term),Republican,Melanie Sellers,130
+Carter,Little Milligan,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Little Milligan,Public Defender,1 (unexpired term),Republican,Bill Donaldson,40
+Carter,Little Milligan,Public Defender,1 (unexpired term),Republican,Melanie Sellers,32
+Carter,Midway,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Midway,Public Defender,1 (unexpired term),Republican,Bill Donaldson,137
+Carter,Midway,Public Defender,1 (unexpired term),Republican,Melanie Sellers,93
+Carter,National Guard,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,National Guard,Public Defender,1 (unexpired term),Republican,Bill Donaldson,37
+Carter,National Guard,Public Defender,1 (unexpired term),Republican,Melanie Sellers,58
+Carter,Range,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Range,Public Defender,1 (unexpired term),Republican,Bill Donaldson,53
+Carter,Range,Public Defender,1 (unexpired term),Republican,Melanie Sellers,86
+Carter,Roan Mountain,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Roan Mountain,Public Defender,1 (unexpired term),Republican,Bill Donaldson,264
+Carter,Roan Mountain,Public Defender,1 (unexpired term),Republican,Melanie Sellers,196
+Carter,Siam,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Siam,Public Defender,1 (unexpired term),Republican,Bill Donaldson,82
+Carter,Siam,Public Defender,1 (unexpired term),Republican,Melanie Sellers,113
+Carter,Tiger Valley,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Tiger Valley,Public Defender,1 (unexpired term),Republican,Bill Donaldson,240
+Carter,Tiger Valley,Public Defender,1 (unexpired term),Republican,Melanie Sellers,154
+Carter,Unaka,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Unaka,Public Defender,1 (unexpired term),Republican,Bill Donaldson,133
+Carter,Unaka,Public Defender,1 (unexpired term),Republican,Melanie Sellers,204
+Carter,Valley Forge,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Valley Forge,Public Defender,1 (unexpired term),Republican,Bill Donaldson,190
+Carter,Valley Forge,Public Defender,1 (unexpired term),Republican,Melanie Sellers,211
+Carter,Watauga,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Watauga,Public Defender,1 (unexpired term),Republican,Bill Donaldson,16
+Carter,Watauga,Public Defender,1 (unexpired term),Republican,Melanie Sellers,26
+Carter,Westside,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Carter,Westside,Public Defender,1 (unexpired term),Republican,Bill Donaldson,196
+Carter,Westside,Public Defender,1 (unexpired term),Republican,Melanie Sellers,298
+Cheatham,1-1 Sycamore Square,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,1-1 Sycamore Square,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,281
+Cheatham,2-1 East Cheatham,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,2-1 East Cheatham,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,444
+Cheatham,3-1 Pleasant View,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,3-1 Pleasant View,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,609
+Cheatham,4-1 West Cheatham,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,4-1 West Cheatham,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,397
+Cheatham,4-3 Sycamore,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,4-3 Sycamore,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,306
+Cheatham,5-1 AC Church of Christ,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,5-1 AC Church of Christ,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,184
+Cheatham,5-2 Pegram,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,5-2 Pegram,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,215
+Cheatham,6-1 Harpeth,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Cheatham,6-1 Harpeth,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,343
+Cocke,Armory,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Armory,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,189
+Cocke,Armory,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Armory,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,179
+Cocke,Bridgeport,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Bridgeport,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,235
+Cocke,Bridgeport,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Bridgeport,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,222
+Cocke,Centerview,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Centerview,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,341
+Cocke,Centerview,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Centerview,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,306
+Cocke,Central,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Central,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,199
+Cocke,Central,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Central,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,183
+Cocke,Cocke County High,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Cocke County High,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,106
+Cocke,Cocke County High,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Cocke County High,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,98
+Cocke,Cosby,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Cosby,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,422
+Cocke,Cosby,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Cosby,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,393
+Cocke,Del Rio,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Del Rio,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,255
+Cocke,Del Rio,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Del Rio,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,238
+Cocke,Edgemont,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Edgemont,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,280
+Cocke,Edgemont,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Edgemont,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,249
+Cocke,Edwina,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Edwina,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,487
+Cocke,Edwina,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Edwina,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,397
+Cocke,Forest Hill,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Forest Hill,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,224
+Cocke,Forest Hill,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Forest Hill,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,204
+Cocke,Grassy Fork,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Grassy Fork,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,178
+Cocke,Grassy Fork,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Grassy Fork,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,174
+Cocke,Long Creek,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Long Creek,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,167
+Cocke,Long Creek,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Long Creek,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,155
+Cocke,Newport Grammar,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Newport Grammar,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,467
+Cocke,Newport Grammar,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Newport Grammar,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,396
+Cocke,Northport,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Northport,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,215
+Cocke,Northport,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Northport,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,200
+Cocke,Parrottsville,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Parrottsville,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,406
+Cocke,Parrottsville,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Parrottsville,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,373
+Cocke,Rankin,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Rankin,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,131
+Cocke,Rankin,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Rankin,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,121
+Cocke,Smoky Mountain,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Smoky Mountain,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,211
+Cocke,Smoky Mountain,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,Smoky Mountain,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,201
+Cocke,West End,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,West End,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,250
+Cocke,West End,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Cocke,West End,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,225
+Davidson,01-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,52
+Davidson,01-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,97
+Davidson,01-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,84
+Davidson,01-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,47
+Davidson,01-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,136
+Davidson,01-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,59
+Davidson,01-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-1,Public Defender,20,Democratic,Martesha Johnson,191
+Davidson,01-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,01-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,21
+Davidson,01-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,39
+Davidson,01-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,19
+Davidson,01-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,27
+Davidson,01-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,44
+Davidson,01-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,19
+Davidson,01-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-2,Public Defender,20,Democratic,Martesha Johnson,65
+Davidson,01-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,01-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,63
+Davidson,01-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,54
+Davidson,01-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,168
+Davidson,01-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,53
+Davidson,01-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,95
+Davidson,01-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,157
+Davidson,01-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-3,Public Defender,20,Democratic,Martesha Johnson,257
+Davidson,01-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,01-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,72
+Davidson,01-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,61
+Davidson,01-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,210
+Davidson,01-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,65
+Davidson,01-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,121
+Davidson,01-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,168
+Davidson,01-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-4,Public Defender,20,Democratic,Martesha Johnson,329
+Davidson,01-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,01-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,84
+Davidson,01-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,63
+Davidson,01-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,207
+Davidson,01-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,73
+Davidson,01-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,110
+Davidson,01-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,189
+Davidson,01-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-5,Public Defender,20,Democratic,Martesha Johnson,329
+Davidson,01-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,01-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,29
+Davidson,01-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,26
+Davidson,01-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,74
+Davidson,01-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,18
+Davidson,01-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,47
+Davidson,01-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,72
+Davidson,01-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-6,Public Defender,20,Democratic,Martesha Johnson,115
+Davidson,01-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,01-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,240
+Davidson,01-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,146
+Davidson,01-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,700
+Davidson,01-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,164
+Davidson,01-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,318
+Davidson,01-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,672
+Davidson,01-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,01-7,Public Defender,20,Democratic,Martesha Johnson,1023
+Davidson,01-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,02-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,55
+Davidson,02-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,37
+Davidson,02-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,91
+Davidson,02-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,53
+Davidson,02-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,50
+Davidson,02-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,89
+Davidson,02-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-1,Public Defender,20,Democratic,Martesha Johnson,169
+Davidson,02-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,02-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,87
+Davidson,02-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,45
+Davidson,02-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,163
+Davidson,02-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,60
+Davidson,02-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,116
+Davidson,02-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,140
+Davidson,02-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-2,Public Defender,20,Democratic,Martesha Johnson,280
+Davidson,02-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,02-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,30
+Davidson,02-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,20
+Davidson,02-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,64
+Davidson,02-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,34
+Davidson,02-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,31
+Davidson,02-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,54
+Davidson,02-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-3,Public Defender,20,Democratic,Martesha Johnson,107
+Davidson,02-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,02-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,59
+Davidson,02-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,50
+Davidson,02-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,175
+Davidson,02-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,79
+Davidson,02-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,73
+Davidson,02-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,137
+Davidson,02-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-4,Public Defender,20,Democratic,Martesha Johnson,262
+Davidson,02-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,02-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,222
+Davidson,02-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,134
+Davidson,02-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,588
+Davidson,02-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,150
+Davidson,02-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,286
+Davidson,02-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,557
+Davidson,02-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,02-5,Public Defender,20,Democratic,Martesha Johnson,878
+Davidson,02-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,0
+Davidson,03-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,0
+Davidson,03-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,0
+Davidson,03-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,0
+Davidson,03-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,0
+Davidson,03-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,0
+Davidson,03-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-1,Public Defender,20,Democratic,Martesha Johnson,0
+Davidson,03-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,147
+Davidson,03-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,157
+Davidson,03-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,439
+Davidson,03-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,167
+Davidson,03-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,218
+Davidson,03-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,373
+Davidson,03-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-2,Public Defender,20,Democratic,Martesha Johnson,694
+Davidson,03-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,8
+Davidson,03-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,5
+Davidson,03-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,15
+Davidson,03-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,11
+Davidson,03-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,6
+Davidson,03-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,11
+Davidson,03-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-3,Public Defender,20,Democratic,Martesha Johnson,27
+Davidson,03-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,66
+Davidson,03-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,57
+Davidson,03-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,77
+Davidson,03-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,88
+Davidson,03-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,72
+Davidson,03-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,50
+Davidson,03-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-4,Public Defender,20,Democratic,Martesha Johnson,183
+Davidson,03-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,27
+Davidson,03-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,26
+Davidson,03-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,42
+Davidson,03-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,36
+Davidson,03-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,25
+Davidson,03-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,34
+Davidson,03-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-5,Public Defender,20,Democratic,Martesha Johnson,86
+Davidson,03-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,29
+Davidson,03-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,27
+Davidson,03-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,52
+Davidson,03-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,31
+Davidson,03-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,40
+Davidson,03-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,45
+Davidson,03-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-6,Public Defender,20,Democratic,Martesha Johnson,104
+Davidson,03-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,69
+Davidson,03-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,60
+Davidson,03-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,135
+Davidson,03-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,83
+Davidson,03-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,82
+Davidson,03-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,113
+Davidson,03-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-7,Public Defender,20,Democratic,Martesha Johnson,245
+Davidson,03-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,03-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,181
+Davidson,03-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,110
+Davidson,03-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,368
+Davidson,03-8,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,143
+Davidson,03-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,191
+Davidson,03-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,358
+Davidson,03-8,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,03-8,Public Defender,20,Democratic,Martesha Johnson,610
+Davidson,03-8,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,04-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,68
+Davidson,04-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,111
+Davidson,04-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,101
+Davidson,04-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,04-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,134
+Davidson,04-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,64
+Davidson,04-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,85
+Davidson,04-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,04-1,Public Defender,20,Democratic,Martesha Johnson,262
+Davidson,04-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,04-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,89
+Davidson,04-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,161
+Davidson,04-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,152
+Davidson,04-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,04-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,108
+Davidson,04-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,160
+Davidson,04-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,145
+Davidson,04-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,04-2,Public Defender,20,Democratic,Martesha Johnson,375
+Davidson,04-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,04-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,54
+Davidson,04-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,127
+Davidson,04-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,69
+Davidson,04-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,04-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,95
+Davidson,04-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,102
+Davidson,04-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,64
+Davidson,04-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,04-3,Public Defender,20,Democratic,Martesha Johnson,225
+Davidson,04-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,20
+Davidson,05-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,16
+Davidson,05-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,45
+Davidson,05-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,35
+Davidson,05-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,16
+Davidson,05-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,34
+Davidson,05-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-1,Public Defender,20,Democratic,Martesha Johnson,77
+Davidson,05-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,3
+Davidson,05-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,2
+Davidson,05-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,3
+Davidson,05-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,3
+Davidson,05-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,4
+Davidson,05-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,2
+Davidson,05-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-2,Public Defender,20,Democratic,Martesha Johnson,6
+Davidson,05-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,13
+Davidson,05-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,21
+Davidson,05-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,31
+Davidson,05-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,25
+Davidson,05-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,21
+Davidson,05-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,20
+Davidson,05-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-3,Public Defender,20,Democratic,Martesha Johnson,57
+Davidson,05-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,99
+Davidson,05-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,74
+Davidson,05-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,130
+Davidson,05-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,138
+Davidson,05-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,76
+Davidson,05-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,98
+Davidson,05-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-4,Public Defender,20,Democratic,Martesha Johnson,279
+Davidson,05-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,33
+Davidson,05-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,31
+Davidson,05-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,74
+Davidson,05-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,50
+Davidson,05-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,37
+Davidson,05-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,58
+Davidson,05-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-5,Public Defender,20,Democratic,Martesha Johnson,136
+Davidson,05-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,93
+Davidson,05-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,147
+Davidson,05-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,209
+Davidson,05-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,187
+Davidson,05-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,109
+Davidson,05-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,177
+Davidson,05-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-6,Public Defender,20,Democratic,Martesha Johnson,412
+Davidson,05-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,59
+Davidson,05-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,88
+Davidson,05-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,143
+Davidson,05-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,149
+Davidson,05-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,65
+Davidson,05-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,80
+Davidson,05-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-7,Public Defender,20,Democratic,Martesha Johnson,253
+Davidson,05-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,05-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,22
+Davidson,05-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,42
+Davidson,05-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,49
+Davidson,05-8,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,60
+Davidson,05-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,28
+Davidson,05-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,26
+Davidson,05-8,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,05-8,Public Defender,20,Democratic,Martesha Johnson,105
+Davidson,05-8,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,11
+Davidson,06-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,17
+Davidson,06-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,23
+Davidson,06-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,23
+Davidson,06-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,14
+Davidson,06-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,14
+Davidson,06-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-1,Public Defender,20,Democratic,Martesha Johnson,48
+Davidson,06-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,5
+Davidson,06-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,7
+Davidson,06-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,15
+Davidson,06-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,16
+Davidson,06-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,8
+Davidson,06-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,4
+Davidson,06-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-2,Public Defender,20,Democratic,Martesha Johnson,22
+Davidson,06-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,86
+Davidson,06-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,224
+Davidson,06-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,151
+Davidson,06-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,262
+Davidson,06-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,147
+Davidson,06-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,83
+Davidson,06-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-3,Public Defender,20,Democratic,Martesha Johnson,422
+Davidson,06-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,88
+Davidson,06-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,174
+Davidson,06-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,158
+Davidson,06-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,238
+Davidson,06-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,105
+Davidson,06-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,89
+Davidson,06-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-4,Public Defender,20,Democratic,Martesha Johnson,372
+Davidson,06-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,48
+Davidson,06-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,68
+Davidson,06-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,76
+Davidson,06-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,108
+Davidson,06-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,41
+Davidson,06-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,51
+Davidson,06-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-5,Public Defender,20,Democratic,Martesha Johnson,185
+Davidson,06-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,41
+Davidson,06-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,118
+Davidson,06-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,89
+Davidson,06-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,172
+Davidson,06-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,60
+Davidson,06-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,27
+Davidson,06-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-6,Public Defender,20,Democratic,Martesha Johnson,212
+Davidson,06-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,43
+Davidson,06-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,56
+Davidson,06-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,63
+Davidson,06-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,80
+Davidson,06-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,46
+Davidson,06-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,45
+Davidson,06-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-7,Public Defender,20,Democratic,Martesha Johnson,147
+Davidson,06-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,06-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,119
+Davidson,06-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,236
+Davidson,06-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,154
+Davidson,06-8,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,343
+Davidson,06-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,145
+Davidson,06-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,55
+Davidson,06-8,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,06-8,Public Defender,20,Democratic,Martesha Johnson,447
+Davidson,06-8,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,50
+Davidson,07-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,73
+Davidson,07-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,82
+Davidson,07-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,86
+Davidson,07-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,50
+Davidson,07-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,73
+Davidson,07-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-1,Public Defender,20,Democratic,Martesha Johnson,183
+Davidson,07-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,35
+Davidson,07-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,34
+Davidson,07-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,49
+Davidson,07-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,45
+Davidson,07-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,36
+Davidson,07-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,36
+Davidson,07-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-2,Public Defender,20,Democratic,Martesha Johnson,107
+Davidson,07-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,63
+Davidson,07-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,64
+Davidson,07-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,84
+Davidson,07-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,87
+Davidson,07-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,70
+Davidson,07-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,68
+Davidson,07-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-3,Public Defender,20,Democratic,Martesha Johnson,194
+Davidson,07-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,86
+Davidson,07-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,214
+Davidson,07-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,111
+Davidson,07-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,202
+Davidson,07-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,161
+Davidson,07-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,62
+Davidson,07-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-4,Public Defender,20,Democratic,Martesha Johnson,358
+Davidson,07-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,105
+Davidson,07-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,179
+Davidson,07-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,131
+Davidson,07-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,247
+Davidson,07-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,116
+Davidson,07-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,73
+Davidson,07-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-5,Public Defender,20,Democratic,Martesha Johnson,388
+Davidson,07-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,38
+Davidson,07-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,61
+Davidson,07-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,61
+Davidson,07-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,89
+Davidson,07-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,38
+Davidson,07-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,43
+Davidson,07-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-6,Public Defender,20,Democratic,Martesha Johnson,153
+Davidson,07-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,07-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,75
+Davidson,07-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,170
+Davidson,07-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,149
+Davidson,07-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,201
+Davidson,07-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,121
+Davidson,07-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,83
+Davidson,07-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,07-7,Public Defender,20,Democratic,Martesha Johnson,348
+Davidson,07-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,08-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,145
+Davidson,08-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,79
+Davidson,08-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,276
+Davidson,08-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,08-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,107
+Davidson,08-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,111
+Davidson,08-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,299
+Davidson,08-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,08-1,Public Defender,20,Democratic,Martesha Johnson,473
+Davidson,08-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,08-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,20
+Davidson,08-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,13
+Davidson,08-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,30
+Davidson,08-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,08-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,17
+Davidson,08-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,19
+Davidson,08-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,33
+Davidson,08-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,08-2,Public Defender,20,Democratic,Martesha Johnson,61
+Davidson,08-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,08-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,116
+Davidson,08-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,97
+Davidson,08-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,302
+Davidson,08-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,08-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,101
+Davidson,08-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,151
+Davidson,08-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,276
+Davidson,08-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,08-3,Public Defender,20,Democratic,Martesha Johnson,482
+Davidson,08-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,09-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,66
+Davidson,09-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,56
+Davidson,09-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,136
+Davidson,09-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,09-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,106
+Davidson,09-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,73
+Davidson,09-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,93
+Davidson,09-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,09-1,Public Defender,20,Democratic,Martesha Johnson,241
+Davidson,09-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,09-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,116
+Davidson,09-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,91
+Davidson,09-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,243
+Davidson,09-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,09-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,155
+Davidson,09-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,101
+Davidson,09-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,200
+Davidson,09-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,09-2,Public Defender,20,Democratic,Martesha Johnson,425
+Davidson,09-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,09-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,101
+Davidson,09-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,83
+Davidson,09-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,116
+Davidson,09-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,09-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,129
+Davidson,09-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,106
+Davidson,09-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,76
+Davidson,09-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,09-3,Public Defender,20,Democratic,Martesha Johnson,265
+Davidson,09-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,26
+Davidson,10-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,20
+Davidson,10-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,20
+Davidson,10-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,19
+Davidson,10-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,34
+Davidson,10-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,18
+Davidson,10-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-1,Public Defender,20,Democratic,Martesha Johnson,61
+Davidson,10-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,13
+Davidson,10-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,16
+Davidson,10-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,0
+Davidson,10-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,10
+Davidson,10-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,18
+Davidson,10-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,3
+Davidson,10-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-2,Public Defender,20,Democratic,Martesha Johnson,21
+Davidson,10-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,37
+Davidson,10-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,33
+Davidson,10-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,24
+Davidson,10-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,44
+Davidson,10-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,52
+Davidson,10-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,9
+Davidson,10-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-3,Public Defender,20,Democratic,Martesha Johnson,81
+Davidson,10-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,122
+Davidson,10-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,106
+Davidson,10-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,175
+Davidson,10-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,139
+Davidson,10-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,125
+Davidson,10-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,159
+Davidson,10-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-4,Public Defender,20,Democratic,Martesha Johnson,369
+Davidson,10-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,44
+Davidson,10-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,30
+Davidson,10-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,74
+Davidson,10-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,51
+Davidson,10-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,45
+Davidson,10-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,50
+Davidson,10-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-5,Public Defender,20,Democratic,Martesha Johnson,132
+Davidson,10-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,32
+Davidson,10-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,31
+Davidson,10-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,51
+Davidson,10-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,37
+Davidson,10-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,40
+Davidson,10-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,47
+Davidson,10-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-6,Public Defender,20,Democratic,Martesha Johnson,108
+Davidson,10-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,3
+Davidson,10-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,3
+Davidson,10-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,7
+Davidson,10-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,3
+Davidson,10-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,10
+Davidson,10-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,3
+Davidson,10-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-7,Public Defender,20,Democratic,Martesha Johnson,12
+Davidson,10-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,53
+Davidson,10-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,29
+Davidson,10-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,90
+Davidson,10-8,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,45
+Davidson,10-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,53
+Davidson,10-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,82
+Davidson,10-8,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-8,Public Defender,20,Democratic,Martesha Johnson,167
+Davidson,10-8,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,10-9,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,14
+Davidson,10-9,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,29
+Davidson,10-9,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,7
+Davidson,10-9,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-9,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,8
+Davidson,10-9,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,32
+Davidson,10-9,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,12
+Davidson,10-9,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,10-9,Public Defender,20,Democratic,Martesha Johnson,37
+Davidson,10-9,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,11-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,144
+Davidson,11-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,127
+Davidson,11-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,106
+Davidson,11-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,174
+Davidson,11-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,122
+Davidson,11-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,96
+Davidson,11-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-1,Public Defender,20,Democratic,Martesha Johnson,347
+Davidson,11-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,11-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,25
+Davidson,11-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,32
+Davidson,11-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,22
+Davidson,11-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,26
+Davidson,11-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,35
+Davidson,11-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,23
+Davidson,11-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-2,Public Defender,20,Democratic,Martesha Johnson,65
+Davidson,11-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,11-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,82
+Davidson,11-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,120
+Davidson,11-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,95
+Davidson,11-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,93
+Davidson,11-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,140
+Davidson,11-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,88
+Davidson,11-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-3,Public Defender,20,Democratic,Martesha Johnson,264
+Davidson,11-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,11-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,122
+Davidson,11-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,119
+Davidson,11-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,128
+Davidson,11-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,146
+Davidson,11-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,114
+Davidson,11-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,117
+Davidson,11-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,11-4,Public Defender,20,Democratic,Martesha Johnson,334
+Davidson,11-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,12-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,97
+Davidson,12-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,135
+Davidson,12-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,135
+Davidson,12-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,151
+Davidson,12-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,120
+Davidson,12-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,107
+Davidson,12-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-1,Public Defender,20,Democratic,Martesha Johnson,329
+Davidson,12-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,12-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,53
+Davidson,12-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,40
+Davidson,12-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,75
+Davidson,12-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,70
+Davidson,12-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,44
+Davidson,12-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,62
+Davidson,12-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-2,Public Defender,20,Democratic,Martesha Johnson,166
+Davidson,12-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,12-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,128
+Davidson,12-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,167
+Davidson,12-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,164
+Davidson,12-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,143
+Davidson,12-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,193
+Davidson,12-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,140
+Davidson,12-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-3,Public Defender,20,Democratic,Martesha Johnson,434
+Davidson,12-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,12-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,7
+Davidson,12-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,6
+Davidson,12-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,15
+Davidson,12-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,10
+Davidson,12-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,11
+Davidson,12-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,8
+Davidson,12-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,12-4,Public Defender,20,Democratic,Martesha Johnson,24
+Davidson,12-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,13-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,37
+Davidson,13-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,38
+Davidson,13-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,48
+Davidson,13-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,51
+Davidson,13-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,30
+Davidson,13-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,42
+Davidson,13-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-1,Public Defender,20,Democratic,Martesha Johnson,111
+Davidson,13-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,13-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,29
+Davidson,13-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,34
+Davidson,13-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,50
+Davidson,13-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,52
+Davidson,13-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,27
+Davidson,13-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,42
+Davidson,13-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-2,Public Defender,20,Democratic,Martesha Johnson,107
+Davidson,13-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,13-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,45
+Davidson,13-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,65
+Davidson,13-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,31
+Davidson,13-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,66
+Davidson,13-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,54
+Davidson,13-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,34
+Davidson,13-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-3,Public Defender,20,Democratic,Martesha Johnson,136
+Davidson,13-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,13-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,9
+Davidson,13-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,5
+Davidson,13-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,10
+Davidson,13-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,6
+Davidson,13-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,13
+Davidson,13-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,7
+Davidson,13-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-4,Public Defender,20,Democratic,Martesha Johnson,23
+Davidson,13-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,13-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,86
+Davidson,13-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,87
+Davidson,13-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,130
+Davidson,13-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,101
+Davidson,13-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,100
+Davidson,13-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,115
+Davidson,13-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,13-5,Public Defender,20,Democratic,Martesha Johnson,289
+Davidson,13-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,14-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,31
+Davidson,14-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,41
+Davidson,14-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,45
+Davidson,14-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,55
+Davidson,14-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,37
+Davidson,14-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,32
+Davidson,14-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-1,Public Defender,20,Democratic,Martesha Johnson,114
+Davidson,14-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,14-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,63
+Davidson,14-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,86
+Davidson,14-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,69
+Davidson,14-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,104
+Davidson,14-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,64
+Davidson,14-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,60
+Davidson,14-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-2,Public Defender,20,Democratic,Martesha Johnson,201
+Davidson,14-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,14-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,84
+Davidson,14-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,107
+Davidson,14-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,64
+Davidson,14-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,109
+Davidson,14-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,94
+Davidson,14-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,57
+Davidson,14-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-3,Public Defender,20,Democratic,Martesha Johnson,233
+Davidson,14-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,14-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,109
+Davidson,14-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,121
+Davidson,14-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,124
+Davidson,14-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,151
+Davidson,14-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,95
+Davidson,14-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,116
+Davidson,14-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-4,Public Defender,20,Democratic,Martesha Johnson,332
+Davidson,14-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,14-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,13
+Davidson,14-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,18
+Davidson,14-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,20
+Davidson,14-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,25
+Davidson,14-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,13
+Davidson,14-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,13
+Davidson,14-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,14-5,Public Defender,20,Democratic,Martesha Johnson,48
+Davidson,14-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,15-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,136
+Davidson,15-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,180
+Davidson,15-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,141
+Davidson,15-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,226
+Davidson,15-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,154
+Davidson,15-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,98
+Davidson,15-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-1,Public Defender,20,Democratic,Martesha Johnson,433
+Davidson,15-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,15-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,11
+Davidson,15-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,7
+Davidson,15-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,8
+Davidson,15-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,5
+Davidson,15-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,8
+Davidson,15-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,14
+Davidson,15-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-2,Public Defender,20,Democratic,Martesha Johnson,25
+Davidson,15-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,15-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,79
+Davidson,15-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,120
+Davidson,15-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,66
+Davidson,15-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,135
+Davidson,15-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,94
+Davidson,15-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,48
+Davidson,15-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-3,Public Defender,20,Democratic,Martesha Johnson,234
+Davidson,15-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,15-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,66
+Davidson,15-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,85
+Davidson,15-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,68
+Davidson,15-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,107
+Davidson,15-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,74
+Davidson,15-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,44
+Davidson,15-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-4,Public Defender,20,Democratic,Martesha Johnson,200
+Davidson,15-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,15-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,48
+Davidson,15-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,88
+Davidson,15-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,58
+Davidson,15-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,88
+Davidson,15-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,59
+Davidson,15-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,51
+Davidson,15-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-5,Public Defender,20,Democratic,Martesha Johnson,183
+Davidson,15-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,15-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,41
+Davidson,15-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,70
+Davidson,15-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,43
+Davidson,15-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,77
+Davidson,15-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,58
+Davidson,15-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,25
+Davidson,15-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,15-6,Public Defender,20,Democratic,Martesha Johnson,147
+Davidson,15-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,16-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,34
+Davidson,16-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,69
+Davidson,16-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,48
+Davidson,16-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,87
+Davidson,16-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,35
+Davidson,16-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,35
+Davidson,16-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-1,Public Defender,20,Democratic,Martesha Johnson,138
+Davidson,16-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,16-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,71
+Davidson,16-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,102
+Davidson,16-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,77
+Davidson,16-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,155
+Davidson,16-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,69
+Davidson,16-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,40
+Davidson,16-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-2,Public Defender,20,Democratic,Martesha Johnson,228
+Davidson,16-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,16-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,30
+Davidson,16-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,33
+Davidson,16-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,42
+Davidson,16-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,60
+Davidson,16-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,27
+Davidson,16-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,19
+Davidson,16-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-3,Public Defender,20,Democratic,Martesha Johnson,96
+Davidson,16-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,16-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,14
+Davidson,16-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,19
+Davidson,16-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,29
+Davidson,16-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,39
+Davidson,16-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,8
+Davidson,16-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,16
+Davidson,16-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,16-4,Public Defender,20,Democratic,Martesha Johnson,51
+Davidson,16-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,28
+Davidson,17-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,58
+Davidson,17-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,39
+Davidson,17-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,53
+Davidson,17-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,54
+Davidson,17-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,30
+Davidson,17-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-1,Public Defender,20,Democratic,Martesha Johnson,114
+Davidson,17-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,29
+Davidson,17-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,33
+Davidson,17-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,43
+Davidson,17-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,47
+Davidson,17-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,37
+Davidson,17-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,35
+Davidson,17-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-2,Public Defender,20,Democratic,Martesha Johnson,97
+Davidson,17-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,22
+Davidson,17-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,8
+Davidson,17-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,9
+Davidson,17-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,13
+Davidson,17-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,11
+Davidson,17-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,13
+Davidson,17-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-3,Public Defender,20,Democratic,Martesha Johnson,35
+Davidson,17-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,36
+Davidson,17-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,31
+Davidson,17-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,45
+Davidson,17-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,51
+Davidson,17-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,33
+Davidson,17-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,32
+Davidson,17-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-4,Public Defender,20,Democratic,Martesha Johnson,102
+Davidson,17-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,12
+Davidson,17-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,14
+Davidson,17-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,10
+Davidson,17-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,10
+Davidson,17-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,14
+Davidson,17-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,13
+Davidson,17-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-5,Public Defender,20,Democratic,Martesha Johnson,32
+Davidson,17-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,8
+Davidson,17-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,7
+Davidson,17-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,22
+Davidson,17-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,9
+Davidson,17-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,11
+Davidson,17-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,18
+Davidson,17-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-6,Public Defender,20,Democratic,Martesha Johnson,36
+Davidson,17-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,71
+Davidson,17-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,189
+Davidson,17-7,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,128
+Davidson,17-7,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,195
+Davidson,17-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,126
+Davidson,17-7,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,82
+Davidson,17-7,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-7,Public Defender,20,Democratic,Martesha Johnson,351
+Davidson,17-7,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,17-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,45
+Davidson,17-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,59
+Davidson,17-8,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,39
+Davidson,17-8,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,78
+Davidson,17-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,30
+Davidson,17-8,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,42
+Davidson,17-8,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,17-8,Public Defender,20,Democratic,Martesha Johnson,130
+Davidson,17-8,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,18-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,44
+Davidson,18-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,123
+Davidson,18-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,52
+Davidson,18-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,18-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,107
+Davidson,18-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,86
+Davidson,18-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,35
+Davidson,18-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,18-1,Public Defender,20,Democratic,Martesha Johnson,184
+Davidson,18-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,18-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,41
+Davidson,18-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,119
+Davidson,18-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,53
+Davidson,18-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,18-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,95
+Davidson,18-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,84
+Davidson,18-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,44
+Davidson,18-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,18-2,Public Defender,20,Democratic,Martesha Johnson,182
+Davidson,18-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,18-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,99
+Davidson,18-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,455
+Davidson,18-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,145
+Davidson,18-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,18-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,337
+Davidson,18-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,292
+Davidson,18-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,110
+Davidson,18-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,18-3,Public Defender,20,Democratic,Martesha Johnson,595
+Davidson,18-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,19-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,6
+Davidson,19-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,5
+Davidson,19-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,14
+Davidson,19-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,18
+Davidson,19-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,3
+Davidson,19-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,9
+Davidson,19-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-1,Public Defender,20,Democratic,Martesha Johnson,24
+Davidson,19-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,19-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,56
+Davidson,19-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,107
+Davidson,19-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,84
+Davidson,19-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,123
+Davidson,19-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,85
+Davidson,19-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,41
+Davidson,19-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-2,Public Defender,20,Democratic,Martesha Johnson,237
+Davidson,19-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,19-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,58
+Davidson,19-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,45
+Davidson,19-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,141
+Davidson,19-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,101
+Davidson,19-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,60
+Davidson,19-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,94
+Davidson,19-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-3,Public Defender,20,Democratic,Martesha Johnson,235
+Davidson,19-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,19-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,29
+Davidson,19-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,61
+Davidson,19-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,40
+Davidson,19-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,62
+Davidson,19-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,48
+Davidson,19-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,22
+Davidson,19-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-4,Public Defender,20,Democratic,Martesha Johnson,112
+Davidson,19-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,19-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,43
+Davidson,19-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,77
+Davidson,19-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,38
+Davidson,19-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,89
+Davidson,19-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,48
+Davidson,19-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,27
+Davidson,19-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,19-5,Public Defender,20,Democratic,Martesha Johnson,141
+Davidson,19-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,20-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,9
+Davidson,20-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,8
+Davidson,20-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,10
+Davidson,20-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,14
+Davidson,20-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,5
+Davidson,20-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,8
+Davidson,20-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-1,Public Defender,20,Democratic,Martesha Johnson,26
+Davidson,20-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,20-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,27
+Davidson,20-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,91
+Davidson,20-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,73
+Davidson,20-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,111
+Davidson,20-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,55
+Davidson,20-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,32
+Davidson,20-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-2,Public Defender,20,Democratic,Martesha Johnson,172
+Davidson,20-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,20-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,75
+Davidson,20-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,140
+Davidson,20-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,119
+Davidson,20-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,177
+Davidson,20-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,101
+Davidson,20-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,64
+Davidson,20-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-3,Public Defender,20,Democratic,Martesha Johnson,313
+Davidson,20-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,20-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,6
+Davidson,20-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,13
+Davidson,20-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,2
+Davidson,20-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,5
+Davidson,20-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,18
+Davidson,20-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,0
+Davidson,20-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-4,Public Defender,20,Democratic,Martesha Johnson,20
+Davidson,20-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,20-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,47
+Davidson,20-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,107
+Davidson,20-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,65
+Davidson,20-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,102
+Davidson,20-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,100
+Davidson,20-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,37
+Davidson,20-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,20-5,Public Defender,20,Democratic,Martesha Johnson,199
+Davidson,20-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,21-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,31
+Davidson,21-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,74
+Davidson,21-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,35
+Davidson,21-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,64
+Davidson,21-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,52
+Davidson,21-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,27
+Davidson,21-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-1,Public Defender,20,Democratic,Martesha Johnson,116
+Davidson,21-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,21-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,70
+Davidson,21-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,35
+Davidson,21-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,135
+Davidson,21-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,67
+Davidson,21-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,71
+Davidson,21-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,105
+Davidson,21-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-2,Public Defender,20,Democratic,Martesha Johnson,219
+Davidson,21-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,21-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,107
+Davidson,21-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,80
+Davidson,21-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,295
+Davidson,21-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,113
+Davidson,21-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,143
+Davidson,21-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,255
+Davidson,21-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-3,Public Defender,20,Democratic,Martesha Johnson,452
+Davidson,21-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,21-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,49
+Davidson,21-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,47
+Davidson,21-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,186
+Davidson,21-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,75
+Davidson,21-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,74
+Davidson,21-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,137
+Davidson,21-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,21-4,Public Defender,20,Democratic,Martesha Johnson,255
+Davidson,21-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,22-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,73
+Davidson,22-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,107
+Davidson,22-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,81
+Davidson,22-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,107
+Davidson,22-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,99
+Davidson,22-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,73
+Davidson,22-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-1,Public Defender,20,Democratic,Martesha Johnson,241
+Davidson,22-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,22-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,85
+Davidson,22-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,124
+Davidson,22-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,111
+Davidson,22-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,129
+Davidson,22-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,117
+Davidson,22-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,84
+Davidson,22-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-2,Public Defender,20,Democratic,Martesha Johnson,283
+Davidson,22-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,22-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,52
+Davidson,22-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,85
+Davidson,22-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,43
+Davidson,22-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,78
+Davidson,22-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,88
+Davidson,22-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,29
+Davidson,22-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-3,Public Defender,20,Democratic,Martesha Johnson,164
+Davidson,22-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,22-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,124
+Davidson,22-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,194
+Davidson,22-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,83
+Davidson,22-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,170
+Davidson,22-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,170
+Davidson,22-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,87
+Davidson,22-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,22-4,Public Defender,20,Democratic,Martesha Johnson,375
+Davidson,22-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,23-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,26
+Davidson,23-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,133
+Davidson,23-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,14
+Davidson,23-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,37
+Davidson,23-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,154
+Davidson,23-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,10
+Davidson,23-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-1,Public Defender,20,Democratic,Martesha Johnson,120
+Davidson,23-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,23-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,81
+Davidson,23-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,218
+Davidson,23-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,68
+Davidson,23-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,109
+Davidson,23-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,264
+Davidson,23-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,34
+Davidson,23-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-2,Public Defender,20,Democratic,Martesha Johnson,296
+Davidson,23-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,23-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,75
+Davidson,23-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,146
+Davidson,23-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,69
+Davidson,23-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,136
+Davidson,23-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,121
+Davidson,23-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,45
+Davidson,23-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-3,Public Defender,20,Democratic,Martesha Johnson,254
+Davidson,23-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,23-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,91
+Davidson,23-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,244
+Davidson,23-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,99
+Davidson,23-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,178
+Davidson,23-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,239
+Davidson,23-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,60
+Davidson,23-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-4,Public Defender,20,Democratic,Martesha Johnson,379
+Davidson,23-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,23-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,12
+Davidson,23-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,39
+Davidson,23-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,13
+Davidson,23-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,17
+Davidson,23-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,35
+Davidson,23-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,17
+Davidson,23-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,23-5,Public Defender,20,Democratic,Martesha Johnson,60
+Davidson,23-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,24-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,4
+Davidson,24-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,3
+Davidson,24-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,2
+Davidson,24-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,4
+Davidson,24-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,1
+Davidson,24-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,4
+Davidson,24-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-1,Public Defender,20,Democratic,Martesha Johnson,9
+Davidson,24-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,24-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,43
+Davidson,24-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,165
+Davidson,24-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,40
+Davidson,24-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,78
+Davidson,24-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,164
+Davidson,24-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,21
+Davidson,24-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-2,Public Defender,20,Democratic,Martesha Johnson,202
+Davidson,24-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,24-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,26
+Davidson,24-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,60
+Davidson,24-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,64
+Davidson,24-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,71
+Davidson,24-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,47
+Davidson,24-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,39
+Davidson,24-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-3,Public Defender,20,Democratic,Martesha Johnson,137
+Davidson,24-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,24-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,51
+Davidson,24-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,232
+Davidson,24-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,62
+Davidson,24-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,158
+Davidson,24-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,175
+Davidson,24-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,29
+Davidson,24-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-4,Public Defender,20,Democratic,Martesha Johnson,285
+Davidson,24-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,24-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,90
+Davidson,24-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,259
+Davidson,24-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,130
+Davidson,24-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,240
+Davidson,24-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,210
+Davidson,24-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,62
+Davidson,24-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-5,Public Defender,20,Democratic,Martesha Johnson,433
+Davidson,24-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,24-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,72
+Davidson,24-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,239
+Davidson,24-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,77
+Davidson,24-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,136
+Davidson,24-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,244
+Davidson,24-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,31
+Davidson,24-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,24-6,Public Defender,20,Democratic,Martesha Johnson,312
+Davidson,24-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,25-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,14
+Davidson,25-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,31
+Davidson,25-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,10
+Davidson,25-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,17
+Davidson,25-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,32
+Davidson,25-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,14
+Davidson,25-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-1,Public Defender,20,Democratic,Martesha Johnson,53
+Davidson,25-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,25-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,38
+Davidson,25-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,166
+Davidson,25-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,36
+Davidson,25-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,81
+Davidson,25-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,163
+Davidson,25-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,22
+Davidson,25-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-2,Public Defender,20,Democratic,Martesha Johnson,192
+Davidson,25-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,25-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,70
+Davidson,25-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,291
+Davidson,25-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,59
+Davidson,25-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,148
+Davidson,25-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,233
+Davidson,25-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,64
+Davidson,25-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-3,Public Defender,20,Democratic,Martesha Johnson,347
+Davidson,25-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,25-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,49
+Davidson,25-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,157
+Davidson,25-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,53
+Davidson,25-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,114
+Davidson,25-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,118
+Davidson,25-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,43
+Davidson,25-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-4,Public Defender,20,Democratic,Martesha Johnson,230
+Davidson,25-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,25-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,50
+Davidson,25-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,133
+Davidson,25-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,55
+Davidson,25-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,106
+Davidson,25-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,115
+Davidson,25-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,28
+Davidson,25-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,25-5,Public Defender,20,Democratic,Martesha Johnson,204
+Davidson,25-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,26-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,11
+Davidson,26-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,26
+Davidson,26-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,24
+Davidson,26-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,28
+Davidson,26-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,23
+Davidson,26-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,14
+Davidson,26-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-1,Public Defender,20,Democratic,Martesha Johnson,56
+Davidson,26-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,26-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,75
+Davidson,26-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,189
+Davidson,26-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,72
+Davidson,26-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,119
+Davidson,26-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,171
+Davidson,26-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,60
+Davidson,26-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-2,Public Defender,20,Democratic,Martesha Johnson,287
+Davidson,26-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,26-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,37
+Davidson,26-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,113
+Davidson,26-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,52
+Davidson,26-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,72
+Davidson,26-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,117
+Davidson,26-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,30
+Davidson,26-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-3,Public Defender,20,Democratic,Martesha Johnson,167
+Davidson,26-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,26-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,56
+Davidson,26-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,105
+Davidson,26-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,58
+Davidson,26-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,87
+Davidson,26-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,89
+Davidson,26-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,56
+Davidson,26-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,26-4,Public Defender,20,Democratic,Martesha Johnson,208
+Davidson,26-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,27-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,40
+Davidson,27-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,35
+Davidson,27-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,61
+Davidson,27-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,27-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,45
+Davidson,27-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,42
+Davidson,27-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,54
+Davidson,27-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,27-1,Public Defender,20,Democratic,Martesha Johnson,131
+Davidson,27-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,27-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,66
+Davidson,27-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,76
+Davidson,27-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,80
+Davidson,27-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,27-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,98
+Davidson,27-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,67
+Davidson,27-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,66
+Davidson,27-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,27-3,Public Defender,20,Democratic,Martesha Johnson,198
+Davidson,27-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,27-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,28
+Davidson,27-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,43
+Davidson,27-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,31
+Davidson,27-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,27-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,39
+Davidson,27-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,34
+Davidson,27-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,32
+Davidson,27-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,27-4,Public Defender,20,Democratic,Martesha Johnson,85
+Davidson,27-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,28-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,0
+Davidson,28-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,2
+Davidson,28-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,0
+Davidson,28-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,0
+Davidson,28-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,1
+Davidson,28-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,1
+Davidson,28-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-1,Public Defender,20,Democratic,Martesha Johnson,2
+Davidson,28-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,28-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,5
+Davidson,28-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,11
+Davidson,28-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,17
+Davidson,28-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,12
+Davidson,28-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,8
+Davidson,28-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,14
+Davidson,28-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-2,Public Defender,20,Democratic,Martesha Johnson,30
+Davidson,28-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,28-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,54
+Davidson,28-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,28
+Davidson,28-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,60
+Davidson,28-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,39
+Davidson,28-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,51
+Davidson,28-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,58
+Davidson,28-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-3,Public Defender,20,Democratic,Martesha Johnson,134
+Davidson,28-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,28-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,42
+Davidson,28-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,34
+Davidson,28-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,119
+Davidson,28-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,40
+Davidson,28-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,43
+Davidson,28-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,115
+Davidson,28-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-4,Public Defender,20,Democratic,Martesha Johnson,177
+Davidson,28-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,28-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,66
+Davidson,28-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,45
+Davidson,28-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,171
+Davidson,28-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,64
+Davidson,28-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,68
+Davidson,28-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,157
+Davidson,28-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,28-5,Public Defender,20,Democratic,Martesha Johnson,272
+Davidson,28-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,29-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,57
+Davidson,29-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,47
+Davidson,29-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,143
+Davidson,29-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,57
+Davidson,29-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,84
+Davidson,29-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,118
+Davidson,29-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-1,Public Defender,20,Democratic,Martesha Johnson,244
+Davidson,29-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,29-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,64
+Davidson,29-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,47
+Davidson,29-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,143
+Davidson,29-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,53
+Davidson,29-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,71
+Davidson,29-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,151
+Davidson,29-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-2,Public Defender,20,Democratic,Martesha Johnson,236
+Davidson,29-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,29-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,47
+Davidson,29-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,38
+Davidson,29-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,96
+Davidson,29-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,51
+Davidson,29-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,53
+Davidson,29-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,85
+Davidson,29-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-3,Public Defender,20,Democratic,Martesha Johnson,168
+Davidson,29-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,29-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,121
+Davidson,29-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,93
+Davidson,29-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,208
+Davidson,29-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,101
+Davidson,29-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,136
+Davidson,29-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,205
+Davidson,29-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,29-4,Public Defender,20,Democratic,Martesha Johnson,397
+Davidson,29-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,30-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,34
+Davidson,30-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,34
+Davidson,30-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,53
+Davidson,30-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,30-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,56
+Davidson,30-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,40
+Davidson,30-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,34
+Davidson,30-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,30-1,Public Defender,20,Democratic,Martesha Johnson,106
+Davidson,30-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,30-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,42
+Davidson,30-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,31
+Davidson,30-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,52
+Davidson,30-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,30-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,22
+Davidson,30-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,36
+Davidson,30-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,71
+Davidson,30-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,30-2,Public Defender,20,Democratic,Martesha Johnson,116
+Davidson,30-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,30-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,39
+Davidson,30-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,56
+Davidson,30-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,57
+Davidson,30-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,30-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,56
+Davidson,30-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,47
+Davidson,30-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,53
+Davidson,30-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,30-3,Public Defender,20,Democratic,Martesha Johnson,134
+Davidson,30-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,31-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,16
+Davidson,31-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,5
+Davidson,31-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,25
+Davidson,31-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,5
+Davidson,31-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,18
+Davidson,31-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,23
+Davidson,31-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-1,Public Defender,20,Democratic,Martesha Johnson,47
+Davidson,31-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,31-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,76
+Davidson,31-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,87
+Davidson,31-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,155
+Davidson,31-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,132
+Davidson,31-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,84
+Davidson,31-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,112
+Davidson,31-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-2,Public Defender,20,Democratic,Martesha Johnson,301
+Davidson,31-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,31-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,63
+Davidson,31-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,64
+Davidson,31-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,101
+Davidson,31-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,78
+Davidson,31-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,61
+Davidson,31-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,99
+Davidson,31-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-3,Public Defender,20,Democratic,Martesha Johnson,219
+Davidson,31-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,31-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,80
+Davidson,31-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,68
+Davidson,31-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,113
+Davidson,31-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,67
+Davidson,31-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,84
+Davidson,31-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,121
+Davidson,31-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,31-4,Public Defender,20,Democratic,Martesha Johnson,247
+Davidson,31-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,32-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,15
+Davidson,32-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,12
+Davidson,32-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,38
+Davidson,32-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,17
+Davidson,32-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,10
+Davidson,32-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,38
+Davidson,32-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-1,Public Defender,20,Democratic,Martesha Johnson,60
+Davidson,32-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,32-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,41
+Davidson,32-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,26
+Davidson,32-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,59
+Davidson,32-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,36
+Davidson,32-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,18
+Davidson,32-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,76
+Davidson,32-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-2,Public Defender,20,Democratic,Martesha Johnson,124
+Davidson,32-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,32-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,101
+Davidson,32-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,81
+Davidson,32-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,205
+Davidson,32-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,85
+Davidson,32-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,85
+Davidson,32-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,231
+Davidson,32-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-3,Public Defender,20,Democratic,Martesha Johnson,373
+Davidson,32-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,32-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,72
+Davidson,32-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,55
+Davidson,32-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,170
+Davidson,32-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,70
+Davidson,32-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,64
+Davidson,32-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,173
+Davidson,32-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,32-4,Public Defender,20,Democratic,Martesha Johnson,278
+Davidson,32-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,33-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,74
+Davidson,33-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,79
+Davidson,33-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,104
+Davidson,33-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,92
+Davidson,33-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,79
+Davidson,33-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,102
+Davidson,33-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-1,Public Defender,20,Democratic,Martesha Johnson,241
+Davidson,33-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,33-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,81
+Davidson,33-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,44
+Davidson,33-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,171
+Davidson,33-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,60
+Davidson,33-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,76
+Davidson,33-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,172
+Davidson,33-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-2,Public Defender,20,Democratic,Martesha Johnson,275
+Davidson,33-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,33-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,1
+Davidson,33-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,3
+Davidson,33-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,1
+Davidson,33-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,1
+Davidson,33-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,2
+Davidson,33-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,2
+Davidson,33-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-3,Public Defender,20,Democratic,Martesha Johnson,4
+Davidson,33-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,33-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,36
+Davidson,33-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,26
+Davidson,33-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,73
+Davidson,33-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,48
+Davidson,33-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,25
+Davidson,33-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,66
+Davidson,33-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-4,Public Defender,20,Democratic,Martesha Johnson,129
+Davidson,33-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,33-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,10
+Davidson,33-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,5
+Davidson,33-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,20
+Davidson,33-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,8
+Davidson,33-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,8
+Davidson,33-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,22
+Davidson,33-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-5,Public Defender,20,Democratic,Martesha Johnson,33
+Davidson,33-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,33-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,35
+Davidson,33-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,29
+Davidson,33-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,33
+Davidson,33-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,27
+Davidson,33-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,27
+Davidson,33-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,50
+Davidson,33-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,33-6,Public Defender,20,Democratic,Martesha Johnson,85
+Davidson,33-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,34-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,55
+Davidson,34-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,220
+Davidson,34-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,47
+Davidson,34-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,83
+Davidson,34-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,240
+Davidson,34-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,32
+Davidson,34-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-1,Public Defender,20,Democratic,Martesha Johnson,270
+Davidson,34-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,34-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,17
+Davidson,34-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,92
+Davidson,34-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,12
+Davidson,34-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,37
+Davidson,34-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,79
+Davidson,34-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,11
+Davidson,34-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-2,Public Defender,20,Democratic,Martesha Johnson,96
+Davidson,34-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,34-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,56
+Davidson,34-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,62
+Davidson,34-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,75
+Davidson,34-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,104
+Davidson,34-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,53
+Davidson,34-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,40
+Davidson,34-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-3,Public Defender,20,Democratic,Martesha Johnson,181
+Davidson,34-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,34-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,57
+Davidson,34-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,181
+Davidson,34-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,35
+Davidson,34-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,80
+Davidson,34-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,203
+Davidson,34-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,20
+Davidson,34-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-4,Public Defender,20,Democratic,Martesha Johnson,234
+Davidson,34-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,34-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,68
+Davidson,34-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,234
+Davidson,34-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,44
+Davidson,34-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,121
+Davidson,34-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,236
+Davidson,34-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,28
+Davidson,34-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-5,Public Defender,20,Democratic,Martesha Johnson,288
+Davidson,34-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,34-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,6
+Davidson,34-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,15
+Davidson,34-6,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,3
+Davidson,34-6,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,6
+Davidson,34-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,13
+Davidson,34-6,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,5
+Davidson,34-6,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,34-6,Public Defender,20,Democratic,Martesha Johnson,18
+Davidson,34-6,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,35-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,8
+Davidson,35-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,23
+Davidson,35-1,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,6
+Davidson,35-1,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,14
+Davidson,35-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,21
+Davidson,35-1,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,8
+Davidson,35-1,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-1,Public Defender,20,Democratic,Martesha Johnson,30
+Davidson,35-1,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,35-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,99
+Davidson,35-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,224
+Davidson,35-2,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,92
+Davidson,35-2,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,172
+Davidson,35-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,203
+Davidson,35-2,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,64
+Davidson,35-2,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-2,Public Defender,20,Democratic,Martesha Johnson,371
+Davidson,35-2,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,35-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,90
+Davidson,35-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,195
+Davidson,35-3,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,87
+Davidson,35-3,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,168
+Davidson,35-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,146
+Davidson,35-3,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,73
+Davidson,35-3,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-3,Public Defender,20,Democratic,Martesha Johnson,346
+Davidson,35-3,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,35-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,14
+Davidson,35-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,26
+Davidson,35-4,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,27
+Davidson,35-4,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,31
+Davidson,35-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,17
+Davidson,35-4,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,19
+Davidson,35-4,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-4,Public Defender,20,Democratic,Martesha Johnson,65
+Davidson,35-4,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,35-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,112
+Davidson,35-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,183
+Davidson,35-5,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,98
+Davidson,35-5,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,174
+Davidson,35-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,158
+Davidson,35-5,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,73
+Davidson,35-5,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,35-5,Public Defender,20,Democratic,Martesha Johnson,363
+Davidson,35-5,Public Defender,20,Republican,No Candidate Qualified,0
+Davidson,All County Precinct,Circuit Court Judge Division III,20 (unexpired term),Democratic,Audrey Anderson,0
+Davidson,All County Precinct,Circuit Court Judge Division III,20 (unexpired term),Democratic,Bethany Peery Glandorf,0
+Davidson,All County Precinct,Circuit Court Judge Division III,20 (unexpired term),Democratic,Corletra Mance,0
+Davidson,All County Precinct,Circuit Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,All County Precinct,Criminal Court Judge Division III,20 (unexpired term),Democratic,Dawn Deaner,0
+Davidson,All County Precinct,Criminal Court Judge Division III,20 (unexpired term),Democratic,Jim Todd,0
+Davidson,All County Precinct,Criminal Court Judge Division III,20 (unexpired term),Democratic,Ronald Jamar Dowdy,0
+Davidson,All County Precinct,Criminal Court Judge Division III,20 (unexpired term),Republican,No Candidate Qualified,0
+Davidson,All County Precinct,Public Defender,20,Democratic,Martesha Johnson,0
+Davidson,All County Precinct,Public Defender,20,Republican,No Candidate Qualified,0
+Dickson,1-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,385
+Dickson,10-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,338
+Dickson,11-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,233
+Dickson,12-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,314
+Dickson,2-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,372
+Dickson,3-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,286
+Dickson,4-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,294
+Dickson,5-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,200
+Dickson,6-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,114
+Dickson,6-2,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,188
+Dickson,7-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,231
+Dickson,8-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,141
+Dickson,9-1,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,324
+Giles,1A Ardmore,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,1B Prospect,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,2A Minor Hill,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,2B Airport,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,3A Richland Trace,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,3B Campbellsville,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,4A Lynnville,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,4B Odd Fellows Hall,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,5A TCAT,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,5B Agri-Park,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,6A UTS,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,6B Bridgeforth,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,7A GCHS,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Giles,7B Rec Center,Circuit Court Judge Part I,22 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,1-1,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,1-1,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,221
+Grainger,1-1,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,1-1,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,217
+Grainger,1-2,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,1-2,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,273
+Grainger,1-2,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,1-2,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,260
+Grainger,2-1,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,2-1,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,97
+Grainger,2-1,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,2-1,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,97
+Grainger,2-2,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,2-2,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,271
+Grainger,2-2,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,2-2,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,261
+Grainger,3-1,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,3-1,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,149
+Grainger,3-1,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,3-1,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,144
+Grainger,3-2,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,3-2,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,279
+Grainger,3-2,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,3-2,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,278
+Grainger,4-1,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,4-1,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,148
+Grainger,4-1,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,4-1,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,147
+Grainger,4-2,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,4-2,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,249
+Grainger,4-2,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,4-2,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,238
+Grainger,5-1,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,5-1,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,148
+Grainger,5-1,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,5-1,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,141
+Grainger,5-2,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,5-2,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,175
+Grainger,5-2,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Grainger,5-2,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,169
+Hamilton,Airport A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Airport A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,2
+Hamilton,Airport B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Airport B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,48
+Hamilton,Alton Park,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Alton Park,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,6
+Hamilton,Apison A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Apison A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,66
+Hamilton,Apison B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Apison B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,192
+Hamilton,Avondale,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Avondale,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,2
+Hamilton,Birchwood,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Birchwood,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,241
+Hamilton,Bonny Oaks,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Bonny Oaks,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,18
+Hamilton,Brainerd,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Brainerd,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,49
+Hamilton,Brainerd Hills,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Brainerd Hills,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,45
+Hamilton,Bushtown,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Bushtown,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,16
+Hamilton,Collegedale A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Collegedale A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,84
+Hamilton,Collegedale B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Collegedale B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,100
+Hamilton,Concord A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Concord A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,42
+Hamilton,Concord B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Concord B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,80
+Hamilton,Courthouse,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Courthouse,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,12
+Hamilton,Dalewood,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Dalewood,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,11
+Hamilton,Dallas,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Dallas,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,137
+Hamilton,Downtown,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Downtown,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,35
+Hamilton,DuPont,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,DuPont,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,116
+Hamilton,East Brainerd A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Brainerd A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,85
+Hamilton,East Brainerd B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Brainerd B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,136
+Hamilton,East Chattanooga,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Chattanooga,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,9
+Hamilton,East Lake,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Lake,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,27
+Hamilton,East Ridge A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Ridge A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,139
+Hamilton,East Ridge B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Ridge B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,168
+Hamilton,East Ridge C,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Ridge C,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,62
+Hamilton,East Ridge D,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,East Ridge D,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,93
+Hamilton,Eastgate,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Eastgate,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,24
+Hamilton,Eastside,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Eastside,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,42
+Hamilton,Fairmount,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Fairmount,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,222
+Hamilton,Falling Water A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Falling Water A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,24
+Hamilton,Falling Water B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Falling Water B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,92
+Hamilton,Flat Top Mountain,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Flat Top Mountain,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,34
+Hamilton,Ganns,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Ganns,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,169
+Hamilton,Glenwood,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Glenwood,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,21
+Hamilton,Harrison,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Harrison,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,258
+Hamilton,Harrison Bay,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Harrison Bay,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,436
+Hamilton,Hixson,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Hixson,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,90
+Hamilton,Hunter,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Hunter,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,309
+Hamilton,Hurricane Creek,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Hurricane Creek,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,192
+Hamilton,Kingspoint,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Kingspoint,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,17
+Hamilton,Lake Hills,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Lake Hills,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,16
+Hamilton,Lakesite,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Lakesite,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,58
+Hamilton,Lookout Mountain,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Lookout Mountain,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,50
+Hamilton,Lookout Valley,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Lookout Valley,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,184
+Hamilton,Lupton City,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Lupton City,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,87
+Hamilton,Meadowview,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Meadowview,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,317
+Hamilton,Middle Valley,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Middle Valley,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,85
+Hamilton,Missionary Ridge,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Missionary Ridge,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,38
+Hamilton,Mountain Creek A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Mountain Creek A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,227
+Hamilton,Mountain Creek B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Mountain Creek B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,57
+Hamilton,Mountain Creek C,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Mountain Creek C,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,3
+Hamilton,Mowbray A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Mowbray A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,48
+Hamilton,Mowbray B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Mowbray B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,60
+Hamilton,Murray Hills,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Murray Hills,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,39
+Hamilton,North Chattanooga A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,North Chattanooga A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,45
+Hamilton,North Chattanooga B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,North Chattanooga B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,16
+Hamilton,Northgate,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Northgate,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,115
+Hamilton,Northshore,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Northshore,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,65
+Hamilton,Northwoods,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Northwoods,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,176
+Hamilton,Ooltewah,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Ooltewah,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,276
+Hamilton,Ooltewah Georgetown,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Ooltewah Georgetown,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,216
+Hamilton,Ooltewah Ringgold,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Ooltewah Ringgold,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,190
+Hamilton,Pleasant Grove A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Pleasant Grove A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,139
+Hamilton,Pleasant Grove B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Pleasant Grove B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,3
+Hamilton,Possum Creek,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Possum Creek,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,161
+Hamilton,Red Bank A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Red Bank A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,47
+Hamilton,Red Bank B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Red Bank B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,63
+Hamilton,Red Bank C,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Red Bank C,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,55
+Hamilton,Ridgedale,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Ridgedale,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,20
+Hamilton,Ridgeside,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Ridgeside,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,18
+Hamilton,Riverview,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Riverview,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,29
+Hamilton,Sale Creek,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Sale Creek,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,124
+Hamilton,Savannah Bay,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Savannah Bay,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,296
+Hamilton,Sequoyah,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Sequoyah,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,109
+Hamilton,Signal Mountain A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Signal Mountain A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,197
+Hamilton,Signal Mountain B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Signal Mountain B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,371
+Hamilton,Silverdale,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Silverdale,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,61
+Hamilton,Soddy Daisy A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Soddy Daisy A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,156
+Hamilton,Soddy Daisy B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Soddy Daisy B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,156
+Hamilton,Soddy Daisy C,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Soddy Daisy C,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,108
+Hamilton,St. Elmo,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,St. Elmo,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,53
+Hamilton,Stuart Heights,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Stuart Heights,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,68
+Hamilton,Summit,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Summit,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,155
+Hamilton,Tyner,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Tyner,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,89
+Hamilton,Valleybrook,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Valleybrook,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,238
+Hamilton,Walden,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Walden,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,143
+Hamilton,Westview A,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Westview A,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,46
+Hamilton,Westview B,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Westview B,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,114
+Hamilton,Wolftever,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Wolftever,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,301
+Hamilton,Woodmore,Circuit Court Judge Division 2,11 (unexpired term),Democratic,No Candidate Qualified,0
+Hamilton,Woodmore,Circuit Court Judge Division 2,11 (unexpired term),Republican,Jennifer K. Peck,10
+Hickman,1-1 Nunnelly,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,1-1 Nunnelly,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",32
+Hickman,1-2 Pinewood,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,1-2 Pinewood,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",46
+Hickman,2-2 Fairfield,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,2-2 Fairfield,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",24
+Hickman,2-3 East Bank,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,2-3 East Bank,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",62
+Hickman,3-1 East CC,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,3-1 East CC,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",103
+Hickman,4-1 Lake Benson,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,4-1 Lake Benson,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",71
+Hickman,5-1 Mt. Pleasant,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,5-1 Mt. Pleasant,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",29
+Hickman,5-2 Middle School,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,5-2 Middle School,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",33
+Hickman,5-3 Shady Grove,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,5-3 Shady Grove,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",30
+Hickman,6-1 Justice Center,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,6-1 Justice Center,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",122
+Hickman,7-1 Nunnelly,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,7-1 Nunnelly,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",7
+Hickman,7-2 Pleasantville,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,7-2 Pleasantville,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",10
+Hickman,7-3 Brushy,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,7-3 Brushy,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",43
+Hickman,7-4 Coble,Circuit and Chancery Court Judge,32 (unexpired term),Democratic,No Candidate Qualified,0
+Hickman,7-4 Coble,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",18
+Houston,Arlington,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Arlington,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,38
+Houston,Erin,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Erin,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,27
+Houston,Erin Elementary,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Erin Elementary,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,29
+Houston,Griffins Chapel,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Griffins Chapel,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,39
+Houston,Houston Co Middle,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Houston Co Middle,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,40
+Houston,Stewart,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Stewart,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,47
+Houston,Tennessee Ridge,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Houston,Tennessee Ridge,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,50
+Humphreys,1-1 Jera,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,5
+Humphreys,1-2 Compassion Church,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,23
+Humphreys,2-3 WCN,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,25
+Humphreys,3-4 Apex,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,10
+Humphreys,4-5 Woodland,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,21
+Humphreys,5-6 Wildwood,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,23
+Humphreys,6-7 South McEwen,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,40
+Humphreys,7-8 North McEwen,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,29
+Jefferson,1 Dandridge ES,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,1 Dandridge ES,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,679
+Jefferson,1 Dandridge ES,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,1 Dandridge ES,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,636
+Jefferson,10 Jeff City Fire Dp,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,10 Jeff City Fire Dp,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,266
+Jefferson,10 Jeff City Fire Dp,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,10 Jeff City Fire Dp,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,251
+Jefferson,2 Piedmont,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,2 Piedmont,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,607
+Jefferson,2 Piedmont,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,2 Piedmont,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,575
+Jefferson,3 White Pine,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,3 White Pine,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,770
+Jefferson,3 White Pine,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,3 White Pine,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,699
+Jefferson,4 Jefferson ES,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,4 Jefferson ES,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,418
+Jefferson,4 Jefferson ES,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,4 Jefferson ES,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,385
+Jefferson,5 Jefferson High,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,5 Jefferson High,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,656
+Jefferson,5 Jefferson High,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,5 Jefferson High,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,605
+Jefferson,6 Rush Strong,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,6 Rush Strong,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,394
+Jefferson,6 Rush Strong,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,6 Rush Strong,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,374
+Jefferson,7 New Market,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,7 New Market,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,609
+Jefferson,7 New Market,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,7 New Market,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,560
+Jefferson,8-1 Chestnut Hill,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,8-1 Chestnut Hill,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,330
+Jefferson,8-1 Chestnut Hill,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,8-1 Chestnut Hill,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,291
+Jefferson,8-2 Swannsylvania,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,8-2 Swannsylvania,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,266
+Jefferson,8-2 Swannsylvania,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,8-2 Swannsylvania,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,238
+Jefferson,9 Talbott School,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,9 Talbott School,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,573
+Jefferson,9 Talbott School,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Jefferson,9 Talbott School,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,531
+Johnson,1A Laurel,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,1A Laurel,Public Defender,1 (unexpired term),Republican,Bill Donaldson,147
+Johnson,1A Laurel,Public Defender,1 (unexpired term),Republican,Melanie Sellers,138
+Johnson,1B Cold Springs,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,1B Cold Springs,Public Defender,1 (unexpired term),Republican,Bill Donaldson,119
+Johnson,1B Cold Springs,Public Defender,1 (unexpired term),Republican,Melanie Sellers,159
+Johnson,2 Forge/Shouns,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,2 Forge/Shouns,Public Defender,1 (unexpired term),Republican,Bill Donaldson,98
+Johnson,2 Forge/Shouns,Public Defender,1 (unexpired term),Republican,Melanie Sellers,99
+Johnson,3A Trade,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,3A Trade,Public Defender,1 (unexpired term),Republican,Bill Donaldson,60
+Johnson,3A Trade,Public Defender,1 (unexpired term),Republican,Melanie Sellers,71
+Johnson,3B Neva,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,3B Neva,Public Defender,1 (unexpired term),Republican,Bill Donaldson,167
+Johnson,3B Neva,Public Defender,1 (unexpired term),Republican,Melanie Sellers,170
+Johnson,4A Dry Run,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,4A Dry Run,Public Defender,1 (unexpired term),Republican,Bill Donaldson,80
+Johnson,4A Dry Run,Public Defender,1 (unexpired term),Republican,Melanie Sellers,58
+Johnson,4B Butler,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,4B Butler,Public Defender,1 (unexpired term),Republican,Bill Donaldson,81
+Johnson,4B Butler,Public Defender,1 (unexpired term),Republican,Melanie Sellers,92
+Johnson,5 Doe,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,5 Doe,Public Defender,1 (unexpired term),Republican,Bill Donaldson,161
+Johnson,5 Doe,Public Defender,1 (unexpired term),Republican,Melanie Sellers,211
+Johnson,6 Shady,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,6 Shady,Public Defender,1 (unexpired term),Republican,Bill Donaldson,89
+Johnson,6 Shady,Public Defender,1 (unexpired term),Republican,Melanie Sellers,72
+Johnson,7 City,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Johnson,7 City,Public Defender,1 (unexpired term),Republican,Bill Donaldson,183
+Johnson,7 City,Public Defender,1 (unexpired term),Republican,Melanie Sellers,161
+Knox,06 Green School,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,06 Green School,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,131
+Knox,09 Eternal Life Harvest,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,09 Eternal Life Harvest,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,8
+Knox,10A Howard Baker Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,10A Howard Baker Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,0
+Knox,10N Fort Sanders,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,10N Fort Sanders,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,20
+Knox,10S Howard Baker Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,10S Howard Baker Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,2
+Knox,10W Howard Baker Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,10W Howard Baker Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,0
+Knox,11 Central UMC,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,11 Central UMC,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,123
+Knox,12 YWCA,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,12 YWCA,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,24
+Knox,13 Fair Garden,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,13 Fair Garden,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,75
+Knox,14 Austin-East,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,14 Austin-East,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,10
+Knox,15E John T. O'Connor,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,15E John T. O'Connor,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,39
+Knox,15W John T. O'Connor,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,15W John T. O'Connor,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,33
+Knox,16E Larry Cox Sr Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,16E Larry Cox Sr Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,232
+Knox,16W Larry Cox Sr Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,16W Larry Cox Sr Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,136
+Knox,16X Larry Cox Sr Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,16X Larry Cox Sr Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,0
+Knox,17 Christenberry,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,17 Christenberry,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,119
+Knox,18 Lincoln Park,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,18 Lincoln Park,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,71
+Knox,19 Thrive Lonsdale,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,19 Thrive Lonsdale,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,37
+Knox,20 Beaumont,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,20 Beaumont,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,22
+Knox,23 Westview,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,23 Westview,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,57
+Knox,24Q Sequoyah Hills,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,24Q Sequoyah Hills,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,435
+Knox,25 South Knox CC,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,25 South Knox CC,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,241
+Knox,26 Dogwood,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,26 Dogwood,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,283
+Knox,27 South Knox,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,27 South Knox,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,198
+Knox,29 Anderson,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,29 Anderson,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,218
+Knox,30 Sarah Moore Greene,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,30 Sarah Moore Greene,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,58
+Knox,31 Chilhowee,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,31 Chilhowee,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,166
+Knox,32 Spring Hill,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,32 Spring Hill,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,173
+Knox,33N Richard Yoakley,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,33N Richard Yoakley,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,38
+Knox,33S Richard Yoakley,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,33S Richard Yoakley,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,139
+Knox,33X Richard Yoakley,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,33X Richard Yoakley,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,0
+Knox,34 Central,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,34 Central,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,120
+Knox,35 Shannondale,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,35 Shannondale,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,338
+Knox,36 Gresham,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,36 Gresham,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,423
+Knox,37 Inskip Elementary,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,37 Inskip Elementary,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,381
+Knox,39E Inskip Rec Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,39E Inskip Rec Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,115
+Knox,39W Inskip Rec Center,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,39W Inskip Rec Center,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,81
+Knox,40 Norwood,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,40 Norwood,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,289
+Knox,41 Norwood,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,41 Norwood,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,51
+Knox,42 Pleasant Ridge,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,42 Pleasant Ridge,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,215
+Knox,43 West Haven,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,43 West Haven,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,185
+Knox,44 Ridgedale,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,44 Ridgedale,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,308
+Knox,45 Bearden Middle,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,45 Bearden Middle,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,564
+Knox,46 1st Nazarene,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,46 1st Nazarene,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,498
+Knox,47N Bearden High,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,47N Bearden High,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,325
+Knox,47S Bearden High,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,47S Bearden High,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,206
+Knox,48 Pond Gap,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,48 Pond Gap,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,139
+Knox,49N Bearden Elementary,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,49N Bearden Elementary,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,115
+Knox,49S Bearden Elementary,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,49S Bearden Elementary,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,56
+Knox,50N West High,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,50N West High,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,42
+Knox,50S West High,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,50S West High,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,10
+Knox,51 Deane Hill Rec Ctr,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,51 Deane Hill Rec Ctr,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,635
+Knox,55 Lonas,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,55 Lonas,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,389
+Knox,56 Heiskell,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,56 Heiskell,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,248
+Knox,57 Hills,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,57 Hills,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,91
+Knox,58 Pedigo,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,58 Pedigo,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,573
+Knox,59 Brickey,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,59 Brickey,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,987
+Knox,60 Fort Sumter,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,60 Fort Sumter,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,392
+Knox,61E Halls East,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,61E Halls East,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,725
+Knox,61W Halls,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,61W Halls,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,886
+Knox,62 Hardin Valley,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,62 Hardin Valley,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,783
+Knox,63 Karns,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,63 Karns,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,990
+Knox,63N Karns North,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,63N Karns North,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,558
+Knox,64 Solway,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,64 Solway,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,763
+Knox,65E Concord East,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,65E Concord East,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,230
+Knox,65N Concord North,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,65N Concord North,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,351
+Knox,65S Concord South,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,65S Concord South,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,639
+Knox,65SW Concord Southwest,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,65SW Concord Southwest,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,561
+Knox,65W Concord West,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,65W Concord West,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,381
+Knox,66NE NE Farragut Middle,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,66NE NE Farragut Middle,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,251
+Knox,66NW NW Farragut Middle,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,66NW NW Farragut Middle,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,951
+Knox,66SE SE Farragut,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,66SE SE Farragut,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,969
+Knox,66SW SW Farragut High,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,66SW SW Farragut High,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,437
+Knox,67 North Cedar Bluff,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,67 North Cedar Bluff,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,673
+Knox,68 South Cedar Bluff,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,68 South Cedar Bluff,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,478
+Knox,68E East Cedar Bluff,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,68E East Cedar Bluff,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,167
+Knox,69E Bluegrass,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,69E Bluegrass,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,686
+Knox,69N West Valley,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,69N West Valley,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,489
+Knox,69S Northshore,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,69S Northshore,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,562
+Knox,69W A. L. Lotts,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,69W A. L. Lotts,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,558
+Knox,70E Amherst,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,70E Amherst,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,750
+Knox,70W Ball Camp,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,70W Ball Camp,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,705
+Knox,71 Rocky Hill,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,71 Rocky Hill,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,1048
+Knox,72E Dante East,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,72E Dante East,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,306
+Knox,72W Dante West,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,72W Dante West,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,299
+Knox,73E Powell East,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,73E Powell East,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,557
+Knox,73W Powell West,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,73W Powell West,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,428
+Knox,74 Shannondale,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,74 Shannondale,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,571
+Knox,76 Sunnyview,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,76 Sunnyview,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,327
+Knox,78 Riverdale,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,78 Riverdale,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,340
+Knox,79 Dora Kennedy,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,79 Dora Kennedy,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,215
+Knox,80 Corryton,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,80 Corryton,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,383
+Knox,81 Gibbs,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,81 Gibbs,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,1331
+Knox,82 Ellistown,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,82 Ellistown,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,280
+Knox,84 Ritta,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,84 Ritta,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,725
+Knox,85 Skaggston,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,85 Skaggston,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,297
+Knox,86 Carter,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,86 Carter,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,407
+Knox,87 Thorngrove,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,87 Thorngrove,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,278
+Knox,89 Mt. Olive,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,89 Mt. Olive,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,553
+Knox,90 Bonny Kate,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,90 Bonny Kate,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,757
+Knox,92 Gap Creek,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,92 Gap Creek,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,167
+Knox,93 Hopewell,Criminal Court Judge Division I,6 (unexpired term),Democratic,No Candidate Qualified,0
+Knox,93 Hopewell,Criminal Court Judge Division I,6 (unexpired term),Republican,Emily F. Abbott,400
+Lewis,1-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",129
+Lewis,2-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",256
+Lewis,3-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",263
+Lewis,4-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",300
+Lewis,5-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",271
+Lewis,6-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",240
+Lewis,7-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",268
+Lewis,8-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",247
+Lewis,9-1,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",230
+Montgomery,10 Minglewood,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,10 Minglewood,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,75
+Montgomery,11A Mosaic,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,11A Mosaic,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,81
+Montgomery,11B Northwest,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,11B Northwest,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,69
+Montgomery,12A West Creek,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,12A West Creek,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,31
+Montgomery,12B Airport,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,12B Airport,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,31
+Montgomery,13A Byrns Darden,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,13A Byrns Darden,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,41
+Montgomery,13B Kenwood,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,13B Kenwood,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,61
+Montgomery,14A St B ELC,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,14A St B ELC,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,29
+Montgomery,14B First MBC,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,14B First MBC,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,101
+Montgomery,15A Excell,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,15A Excell,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,297
+Montgomery,15B Sango,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,15B Sango,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,267
+Montgomery,16A Ringgold,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,16A Ringgold,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,65
+Montgomery,16B New Providence,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,16B New Providence,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,63
+Montgomery,17A Grace,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,17A Grace,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,50
+Montgomery,17B Glenellen,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,17B Glenellen,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,68
+Montgomery,18A Barkers Mill,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,18A Barkers Mill,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,53
+Montgomery,18B Pisgah,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,18B Pisgah,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,65
+Montgomery,19A Rossview,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,19A Rossview,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,200
+Montgomery,19B South Guthrie,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,19B South Guthrie,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,64
+Montgomery,1A St B CC,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,1A St B CC,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,164
+Montgomery,1B St B UMC,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,1B St B UMC,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,131
+Montgomery,20A Northeast,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,20A Northeast,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,57
+Montgomery,20B Oakland,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,20B Oakland,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,79
+Montgomery,21A Hilldale,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,21A Hilldale,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,252
+Montgomery,21B Barksdale,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,21B Barksdale,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,119
+Montgomery,2A Clarksville,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,2A Clarksville,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,310
+Montgomery,2B Bible,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,2B Bible,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,174
+Montgomery,3A East Montgomery,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,3A East Montgomery,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,256
+Montgomery,3B Fredonia,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,3B Fredonia,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,301
+Montgomery,4A MCMS,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,4A MCMS,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,222
+Montgomery,4B WR Event Center,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,4B WR Event Center,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,123
+Montgomery,5 Cumberland,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,5 Cumberland,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,90
+Montgomery,6A Cumberland,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,6A Cumberland,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,217
+Montgomery,6B Bethel,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,6B Bethel,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,185
+Montgomery,7A Liberty,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,7A Liberty,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,149
+Montgomery,7B Woodlawn,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,7B Woodlawn,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,248
+Montgomery,8 Bethel,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,8 Bethel,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,30
+Montgomery,9A Hazelwood,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,9A Hazelwood,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,60
+Montgomery,9B St John,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Montgomery,9B St John,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,56
+Perry,1-1 Cedar Creek,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",14
+Perry,1-2 Marsh Creek,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",14
+Perry,2-1 Pineview,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",21
+Perry,2-2 Pope,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",12
+Perry,3-1 Coon Creek,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",16
+Perry,3-2 Flatwoods,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",21
+Perry,4-1 Brush Creek,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",4
+Perry,4-3 Lobelville,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",13
+Perry,5-1 Linden,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",22
+Perry,6-1 Lobelville,Circuit and Chancery Court Judge,32 (unexpired term),Republican,"William K. Lane, III",23
+Robertson,01-1 East Robertson,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,01-1 East Robertson,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,441
+Robertson,02-1 Woodall,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,02-1 Woodall,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,272
+Robertson,03-1 Ebenezer,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,03-1 Ebenezer,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,172
+Robertson,03-2 Heritage,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,03-2 Heritage,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,263
+Robertson,04-1 Watauga,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,04-1 Watauga,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,274
+Robertson,05-1 Greenbrier,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,05-1 Greenbrier,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,273
+Robertson,06-1 Coopertown,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,06-1 Coopertown,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,253
+Robertson,06-2 Mt. Sharon,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,06-2 Mt. Sharon,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,222
+Robertson,07-1 Jo Byrns,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,07-1 Jo Byrns,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,601
+Robertson,07-2 Stroudsville,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,07-2 Stroudsville,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,153
+Robertson,08-1 Krisle,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,08-1 Krisle,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,206
+Robertson,08-2 HATS,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,08-2 HATS,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,220
+Robertson,08-3 Owens Chapel,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,08-3 Owens Chapel,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,256
+Robertson,09-1 Fair Assoc.,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,09-1 Fair Assoc.,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,312
+Robertson,10-1 South Haven,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,10-1 South Haven,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,468
+Robertson,11-1 Westside,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,11-1 Westside,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,440
+Robertson,11-2 Heads,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,11-2 Heads,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,101
+Robertson,12-1 Bransford,Chancellor Part II,19 (unexpired term),Democratic,No Candidate Qualified,0
+Robertson,12-1 Bransford,Chancellor Part II,19 (unexpired term),Republican,Kimberly Lund,62
+Sevier,1-1 Caton's Chapel,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,1-1 Caton's Chapel,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,128
+Sevier,1-1 Caton's Chapel,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,1-1 Caton's Chapel,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,124
+Sevier,1-2 Caton's Chapel,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,1-2 Caton's Chapel,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,582
+Sevier,1-2 Caton's Chapel,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,1-2 Caton's Chapel,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,566
+Sevier,1-3 Jones Cove,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,1-3 Jones Cove,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,296
+Sevier,1-3 Jones Cove,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,1-3 Jones Cove,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,303
+Sevier,10-1 Boyds Creek,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,10-1 Boyds Creek,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,523
+Sevier,10-1 Boyds Creek,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,10-1 Boyds Creek,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,513
+Sevier,10-2 DuPont,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,10-2 DuPont,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,266
+Sevier,10-2 DuPont,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,10-2 DuPont,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,256
+Sevier,10-3 Zion Hill,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,10-3 Zion Hill,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,100
+Sevier,10-3 Zion Hill,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,10-3 Zion Hill,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,95
+Sevier,11-1 Gatlinburg,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,11-1 Gatlinburg,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,29
+Sevier,11-1 Gatlinburg,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,11-1 Gatlinburg,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,26
+Sevier,11-2 Gatlinburg,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,11-2 Gatlinburg,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,443
+Sevier,11-2 Gatlinburg,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,11-2 Gatlinburg,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,455
+Sevier,11-3 Pittman Center,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,11-3 Pittman Center,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,173
+Sevier,11-3 Pittman Center,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,11-3 Pittman Center,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,174
+Sevier,2-1 Waldens Creek,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,2-1 Waldens Creek,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,362
+Sevier,2-1 Waldens Creek,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,2-1 Waldens Creek,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,360
+Sevier,2-2 Whites,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,2-2 Whites,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,103
+Sevier,2-2 Whites,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,2-2 Whites,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,102
+Sevier,2-3 Wearwood,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,2-3 Wearwood,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,461
+Sevier,2-3 Wearwood,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,2-3 Wearwood,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,467
+Sevier,3-1 Harrisburg,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,3-1 Harrisburg,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,50
+Sevier,3-1 Harrisburg,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,3-1 Harrisburg,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,49
+Sevier,3-2 New Center,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,3-2 New Center,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,1075
+Sevier,3-2 New Center,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,3-2 New Center,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,1067
+Sevier,4-1 Pigeon Forge,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,4-1 Pigeon Forge,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,488
+Sevier,4-1 Pigeon Forge,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,4-1 Pigeon Forge,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,487
+Sevier,4-2 Sevierville Elem,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,4-2 Sevierville Elem,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,584
+Sevier,4-2 Sevierville Elem,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,4-2 Sevierville Elem,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,585
+Sevier,5-1 Sevierville,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,5-1 Sevierville,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,756
+Sevier,5-1 Sevierville,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,5-1 Sevierville,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,750
+Sevier,5-2 Senior Center,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,5-2 Senior Center,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,403
+Sevier,5-2 Senior Center,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,5-2 Senior Center,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,401
+Sevier,6-1 Seymour,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,6-1 Seymour,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,1078
+Sevier,6-1 Seymour,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,6-1 Seymour,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,1070
+Sevier,7-1 Catlettsburg,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,7-1 Catlettsburg,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,314
+Sevier,7-1 Catlettsburg,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,7-1 Catlettsburg,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,309
+Sevier,7-2 Catlettsburg,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,7-2 Catlettsburg,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,149
+Sevier,7-2 Catlettsburg,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,7-2 Catlettsburg,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,145
+Sevier,7-3 Walnut Grove,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,7-3 Walnut Grove,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,126
+Sevier,7-3 Walnut Grove,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,7-3 Walnut Grove,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,122
+Sevier,8-1 Kodak,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,8-1 Kodak,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,938
+Sevier,8-1 Kodak,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,8-1 Kodak,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,913
+Sevier,8-2 Underwood,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,8-2 Underwood,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,417
+Sevier,8-2 Underwood,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,8-2 Underwood,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,407
+Sevier,9-1 Seymour Primary,Circuit Court Judge Part IV,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,9-1 Seymour Primary,Circuit Court Judge Part IV,4 (unexpired term),Republican,Jeremy Ball,782
+Sevier,9-1 Seymour Primary,Circuit Court Judge Part V,4 (unexpired term),Democratic,No Candidate Qualified,0
+Sevier,9-1 Seymour Primary,Circuit Court Judge Part V,4 (unexpired term),Republican,Adrienne Ogle,782
+Stewart,1-1 Indian Mound,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,1-1 Indian Mound,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,22
+Stewart,2-1 Big Rock,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,2-1 Big Rock,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,26
+Stewart,3-1 Bumpus Mills,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,3-1 Bumpus Mills,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,52
+Stewart,4-1 Church Street,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,4-1 Church Street,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,35
+Stewart,5-1 Visitors Center,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,5-1 Visitors Center,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,28
+Stewart,6-1 Public Library,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,6-1 Public Library,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,22
+Stewart,7-1 Cumberland City,Circuit Court Judge Division IV,23 (unexpired term),Democratic,No Candidate Qualified,0
+Stewart,7-1 Cumberland City,Circuit Court Judge Division IV,23 (unexpired term),Republican,Joshua Turnbow,23
+Sumner,1-1 Westmoreland,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,1-1 Westmoreland,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,275
+Sumner,1-1 Westmoreland,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,244
+Sumner,1-1 Westmoreland,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,1-1 Westmoreland,District Attorney General,18 (unexpired term),Republican,Thomas Dean,456
+Sumner,10-1 Vol State,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,10-1 Vol State,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,332
+Sumner,10-1 Vol State,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,306
+Sumner,10-1 Vol State,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,10-1 Vol State,District Attorney General,18 (unexpired term),Republican,Thomas Dean,559
+Sumner,11-1 Station Camp MS,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,11-1 Station Camp MS,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,220
+Sumner,11-1 Station Camp MS,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,165
+Sumner,11-1 Station Camp MS,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,11-1 Station Camp MS,District Attorney General,18 (unexpired term),Republican,Thomas Dean,350
+Sumner,12-1 Howard,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,12-1 Howard,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,117
+Sumner,12-1 Howard,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,66
+Sumner,12-1 Howard,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,12-1 Howard,District Attorney General,18 (unexpired term),Republican,Thomas Dean,158
+Sumner,12-2 Station Camp HS,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,12-2 Station Camp HS,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,238
+Sumner,12-2 Station Camp HS,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,124
+Sumner,12-2 Station Camp HS,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,12-2 Station Camp HS,District Attorney General,18 (unexpired term),Republican,Thomas Dean,309
+Sumner,13-1 Union,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,13-1 Union,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,206
+Sumner,13-1 Union,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,137
+Sumner,13-1 Union,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,13-1 Union,District Attorney General,18 (unexpired term),Republican,Thomas Dean,294
+Sumner,14-1 Beech,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,14-1 Beech,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,218
+Sumner,14-1 Beech,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,177
+Sumner,14-1 Beech,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,14-1 Beech,District Attorney General,18 (unexpired term),Republican,Thomas Dean,314
+Sumner,14-2 Birdwell,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,14-2 Birdwell,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,146
+Sumner,14-2 Birdwell,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,139
+Sumner,14-2 Birdwell,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,14-2 Birdwell,District Attorney General,18 (unexpired term),Republican,Thomas Dean,237
+Sumner,15-1 White House,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,15-1 White House,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,166
+Sumner,15-1 White House,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,143
+Sumner,15-1 White House,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,15-1 White House,District Attorney General,18 (unexpired term),Republican,Thomas Dean,267
+Sumner,16-1 Millersville,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,16-1 Millersville,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,193
+Sumner,16-1 Millersville,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,187
+Sumner,16-1 Millersville,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,16-1 Millersville,District Attorney General,18 (unexpired term),Republican,Thomas Dean,313
+Sumner,17-1 Goodlettsville,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,17-1 Goodlettsville,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,305
+Sumner,17-1 Goodlettsville,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,286
+Sumner,17-1 Goodlettsville,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,17-1 Goodlettsville,District Attorney General,18 (unexpired term),Republican,Thomas Dean,465
+Sumner,18-1 Merrol Hyde,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,18-1 Merrol Hyde,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,122
+Sumner,18-1 Merrol Hyde,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,121
+Sumner,18-1 Merrol Hyde,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,18-1 Merrol Hyde,District Attorney General,18 (unexpired term),Republican,Thomas Dean,212
+Sumner,19-1 Brown,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,19-1 Brown,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,113
+Sumner,19-1 Brown,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,97
+Sumner,19-1 Brown,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,19-1 Brown,District Attorney General,18 (unexpired term),Republican,Thomas Dean,184
+Sumner,2-1 Corinth,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,2-1 Corinth,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,149
+Sumner,2-1 Corinth,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,226
+Sumner,2-1 Corinth,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,2-1 Corinth,District Attorney General,18 (unexpired term),Republican,Thomas Dean,318
+Sumner,20-1 Hawkins,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,20-1 Hawkins,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,195
+Sumner,20-1 Hawkins,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,173
+Sumner,20-1 Hawkins,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,20-1 Hawkins,District Attorney General,18 (unexpired term),Republican,Thomas Dean,304
+Sumner,21-1 Indian Lake,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,21-1 Indian Lake,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,690
+Sumner,21-1 Indian Lake,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,570
+Sumner,21-1 Indian Lake,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,21-1 Indian Lake,District Attorney General,18 (unexpired term),Republican,Thomas Dean,1051
+Sumner,22-1 Jack Anderson,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,22-1 Jack Anderson,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,335
+Sumner,22-1 Jack Anderson,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,241
+Sumner,22-1 Jack Anderson,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,22-1 Jack Anderson,District Attorney General,18 (unexpired term),Republican,Thomas Dean,499
+Sumner,23-1 Whitten,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,23-1 Whitten,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,103
+Sumner,23-1 Whitten,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,84
+Sumner,23-1 Whitten,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,23-1 Whitten,District Attorney General,18 (unexpired term),Republican,Thomas Dean,161
+Sumner,23-2 Hendersonville,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,23-2 Hendersonville,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,148
+Sumner,23-2 Hendersonville,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,88
+Sumner,23-2 Hendersonville,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,23-2 Hendersonville,District Attorney General,18 (unexpired term),Republican,Thomas Dean,194
+Sumner,24-1 Long Hollow,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,24-1 Long Hollow,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,291
+Sumner,24-1 Long Hollow,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,323
+Sumner,24-1 Long Hollow,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,24-1 Long Hollow,District Attorney General,18 (unexpired term),Republican,Thomas Dean,522
+Sumner,3-1 Portland,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,3-1 Portland,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,109
+Sumner,3-1 Portland,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,132
+Sumner,3-1 Portland,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,3-1 Portland,District Attorney General,18 (unexpired term),Republican,Thomas Dean,222
+Sumner,4-1 Oakmont,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,4-1 Oakmont,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,92
+Sumner,4-1 Oakmont,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,101
+Sumner,4-1 Oakmont,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,4-1 Oakmont,District Attorney General,18 (unexpired term),Republican,Thomas Dean,178
+Sumner,4-2 Cottontown,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,4-2 Cottontown,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,154
+Sumner,4-2 Cottontown,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,118
+Sumner,4-2 Cottontown,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,4-2 Cottontown,District Attorney General,18 (unexpired term),Republican,Thomas Dean,227
+Sumner,5-1 Bethpage,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,5-1 Bethpage,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,123
+Sumner,5-1 Bethpage,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,90
+Sumner,5-1 Bethpage,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,5-1 Bethpage,District Attorney General,18 (unexpired term),Republican,Thomas Dean,182
+Sumner,5-2 Highland,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,5-2 Highland,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,135
+Sumner,5-2 Highland,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,109
+Sumner,5-2 Highland,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,5-2 Highland,District Attorney General,18 (unexpired term),Republican,Thomas Dean,205
+Sumner,6-1 Creekside,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,6-1 Creekside,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,440
+Sumner,6-1 Creekside,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,293
+Sumner,6-1 Creekside,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,6-1 Creekside,District Attorney General,18 (unexpired term),Republican,Thomas Dean,649
+Sumner,7-1 Civic Center,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,7-1 Civic Center,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,341
+Sumner,7-1 Civic Center,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,189
+Sumner,7-1 Civic Center,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,7-1 Civic Center,District Attorney General,18 (unexpired term),Republican,Thomas Dean,437
+Sumner,8-1 Guild,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,8-1 Guild,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,143
+Sumner,8-1 Guild,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,104
+Sumner,8-1 Guild,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,8-1 Guild,District Attorney General,18 (unexpired term),Republican,Thomas Dean,206
+Sumner,9-1 Gallatin HS,Circuit Court Judge Division II,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,9-1 Gallatin HS,Circuit Court Judge Division II,18 (unexpired term),Republican,Jennifer Nichols,547
+Sumner,9-1 Gallatin HS,Circuit Court Judge Division II,18 (unexpired term),Republican,Michael Begley,332
+Sumner,9-1 Gallatin HS,District Attorney General,18 (unexpired term),Democratic,No Candidate Qualified,0
+Sumner,9-1 Gallatin HS,District Attorney General,18 (unexpired term),Republican,Thomas Dean,723
+Unicoi,Fishery,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Fishery,Public Defender,1 (unexpired term),Republican,Bill Donaldson,117
+Unicoi,Fishery,Public Defender,1 (unexpired term),Republican,Melanie Sellers,105
+Unicoi,Flag Pond,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Flag Pond,Public Defender,1 (unexpired term),Republican,Bill Donaldson,123
+Unicoi,Flag Pond,Public Defender,1 (unexpired term),Republican,Melanie Sellers,120
+Unicoi,High School,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,High School,Public Defender,1 (unexpired term),Republican,Bill Donaldson,234
+Unicoi,High School,Public Defender,1 (unexpired term),Republican,Melanie Sellers,232
+Unicoi,Limestone Cove,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Limestone Cove,Public Defender,1 (unexpired term),Republican,Bill Donaldson,137
+Unicoi,Limestone Cove,Public Defender,1 (unexpired term),Republican,Melanie Sellers,96
+Unicoi,Love Chapel,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Love Chapel,Public Defender,1 (unexpired term),Republican,Bill Donaldson,273
+Unicoi,Love Chapel,Public Defender,1 (unexpired term),Republican,Melanie Sellers,227
+Unicoi,Rock Creek,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Rock Creek,Public Defender,1 (unexpired term),Republican,Bill Donaldson,274
+Unicoi,Rock Creek,Public Defender,1 (unexpired term),Republican,Melanie Sellers,265
+Unicoi,Temple Hill,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Temple Hill,Public Defender,1 (unexpired term),Republican,Bill Donaldson,141
+Unicoi,Temple Hill,Public Defender,1 (unexpired term),Republican,Melanie Sellers,116
+Unicoi,Unicoi,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Unicoi,Unicoi,Public Defender,1 (unexpired term),Republican,Bill Donaldson,322
+Unicoi,Unicoi,Public Defender,1 (unexpired term),Republican,Melanie Sellers,237
+Washington,01 Fall Branch,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,01 Fall Branch,Public Defender,1 (unexpired term),Republican,Bill Donaldson,168
+Washington,01 Fall Branch,Public Defender,1 (unexpired term),Republican,Melanie Sellers,130
+Washington,02 Grandview,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,02 Grandview,Public Defender,1 (unexpired term),Republican,Bill Donaldson,166
+Washington,02 Grandview,Public Defender,1 (unexpired term),Republican,Melanie Sellers,153
+Washington,03 West View,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,03 West View,Public Defender,1 (unexpired term),Republican,Bill Donaldson,343
+Washington,03 West View,Public Defender,1 (unexpired term),Republican,Melanie Sellers,299
+Washington,04 Visitor's Center,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,04 Visitor's Center,Public Defender,1 (unexpired term),Republican,Bill Donaldson,243
+Washington,04 Visitor's Center,Public Defender,1 (unexpired term),Republican,Melanie Sellers,254
+Washington,05 Jonesborough County,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,05 Jonesborough County,Public Defender,1 (unexpired term),Republican,Bill Donaldson,113
+Washington,05 Jonesborough County,Public Defender,1 (unexpired term),Republican,Melanie Sellers,110
+Washington,06 Lamar,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,06 Lamar,Public Defender,1 (unexpired term),Republican,Bill Donaldson,348
+Washington,06 Lamar,Public Defender,1 (unexpired term),Republican,Melanie Sellers,308
+Washington,07 Gray West,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,07 Gray West,Public Defender,1 (unexpired term),Republican,Bill Donaldson,142
+Washington,07 Gray West,Public Defender,1 (unexpired term),Republican,Melanie Sellers,101
+Washington,08 Gray East,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,08 Gray East,Public Defender,1 (unexpired term),Republican,Bill Donaldson,139
+Washington,08 Gray East,Public Defender,1 (unexpired term),Republican,Melanie Sellers,113
+Washington,09 Lakeridge City,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,09 Lakeridge City,Public Defender,1 (unexpired term),Republican,Bill Donaldson,71
+Washington,09 Lakeridge City,Public Defender,1 (unexpired term),Republican,Melanie Sellers,94
+Washington,10 Lakeridge County,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,10 Lakeridge County,Public Defender,1 (unexpired term),Republican,Bill Donaldson,99
+Washington,10 Lakeridge County,Public Defender,1 (unexpired term),Republican,Melanie Sellers,89
+Washington,11 Town Acres,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,11 Town Acres,Public Defender,1 (unexpired term),Republican,Bill Donaldson,179
+Washington,11 Town Acres,Public Defender,1 (unexpired term),Republican,Melanie Sellers,158
+Washington,12 Freedom Hall,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,12 Freedom Hall,Public Defender,1 (unexpired term),Republican,Bill Donaldson,190
+Washington,12 Freedom Hall,Public Defender,1 (unexpired term),Republican,Melanie Sellers,163
+Washington,13 Indian Trail North,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,13 Indian Trail North,Public Defender,1 (unexpired term),Republican,Bill Donaldson,116
+Washington,13 Indian Trail North,Public Defender,1 (unexpired term),Republican,Melanie Sellers,137
+Washington,14 Indian Trail South,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,14 Indian Trail South,Public Defender,1 (unexpired term),Republican,Bill Donaldson,63
+Washington,14 Indian Trail South,Public Defender,1 (unexpired term),Republican,Melanie Sellers,96
+Washington,15 Carver,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,15 Carver,Public Defender,1 (unexpired term),Republican,Bill Donaldson,132
+Washington,15 Carver,Public Defender,1 (unexpired term),Republican,Melanie Sellers,192
+Washington,16 Keystone,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,16 Keystone,Public Defender,1 (unexpired term),Republican,Bill Donaldson,111
+Washington,16 Keystone,Public Defender,1 (unexpired term),Republican,Melanie Sellers,108
+Washington,17 South Side,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,17 South Side,Public Defender,1 (unexpired term),Republican,Bill Donaldson,57
+Washington,17 South Side,Public Defender,1 (unexpired term),Republican,Melanie Sellers,77
+Washington,18 Cherokee,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,18 Cherokee,Public Defender,1 (unexpired term),Republican,Bill Donaldson,128
+Washington,18 Cherokee,Public Defender,1 (unexpired term),Republican,Melanie Sellers,145
+Washington,19 Henry Johnson,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,19 Henry Johnson,Public Defender,1 (unexpired term),Republican,Bill Donaldson,116
+Washington,19 Henry Johnson,Public Defender,1 (unexpired term),Republican,Melanie Sellers,149
+Washington,20 Woodland,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,20 Woodland,Public Defender,1 (unexpired term),Republican,Bill Donaldson,118
+Washington,20 Woodland,Public Defender,1 (unexpired term),Republican,Melanie Sellers,133
+Washington,21 Asbury School,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,21 Asbury School,Public Defender,1 (unexpired term),Republican,Bill Donaldson,87
+Washington,21 Asbury School,Public Defender,1 (unexpired term),Republican,Melanie Sellers,71
+Washington,22 Boones Creek,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,22 Boones Creek,Public Defender,1 (unexpired term),Republican,Bill Donaldson,143
+Washington,22 Boones Creek,Public Defender,1 (unexpired term),Republican,Melanie Sellers,149
+Washington,23 Sulphur Springs,Public Defender,1 (unexpired term),Democratic,No Candidate Qualified,0
+Washington,23 Sulphur Springs,Public Defender,1 (unexpired term),Republican,Bill Donaldson,219
+Washington,23 Sulphur Springs,Public Defender,1 (unexpired term),Republican,Melanie Sellers,202

--- a/cleaning/tn_2025_special_us_house_d7_parser.py
+++ b/cleaning/tn_2025_special_us_house_d7_parser.py
@@ -1,0 +1,188 @@
+"""
+Parser for the 2025 Tennessee U.S. House District 7 special elections
+(unexpired term), covering both the October 7, 2025 special primary and the
+December 2, 2025 special general.
+
+Source (TN SoS "All by Precinct" spreadsheets, which list every precinct's
+votes for every candidate; grand totals were cross-checked against the official
+by-county PDFs and match exactly):
+  primary:  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20251007AllbyPrecinct.xlsx
+  general:  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20251202AllbyPrecinct.xlsx
+
+Outputs (in 2025/):
+  20251007__tn__special__primary__county.csv
+  20251007__tn__special__primary__precinct.csv
+  20251202__tn__special__general__county.csv
+  20251202__tn__special__general__precinct.csv
+
+The XLSX is a wide layout: one row per (precinct, candidate-group) with up to 10
+candidates per row in RNAME*/PARTY*/PVTALLY* columns. A precinct may span
+multiple rows when a party fields more than 10 candidates (the Republican
+primary had 11). County-level totals are derived by summing the precinct votes
+per county, which matches the official by-county PDFs exactly. The
+"All County Precinct" bucket (absentee/early votes reported at the county level)
+is kept as a precinct, matching the repo's 2022 convention, so precinct sums
+reconcile to county totals.
+
+Conventions (matching the repo's canonical files):
+  county:   Title case, e.g. "Humphreys" (the primary source misspells it
+            "Humhreys" and the general source uppercases it; both are normalized)
+  office:   "U.S. House"
+  district: "7"
+  party:    full names ("Democratic", "Republican", "Independent")
+  precinct: as printed in the source (e.g. "1 Holladay", "All County Precinct")
+
+Requires `requests` (in the Pipfile) and `openpyxl` (a third-party package;
+install separately, e.g. `pip install openpyxl`) to read the .xlsx workbook,
+which is far more reliable than parsing the multi-county PDFs.
+"""
+
+import csv
+import os
+import re
+from collections import defaultdict
+
+import requests
+
+try:
+    import openpyxl
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("This parser requires openpyxl: pipenv install openpyxl") from exc
+
+BASE = "https://sos-prod.tnsosgovfiles.com/s3fs-public/document"
+PRIMARY_URL = f"{BASE}/20251007AllbyPrecinct.xlsx"
+GENERAL_URL = f"{BASE}/20251202AllbyPrecinct.xlsx"
+
+OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "2025")
+
+OFFICE = "U.S. House"
+DISTRICT = "7"
+
+# Canonical Title-case county names, keyed by lowercased source spelling so the
+# primary's "Humhreys" typo and the general's all-caps names both normalize.
+COUNTY_CANON = {
+    "benton": "Benton", "cheatham": "Cheatham", "davidson": "Davidson",
+    "decatur": "Decatur", "dickson": "Dickson", "hickman": "Hickman",
+    "houston": "Houston", "humphreys": "Humphreys", "humhreys": "Humphreys",
+    "montgomery": "Montgomery", "perry": "Perry", "robertson": "Robertson",
+    "stewart": "Stewart", "wayne": "Wayne", "williamson": "Williamson",
+}
+
+PARTY_ORDER = {"Democratic": 0, "Republican": 1, "Independent": 2}
+
+
+def norm_county(raw):
+    return COUNTY_CANON.get(str(raw).strip().lower(), str(raw).strip().title())
+
+
+def fetch_workbook(url):
+    resp = requests.get(url)
+    resp.raise_for_status()
+    # openpyxl reads from a file-like object via load_workbook; write bytes to a
+    # temp file to avoid seeking issues with some stream wrappers.
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".xlsx") as f:
+        f.write(resp.content)
+        f.flush()
+        return openpyxl.load_workbook(f.name, read_only=True, data_only=True)
+
+
+def iter_precinct_rows(url):
+    """Yield (county, precinct, party, candidate, votes) for every candidate."""
+    wb = fetch_workbook(url)
+    ws = wb["Sheet1"]
+    rows = ws.iter_rows(values_only=True)
+    header = next(rows)
+    rname_cols = [header.index(f"RNAME{i}") for i in range(1, 11)
+                  if f"RNAME{i}" in header]
+    party_cols = [header.index(f"PARTY{i}") for i in range(1, 11)
+                  if f"PARTY{i}" in header]
+    tally_cols = [header.index(f"PVTALLY{i}") for i in range(1, 11)
+                  if f"PVTALLY{i}" in header]
+    n = min(len(rname_cols), len(party_cols), len(tally_cols))
+    ci_county = header.index("COUNTY")
+    ci_precinct = header.index("PRECINCT")
+    for r in rows:
+        county = norm_county(r[ci_county])
+        precinct = str(r[ci_precinct]).strip()
+        for k in range(n):
+            name = r[rname_cols[k]]
+            if not name:
+                continue
+            party = str(r[party_cols[k]] or "").strip()
+            votes = r[tally_cols[k]] or 0
+            yield county, precinct, party, str(name).strip(), int(votes)
+
+
+def sort_key_county(row):
+    # row: [county, office, district, party, candidate, votes]
+    return (row[0], PARTY_ORDER.get(row[3], 99), row[4])
+
+
+def sort_key_precinct(row):
+    # row: [county, precinct, office, district, party, candidate, votes]
+    return (row[0], row[1], PARTY_ORDER.get(row[4], 99), row[5])
+
+
+def build(url, county_path, precinct_path):
+    precinct_rows = []
+    county_sums = defaultdict(int)  # (county, party, candidate) -> votes
+    for county, precinct, party, candidate, votes in iter_precinct_rows(url):
+        precinct_rows.append(
+            [county, precinct, OFFICE, DISTRICT, party, candidate, votes]
+        )
+        county_sums[(county, party, candidate)] += votes
+
+    county_rows = [
+        [county, OFFICE, DISTRICT, party, candidate, votes]
+        for (county, party, candidate), votes in county_sums.items()
+    ]
+    county_rows.sort(key=sort_key_county)
+    precinct_rows.sort(key=sort_key_precinct)
+
+    write_csv(
+        county_path,
+        ["county", "office", "district", "party", "candidate", "votes"],
+        county_rows,
+    )
+    write_csv(
+        precinct_path,
+        ["county", "precinct", "office", "district", "party", "candidate", "votes"],
+        precinct_rows,
+    )
+
+    # Sanity check: precinct sums must equal county totals.
+    ps = defaultdict(int)
+    for r in precinct_rows:
+        ps[(r[0], r[4], r[5])] += r[6]
+    for key, v in county_sums.items():
+        assert ps[key] == v, f"mismatch {key}: {ps[key]} != {v}"
+    return county_rows, precinct_rows
+
+
+def write_csv(path, header, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(rows)
+    print(f"Wrote {path} ({len(rows)} rows)")
+
+
+def main():
+    county_dir = os.path.abspath(OUT_DIR)
+    os.makedirs(county_dir, exist_ok=True)
+
+    build(
+        PRIMARY_URL,
+        os.path.join(county_dir, "20251007__tn__special__primary__county.csv"),
+        os.path.join(county_dir, "20251007__tn__special__primary__precinct.csv"),
+    )
+    build(
+        GENERAL_URL,
+        os.path.join(county_dir, "20251202__tn__special__general__county.csv"),
+        os.path.join(county_dir, "20251202__tn__special__general__precinct.csv"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cleaning/tn_2026_primary_parser.py
+++ b/cleaning/tn_2026_primary_parser.py
@@ -1,0 +1,269 @@
+"""
+Parser for the May 5, 2026 Tennessee primary election (Democratic and Republican
+primaries), producing county- and precinct-level OpenElections CSVs.
+
+Source (TN SoS "by County" / "by Precinct" PDFs, hosted on the 2025+ bucket):
+  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20260506_DemocraticPrimarybyCounty.pdf
+  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20260506_DemocraticPrimarybyPrecinct.pdf
+  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20260506_RepublicanPrimarybyCounty.pdf
+  https://sos-prod.tnsosgovfiles.com/s3fs-public/document/20260506_RepublicanPrimarybyPrecinct.pdf
+
+The source filenames use 20260506 (the posting date); the election date in the
+PDFs and in the OpenElections output filenames is May 5, 2026 -> 20260505.
+
+The 2026 primaries are entirely judicial/local offices by judicial district
+(Circuit Court Judge, Criminal Court Judge, Chancellor, Circuit and Chancery
+Court Judge, District Attorney General, Public Defender), all "(unexpired
+term)". There is no Governor / U.S. Senate / U.S. House / State Senate /
+State House on this primary ballot.
+
+PDF layout (via `pdftotext -layout`, which preserves columns):
+  <office header>            e.g. "Circuit Court Judge Division III District 20 (unexpired term)"
+  1. <candidate>             numbered candidate list ("1. No Candidate Qualified" if uncontested)
+  2. <candidate>
+      1      2      3        column header (one number per candidate) [county PDF only]
+  <county>  <v1> <v2> ...    county rows (county PDF) -- votes are comma-formatted
+  -or-
+  <X> County                 county header (precinct PDF)
+   Precincts:
+    <precinct> <v1> ...      precinct rows (precinct PDF) -- votes comma-formatted >= 1000
+   County Totals: <v1> ...   county subtotal (precinct PDF)
+  DISTRICT TOTALS <v1> ...   district total (county PDF)
+
+Office/district split (matching the repo's canonical 2016/2018 primary files):
+  the "Division"/"Part"/"Division II" qualifier stays in the OFFICE column, and
+  "District N (unexpired term)" becomes the DISTRICT column "N (unexpired term)".
+  e.g. "Circuit Court Judge Division III District 20 (unexpired term)"
+       -> office  = "Circuit Court Judge Division III"
+          district = "20 (unexpired term)"
+
+Vote columns are matched to candidates by taking the LAST N whitespace-delimited
+tokens of each row as the vote values (N = number of candidates), and the
+remaining leading tokens as the county/precinct name. This is robust to names
+that contain digits or commas (e.g. "01-1", "Cocke County High",
+"William K. Lane, III").
+
+Conventions (matching the repo's canonical files):
+  county:   Title case as printed (e.g. "Davidson", "Van Buren")
+  office:   text before "District N" (Division/Part kept)
+  district: "N (unexpired term)" (or "N" if a full-term race ever appears)
+  party:    "Democratic" / "Republican"
+  precinct: as printed, single-spaced (e.g. "1 Dandridge ES", "01-1")
+
+Requires `requests` (in the Pipfile) and the `pdftotext` command (poppler) to be
+on PATH.
+"""
+
+import csv
+import os
+import re
+import subprocess
+import tempfile
+
+import requests
+
+BASE = "https://sos-prod.tnsosgovfiles.com/s3fs-public/document"
+SOURCES = {
+    "Democratic": {
+        "county": f"{BASE}/20260506_DemocraticPrimarybyCounty.pdf",
+        "precinct": f"{BASE}/20260506_DemocraticPrimarybyPrecinct.pdf",
+    },
+    "Republican": {
+        "county": f"{BASE}/20260506_RepublicanPrimarybyCounty.pdf",
+        "precinct": f"{BASE}/20260506_RepublicanPrimarybyPrecinct.pdf",
+    },
+}
+
+OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "2026")
+COUNTY_CSV = "20260505__tn__primary__county.csv"
+PRECINCT_CSV = "20260505__tn__primary__precinct.csv"
+
+COUNTY_HEADER = ["county", "office", "district", "party", "candidate", "votes"]
+PRECINCT_HEADER = ["county", "precinct", "office", "district", "party", "candidate", "votes"]
+
+# Office header: everything before "District N", then an optional "(unexpired term)".
+OFFICE_RE = re.compile(r"^(.+?)\s+District\s+(\d+)\s*(\(unexpired term\))?\s*$")
+# Candidate line: "1. Name" (name may contain commas, e.g. "William K. Lane, III").
+CAND_RE = re.compile(r"^\s*\d+\.\s+(.+?)\s*$")
+# County header in the precinct PDF: "Davidson County" (ends with "County").
+COUNTY_HEADER_RE = re.compile(r"^([A-Za-z][A-Za-z.'\- ]+?)\s+County\s*$")
+# Column-header line in the county PDF: just candidate-index numbers.
+COL_HEADER_RE = re.compile(r"^\s*\d+(\s+\d+)*\s*$")
+FOOTER_RE = re.compile(r"Page\s+\d+\s+of\s+\d+")
+
+
+def split_office(stripped):
+    """Return (office, district) from a stripped office header line."""
+    m = OFFICE_RE.match(stripped)
+    office = m.group(1).strip()
+    district = m.group(2)
+    if m.group(3):
+        district = f"{district} (unexpired term)"
+    return office, district
+
+
+def is_num(tok):
+    return tok.replace(",", "").isdigit()
+
+
+def to_int(tok):
+    return int(tok.replace(",", ""))
+
+
+def pdftotext_layout(url):
+    """Download a PDF and return its `pdftotext -layout` text."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+        f.write(resp.content)
+        f.flush()
+        out = subprocess.run(
+            ["pdftotext", "-layout", f.name, "-"],
+            check=True, capture_output=True, text=True,
+        )
+    return out.stdout
+
+
+def _skip_line(s):
+    if not s:
+        return True
+    if s == "State of Tennessee":
+        return True
+    if s.startswith("May ") and "2026" in s:  # election + posting dates
+        return True
+    if s.endswith("Primary"):  # "Democratic Primary" / "Republican Primary"
+        return True
+    if FOOTER_RE.search(s):  # "Page 1 of 6"
+        return True
+    return False
+
+
+def parse_county(text, party):
+    """Parse a by-county PDF text -> list of county rows."""
+    rows = []
+    office = district = None
+    candidates = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if _skip_line(s):
+            continue
+        if OFFICE_RE.match(s):
+            office, district = split_office(s)
+            candidates = []
+            continue
+        mc = CAND_RE.match(raw)
+        if mc:
+            candidates.append(mc.group(1).strip())
+            continue
+        if COL_HEADER_RE.match(raw) and candidates:
+            continue  # column header
+        if s.startswith("DISTRICT TOTALS") or "County Totals" in s:
+            continue
+        if not candidates:
+            continue
+        toks = s.split()
+        n = len(candidates)
+        if len(toks) < n + 1:
+            continue
+        vote_toks = toks[-n:]
+        if not all(is_num(t) for t in vote_toks):
+            continue
+        county = " ".join(toks[:-n])
+        votes = [to_int(t) for t in vote_toks]
+        for cand, v in zip(candidates, votes):
+            rows.append([county, office, district, party, cand, v])
+    return rows
+
+
+def parse_precinct(text, party):
+    """Parse a by-precinct PDF text -> list of precinct rows."""
+    rows = []
+    office = district = None
+    candidates = []
+    county = None
+    for raw in text.splitlines():
+        s = raw.strip()
+        if _skip_line(s):
+            continue
+        if OFFICE_RE.match(s):
+            office, district = split_office(s)
+            candidates = []
+            county = None
+            continue
+        mc = CAND_RE.match(raw)
+        if mc:
+            candidates.append(mc.group(1).strip())
+            continue
+        if COL_HEADER_RE.match(raw) and candidates:
+            continue  # column header
+        mcy = COUNTY_HEADER_RE.match(s)
+        if mcy and "Totals" not in s:
+            county = mcy.group(1).strip()
+            continue
+        if s == "Precincts:" or "County Totals" in s or s.startswith("DISTRICT TOTALS"):
+            continue
+        if not candidates or county is None:
+            continue
+        toks = s.split()
+        n = len(candidates)
+        if len(toks) < n + 1:
+            continue
+        vote_toks = toks[-n:]
+        if not all(is_num(t) for t in vote_toks):
+            continue
+        precinct = " ".join(toks[:-n])
+        votes = [to_int(t) for t in vote_toks]
+        for cand, v in zip(candidates, votes):
+            rows.append([county, precinct, office, district, party, cand, v])
+    return rows
+
+
+def write_csv(path, header, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(rows)
+    print(f"Wrote {path} ({len(rows)} rows)")
+
+
+def main():
+    out = os.path.abspath(OUT_DIR)
+    os.makedirs(out, exist_ok=True)
+
+    county_rows = []
+    precinct_rows = []
+    for party, urls in SOURCES.items():
+        print(f"--- {party} ---")
+        ctext = pdftotext_layout(urls["county"])
+        ptext = pdftotext_layout(urls["precinct"])
+        crows = parse_county(ctext, party)
+        prows = parse_precinct(ptext, party)
+        print(f"  county: {len(crows)} rows, precinct: {len(prows)} rows")
+        county_rows.extend(crows)
+        precinct_rows.extend(prows)
+
+    # Sort: county by (county, office, district, party, candidate); precinct likewise
+    # with precinct after county.
+    county_rows.sort(key=lambda r: (r[0], r[1], r[2], r[3], r[4]))
+    precinct_rows.sort(key=lambda r: (r[0], r[1], r[2], r[3], r[4], r[5]))
+
+    write_csv(os.path.join(out, COUNTY_CSV), COUNTY_HEADER, county_rows)
+    write_csv(os.path.join(out, PRECINCT_CSV), PRECINCT_HEADER, precinct_rows)
+
+    # Sanity check: precinct sums must equal county totals.
+    from collections import defaultdict
+    ps = defaultdict(int)
+    for r in precinct_rows:
+        ps[(r[0], r[2], r[3], r[4], r[5])] += r[6]  # county, office, district, party, candidate
+    cs = defaultdict(int)
+    for r in county_rows:
+        cs[(r[0], r[1], r[2], r[3], r[4])] += r[5]
+    assert set(ps) == set(cs), "precinct keys != county keys"
+    for k in cs:
+        assert ps[k] == cs[k], f"mismatch {k}: precinct {ps[k]} != county {cs[k]}"
+    print("OK: precinct sums equal county totals for all "
+          f"{len(cs)} county/candidate combinations.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds county- and precinct-level CSVs for the May 5, 2026 Tennessee primary (Democratic and Republican), parsed from the TN SoS [by-county and by-precinct PDFs](https://sos.tn.gov/elections/results#2026).

### Files
- `2026/20260505__tn__primary__county.csv` (64 rows)
- `2026/20260505__tn__primary__precinct.csv` (3,008 rows)

### Coverage
The 2026 primaries are entirely judicial/local offices by judicial district — Circuit Court Judge, Criminal Court Judge, Chancellor, Circuit and Chancery Court Judge, District Attorney General, and Public Defender. There is no Governor / U.S. Senate / U.S. House / State Senate / State House on this ballot. All but one race are "(unexpired term)"; "Public Defender District 20" is a full-term race.

Contested races:
- **Dem Circuit Court Judge Division III D20** (Davidson) — Audrey Anderson 9,930; Bethany Peery Glandorf 14,670; Corletra Mance 15,817
- **Dem Criminal Court Judge Division III D20** (Davidson) — Dawn Deaner 15,033; Ronald Jamar Dowdy 12,943; Jim Todd 14,384
- **Dem Public Defender D20** (Davidson) — Martesha Johnson 36,735
- **Rep Circuit Court Judge Division II D18** (Sumner) — Michael Begley 5,365; Jennifer Nichols 6,646
- **Rep Public Defender D1** (Carter/Johnson/Unicoi/Washington) — Bill Donaldson 9,193; Melanie Sellers 9,434
- Plus 8 uncontested Republican races (single candidate each)

All other races had "No Candidate Qualified" in the source.

### Source & verification
Parsed from the four TN SoS PDFs (`20260506_DemocraticPrimarybyCounty.pdf`, `...byPrecinct.pdf`, `20260506_RepublicanPrimarybyCounty.pdf`, `...byPrecinct.pdf`) using `pdftotext -layout`. Source filenames use the posting date (20260506); the election date in the output filenames is May 5, 2026.

Precinct sums equal county totals for all 64 county/candidate combinations, and the contested totals match the source DISTRICT TOTALS exactly (e.g. Rep Public Defender D1: Donaldson 9,193 / Sellers 9,434). Files pass inline equivalents of all four OpenElections data tests (file format, missing values, duplicate entries, vote breakdown totals).

### Conventions
Matches the repo's canonical 2016/2018 primary files: the Division/Part qualifier stays in the **office** column and "District N (unexpired term)" becomes the **district** column (e.g. office `Circuit Court Judge Division III`, district `20 (unexpired term)`). Title-case counties, full party names (`Democratic`/`Republican`), precinct names as printed (single-spaced, e.g. `01-1`, `1 Dandridge ES`), and proper CSV quote-doubling (e.g. `"William K. Lane, III"`).

A reproducible parser is at `cleaning/tn_2026_primary_parser.py` (requires `requests` from the Pipfile plus `pdftotext`/poppler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)