### PR TITLE
Add 2019 TN special election results

### DIFF
--- a/2019/20190124__tn__special__primary__county.csv
+++ b/2019/20190124__tn__special__primary__county.csv
@@ -1,0 +1,11 @@
+county,office,district,party,candidate,votes
+Shelby,State Senate,32,Democratic,Eric R. Coleman,377
+Shelby,State Senate,32,Republican,George Chism,1512
+Shelby,State Senate,32,Republican,Heidi Shafer,1322
+Shelby,State Senate,32,Republican,Paul Rose,2266
+Shelby,State Senate,32,Republican,Steve McManus,1055
+Tipton,State Senate,32,Democratic,Eric R. Coleman,166
+Tipton,State Senate,32,Republican,George Chism,18
+Tipton,State Senate,32,Republican,Heidi Shafer,198
+Tipton,State Senate,32,Republican,Paul Rose,4132
+Tipton,State Senate,32,Republican,Steve McManus,102

--- a/2019/20190124__tn__special__primary__precinct.csv
+++ b/2019/20190124__tn__special__primary__precinct.csv
@@ -1,0 +1,181 @@
+county,precinct,office,district,party,candidate,votes
+Shelby,Arlington 01,State Senate,32,Democratic,Eric R. Coleman,27
+Shelby,Arlington 01,State Senate,32,Republican,George Chism,135
+Shelby,Arlington 01,State Senate,32,Republican,Heidi Shafer,68
+Shelby,Arlington 01,State Senate,32,Republican,Paul Rose,132
+Shelby,Arlington 01,State Senate,32,Republican,Steve McManus,37
+Shelby,Arlington 02,State Senate,32,Democratic,Eric R. Coleman,10
+Shelby,Arlington 02,State Senate,32,Republican,George Chism,28
+Shelby,Arlington 02,State Senate,32,Republican,Heidi Shafer,30
+Shelby,Arlington 02,State Senate,32,Republican,Paul Rose,43
+Shelby,Arlington 02,State Senate,32,Republican,Steve McManus,10
+Shelby,Bartlett 03,State Senate,32,Democratic,Eric R. Coleman,7
+Shelby,Bartlett 03,State Senate,32,Republican,George Chism,25
+Shelby,Bartlett 03,State Senate,32,Republican,Heidi Shafer,55
+Shelby,Bartlett 03,State Senate,32,Republican,Paul Rose,96
+Shelby,Bartlett 03,State Senate,32,Republican,Steve McManus,45
+Shelby,Bartlett 04,State Senate,32,Democratic,Eric R. Coleman,12
+Shelby,Bartlett 04,State Senate,32,Republican,George Chism,25
+Shelby,Bartlett 04,State Senate,32,Republican,Heidi Shafer,42
+Shelby,Bartlett 04,State Senate,32,Republican,Paul Rose,102
+Shelby,Bartlett 04,State Senate,32,Republican,Steve McManus,35
+Shelby,Bartlett 05,State Senate,32,Democratic,Eric R. Coleman,17
+Shelby,Bartlett 05,State Senate,32,Republican,George Chism,24
+Shelby,Bartlett 05,State Senate,32,Republican,Heidi Shafer,33
+Shelby,Bartlett 05,State Senate,32,Republican,Paul Rose,80
+Shelby,Bartlett 05,State Senate,32,Republican,Steve McManus,26
+Shelby,Bartlett 06,State Senate,32,Democratic,Eric R. Coleman,9
+Shelby,Bartlett 06,State Senate,32,Republican,George Chism,18
+Shelby,Bartlett 06,State Senate,32,Republican,Heidi Shafer,44
+Shelby,Bartlett 06,State Senate,32,Republican,Paul Rose,67
+Shelby,Bartlett 06,State Senate,32,Republican,Steve McManus,27
+Shelby,Bartlett 08,State Senate,32,Democratic,Eric R. Coleman,11
+Shelby,Bartlett 08,State Senate,32,Republican,George Chism,53
+Shelby,Bartlett 08,State Senate,32,Republican,Heidi Shafer,56
+Shelby,Bartlett 08,State Senate,32,Republican,Paul Rose,158
+Shelby,Bartlett 08,State Senate,32,Republican,Steve McManus,70
+Shelby,Bartlett 09,State Senate,32,Democratic,Eric R. Coleman,17
+Shelby,Bartlett 09,State Senate,32,Republican,George Chism,34
+Shelby,Bartlett 09,State Senate,32,Republican,Heidi Shafer,61
+Shelby,Bartlett 09,State Senate,32,Republican,Paul Rose,110
+Shelby,Bartlett 09,State Senate,32,Republican,Steve McManus,70
+Shelby,Bartlett 11,State Senate,32,Democratic,Eric R. Coleman,10
+Shelby,Bartlett 11,State Senate,32,Republican,George Chism,24
+Shelby,Bartlett 11,State Senate,32,Republican,Heidi Shafer,61
+Shelby,Bartlett 11,State Senate,32,Republican,Paul Rose,69
+Shelby,Bartlett 11,State Senate,32,Republican,Steve McManus,44
+Shelby,Bartlett 13,State Senate,32,Democratic,Eric R. Coleman,19
+Shelby,Bartlett 13,State Senate,32,Republican,George Chism,34
+Shelby,Bartlett 13,State Senate,32,Republican,Heidi Shafer,41
+Shelby,Bartlett 13,State Senate,32,Republican,Paul Rose,77
+Shelby,Bartlett 13,State Senate,32,Republican,Steve McManus,18
+Shelby,Brunswick 01,State Senate,32,Democratic,Eric R. Coleman,3
+Shelby,Brunswick 01,State Senate,32,Republican,George Chism,19
+Shelby,Brunswick 01,State Senate,32,Republican,Heidi Shafer,55
+Shelby,Brunswick 01,State Senate,32,Republican,Paul Rose,62
+Shelby,Brunswick 01,State Senate,32,Republican,Steve McManus,46
+Shelby,Brunswick 02,State Senate,32,Democratic,Eric R. Coleman,15
+Shelby,Brunswick 02,State Senate,32,Republican,George Chism,34
+Shelby,Brunswick 02,State Senate,32,Republican,Heidi Shafer,46
+Shelby,Brunswick 02,State Senate,32,Republican,Paul Rose,103
+Shelby,Brunswick 02,State Senate,32,Republican,Steve McManus,19
+Shelby,Collierville 01,State Senate,32,Democratic,Eric R. Coleman,10
+Shelby,Collierville 01,State Senate,32,Republican,George Chism,154
+Shelby,Collierville 01,State Senate,32,Republican,Heidi Shafer,33
+Shelby,Collierville 01,State Senate,32,Republican,Paul Rose,125
+Shelby,Collierville 01,State Senate,32,Republican,Steve McManus,68
+Shelby,Collierville 02,State Senate,32,Democratic,Eric R. Coleman,23
+Shelby,Collierville 02,State Senate,32,Republican,George Chism,77
+Shelby,Collierville 02,State Senate,32,Republican,Heidi Shafer,47
+Shelby,Collierville 02,State Senate,32,Republican,Paul Rose,98
+Shelby,Collierville 02,State Senate,32,Republican,Steve McManus,54
+Shelby,Collierville 03,State Senate,32,Democratic,Eric R. Coleman,23
+Shelby,Collierville 03,State Senate,32,Republican,George Chism,130
+Shelby,Collierville 03,State Senate,32,Republican,Heidi Shafer,54
+Shelby,Collierville 03,State Senate,32,Republican,Paul Rose,98
+Shelby,Collierville 03,State Senate,32,Republican,Steve McManus,46
+Shelby,Collierville 04,State Senate,32,Democratic,Eric R. Coleman,18
+Shelby,Collierville 04,State Senate,32,Republican,George Chism,123
+Shelby,Collierville 04,State Senate,32,Republican,Heidi Shafer,46
+Shelby,Collierville 04,State Senate,32,Republican,Paul Rose,124
+Shelby,Collierville 04,State Senate,32,Republican,Steve McManus,68
+Shelby,Collierville 05,State Senate,32,Democratic,Eric R. Coleman,12
+Shelby,Collierville 05,State Senate,32,Republican,George Chism,75
+Shelby,Collierville 05,State Senate,32,Republican,Heidi Shafer,35
+Shelby,Collierville 05,State Senate,32,Republican,Paul Rose,73
+Shelby,Collierville 05,State Senate,32,Republican,Steve McManus,38
+Shelby,Collierville 06,State Senate,32,Democratic,Eric R. Coleman,10
+Shelby,Collierville 06,State Senate,32,Republican,George Chism,71
+Shelby,Collierville 06,State Senate,32,Republican,Heidi Shafer,52
+Shelby,Collierville 06,State Senate,32,Republican,Paul Rose,74
+Shelby,Collierville 06,State Senate,32,Republican,Steve McManus,51
+Shelby,Collierville 07,State Senate,32,Democratic,Eric R. Coleman,38
+Shelby,Collierville 07,State Senate,32,Republican,George Chism,29
+Shelby,Collierville 07,State Senate,32,Republican,Heidi Shafer,16
+Shelby,Collierville 07,State Senate,32,Republican,Paul Rose,42
+Shelby,Collierville 07,State Senate,32,Republican,Steve McManus,30
+Shelby,Collierville 08,State Senate,32,Democratic,Eric R. Coleman,11
+Shelby,Collierville 08,State Senate,32,Republican,George Chism,60
+Shelby,Collierville 08,State Senate,32,Republican,Heidi Shafer,27
+Shelby,Collierville 08,State Senate,32,Republican,Paul Rose,43
+Shelby,Collierville 08,State Senate,32,Republican,Steve McManus,35
+Shelby,Collierville 09,State Senate,32,Democratic,Eric R. Coleman,17
+Shelby,Collierville 09,State Senate,32,Republican,George Chism,123
+Shelby,Collierville 09,State Senate,32,Republican,Heidi Shafer,81
+Shelby,Collierville 09,State Senate,32,Republican,Paul Rose,63
+Shelby,Collierville 09,State Senate,32,Republican,Steve McManus,50
+Shelby,Eads,State Senate,32,Democratic,Eric R. Coleman,8
+Shelby,Eads,State Senate,32,Republican,George Chism,31
+Shelby,Eads,State Senate,32,Republican,Heidi Shafer,23
+Shelby,Eads,State Senate,32,Republican,Paul Rose,53
+Shelby,Eads,State Senate,32,Republican,Steve McManus,59
+Shelby,Forest Hills 02,State Senate,32,Democratic,Eric R. Coleman,8
+Shelby,Forest Hills 02,State Senate,32,Republican,George Chism,6
+Shelby,Forest Hills 02,State Senate,32,Republican,Heidi Shafer,11
+Shelby,Forest Hills 02,State Senate,32,Republican,Paul Rose,8
+Shelby,Forest Hills 02,State Senate,32,Republican,Steve McManus,5
+Shelby,Lakeland 01,State Senate,32,Democratic,Eric R. Coleman,22
+Shelby,Lakeland 01,State Senate,32,Republican,George Chism,134
+Shelby,Lakeland 01,State Senate,32,Republican,Heidi Shafer,141
+Shelby,Lakeland 01,State Senate,32,Republican,Paul Rose,151
+Shelby,Lakeland 01,State Senate,32,Republican,Steve McManus,58
+Shelby,Lakeland 02,State Senate,32,Democratic,Eric R. Coleman,8
+Shelby,Lakeland 02,State Senate,32,Republican,George Chism,25
+Shelby,Lakeland 02,State Senate,32,Republican,Heidi Shafer,50
+Shelby,Lakeland 02,State Senate,32,Republican,Paul Rose,51
+Shelby,Lakeland 02,State Senate,32,Republican,Steve McManus,24
+Shelby,Memphis 88-2,State Senate,32,Democratic,Eric R. Coleman,2
+Shelby,Memphis 88-2,State Senate,32,Republican,George Chism,2
+Shelby,Memphis 88-2,State Senate,32,Republican,Heidi Shafer,5
+Shelby,Memphis 88-2,State Senate,32,Republican,Paul Rose,7
+Shelby,Memphis 88-2,State Senate,32,Republican,Steve McManus,2
+Shelby,Stewartville,State Senate,32,Democratic,Eric R. Coleman,10
+Shelby,Stewartville,State Senate,32,Republican,George Chism,19
+Shelby,Stewartville,State Senate,32,Republican,Heidi Shafer,109
+Shelby,Stewartville,State Senate,32,Republican,Paul Rose,157
+Shelby,Stewartville,State Senate,32,Republican,Steve McManus,20
+Tipton,1-1 NE Covington,State Senate,32,Democratic,Eric R. Coleman,35
+Tipton,1-1 NE Covington,State Senate,32,Republican,George Chism,3
+Tipton,1-1 NE Covington,State Senate,32,Republican,Heidi Shafer,14
+Tipton,1-1 NE Covington,State Senate,32,Republican,Paul Rose,401
+Tipton,1-1 NE Covington,State Senate,32,Republican,Steve McManus,9
+Tipton,2-3 SE Covington,State Senate,32,Democratic,Eric R. Coleman,28
+Tipton,2-3 SE Covington,State Senate,32,Republican,George Chism,2
+Tipton,2-3 SE Covington,State Senate,32,Republican,Heidi Shafer,21
+Tipton,2-3 SE Covington,State Senate,32,Republican,Paul Rose,859
+Tipton,2-3 SE Covington,State Senate,32,Republican,Steve McManus,11
+Tipton,3-6 Tipton West,State Senate,32,Democratic,Eric R. Coleman,6
+Tipton,3-6 Tipton West,State Senate,32,Republican,George Chism,2
+Tipton,3-6 Tipton West,State Senate,32,Republican,Heidi Shafer,11
+Tipton,3-6 Tipton West,State Senate,32,Republican,Paul Rose,682
+Tipton,3-6 Tipton West,State Senate,32,Republican,Steve McManus,6
+Tipton,4-11 Atoka,State Senate,32,Democratic,Eric R. Coleman,15
+Tipton,4-11 Atoka,State Senate,32,Republican,George Chism,2
+Tipton,4-11 Atoka,State Senate,32,Republican,Heidi Shafer,69
+Tipton,4-11 Atoka,State Senate,32,Republican,Paul Rose,425
+Tipton,4-11 Atoka,State Senate,32,Republican,Steve McManus,17
+Tipton,5-12 Munford,State Senate,32,Democratic,Eric R. Coleman,15
+Tipton,5-12 Munford,State Senate,32,Republican,George Chism,3
+Tipton,5-12 Munford,State Senate,32,Republican,Heidi Shafer,13
+Tipton,5-12 Munford,State Senate,32,Republican,Paul Rose,472
+Tipton,5-12 Munford,State Senate,32,Republican,Steve McManus,18
+Tipton,6-14 SW Tipton,State Senate,32,Democratic,Eric R. Coleman,9
+Tipton,6-14 SW Tipton,State Senate,32,Republican,George Chism,1
+Tipton,6-14 SW Tipton,State Senate,32,Republican,Heidi Shafer,23
+Tipton,6-14 SW Tipton,State Senate,32,Republican,Paul Rose,324
+Tipton,6-14 SW Tipton,State Senate,32,Republican,Steve McManus,12
+Tipton,7-19 Austin Peay,State Senate,32,Democratic,Eric R. Coleman,17
+Tipton,7-19 Austin Peay,State Senate,32,Republican,George Chism,2
+Tipton,7-19 Austin Peay,State Senate,32,Republican,Heidi Shafer,18
+Tipton,7-19 Austin Peay,State Senate,32,Republican,Paul Rose,401
+Tipton,7-19 Austin Peay,State Senate,32,Republican,Steve McManus,9
+Tipton,8-21 Wilkinsville,State Senate,32,Democratic,Eric R. Coleman,19
+Tipton,8-21 Wilkinsville,State Senate,32,Republican,George Chism,1
+Tipton,8-21 Wilkinsville,State Senate,32,Republican,Heidi Shafer,16
+Tipton,8-21 Wilkinsville,State Senate,32,Republican,Paul Rose,187
+Tipton,8-21 Wilkinsville,State Senate,32,Republican,Steve McManus,7
+Tipton,9-22 Brighton,State Senate,32,Democratic,Eric R. Coleman,22
+Tipton,9-22 Brighton,State Senate,32,Republican,George Chism,2
+Tipton,9-22 Brighton,State Senate,32,Republican,Heidi Shafer,13
+Tipton,9-22 Brighton,State Senate,32,Republican,Paul Rose,381
+Tipton,9-22 Brighton,State Senate,32,Republican,Steve McManus,13

--- a/2019/20190307__tn__special__primary__county.csv
+++ b/2019/20190307__tn__special__primary__county.csv
@@ -1,0 +1,16 @@
+county,office,district,party,candidate,votes
+Houston,State Senate,22,Democratic,Juanita Charles,64
+Houston,State Senate,22,Republican,Betty M. Burchett,44
+Houston,State Senate,22,Republican,Bill Powers,84
+Houston,State Senate,22,Republican,Jason D. Knight,43
+Houston,State Senate,22,Republican,Jeff Burkhart,208
+Montgomery,State Senate,22,Democratic,Juanita Charles,960
+Montgomery,State Senate,22,Republican,Betty M. Burchett,1184
+Montgomery,State Senate,22,Republican,Bill Powers,2483
+Montgomery,State Senate,22,Republican,Jason D. Knight,721
+Montgomery,State Senate,22,Republican,Jeff Burkhart,1967
+Stewart,State Senate,22,Democratic,Juanita Charles,101
+Stewart,State Senate,22,Republican,Betty M. Burchett,69
+Stewart,State Senate,22,Republican,Bill Powers,215
+Stewart,State Senate,22,Republican,Jason D. Knight,104
+Stewart,State Senate,22,Republican,Jeff Burkhart,338

--- a/2019/20190307__tn__special__primary__precinct.csv
+++ b/2019/20190307__tn__special__primary__precinct.csv
@@ -1,0 +1,216 @@
+county,precinct,office,district,party,candidate,votes
+Houston,Arlington,State Senate,22,Democratic,Juanita Charles,7
+Houston,Arlington,State Senate,22,Republican,Betty M. Burchett,2
+Houston,Arlington,State Senate,22,Republican,Bill Powers,8
+Houston,Arlington,State Senate,22,Republican,Jason D. Knight,4
+Houston,Arlington,State Senate,22,Republican,Jeff Burkhart,45
+Houston,Erin,State Senate,22,Democratic,Juanita Charles,16
+Houston,Erin,State Senate,22,Republican,Betty M. Burchett,5
+Houston,Erin,State Senate,22,Republican,Bill Powers,16
+Houston,Erin,State Senate,22,Republican,Jason D. Knight,6
+Houston,Erin,State Senate,22,Republican,Jeff Burkhart,11
+Houston,Erin Elementary,State Senate,22,Democratic,Juanita Charles,6
+Houston,Erin Elementary,State Senate,22,Republican,Betty M. Burchett,11
+Houston,Erin Elementary,State Senate,22,Republican,Bill Powers,7
+Houston,Erin Elementary,State Senate,22,Republican,Jason D. Knight,0
+Houston,Erin Elementary,State Senate,22,Republican,Jeff Burkhart,30
+Houston,Griffins Chapel,State Senate,22,Democratic,Juanita Charles,9
+Houston,Griffins Chapel,State Senate,22,Republican,Betty M. Burchett,3
+Houston,Griffins Chapel,State Senate,22,Republican,Bill Powers,15
+Houston,Griffins Chapel,State Senate,22,Republican,Jason D. Knight,18
+Houston,Griffins Chapel,State Senate,22,Republican,Jeff Burkhart,37
+Houston,Houston Co Middle,State Senate,22,Democratic,Juanita Charles,10
+Houston,Houston Co Middle,State Senate,22,Republican,Betty M. Burchett,10
+Houston,Houston Co Middle,State Senate,22,Republican,Bill Powers,11
+Houston,Houston Co Middle,State Senate,22,Republican,Jason D. Knight,6
+Houston,Houston Co Middle,State Senate,22,Republican,Jeff Burkhart,22
+Houston,Stewart,State Senate,22,Democratic,Juanita Charles,3
+Houston,Stewart,State Senate,22,Republican,Betty M. Burchett,8
+Houston,Stewart,State Senate,22,Republican,Bill Powers,17
+Houston,Stewart,State Senate,22,Republican,Jason D. Knight,9
+Houston,Stewart,State Senate,22,Republican,Jeff Burkhart,30
+Houston,Tennessee Ridge,State Senate,22,Democratic,Juanita Charles,13
+Houston,Tennessee Ridge,State Senate,22,Republican,Betty M. Burchett,5
+Houston,Tennessee Ridge,State Senate,22,Republican,Bill Powers,10
+Houston,Tennessee Ridge,State Senate,22,Republican,Jason D. Knight,0
+Houston,Tennessee Ridge,State Senate,22,Republican,Jeff Burkhart,33
+Montgomery,10 Minglewood,State Senate,22,Democratic,Juanita Charles,33
+Montgomery,10 Minglewood,State Senate,22,Republican,Betty M. Burchett,17
+Montgomery,10 Minglewood,State Senate,22,Republican,Bill Powers,40
+Montgomery,10 Minglewood,State Senate,22,Republican,Jason D. Knight,32
+Montgomery,10 Minglewood,State Senate,22,Republican,Jeff Burkhart,40
+Montgomery,11 Northwest,State Senate,22,Democratic,Juanita Charles,32
+Montgomery,11 Northwest,State Senate,22,Republican,Betty M. Burchett,17
+Montgomery,11 Northwest,State Senate,22,Republican,Bill Powers,36
+Montgomery,11 Northwest,State Senate,22,Republican,Jason D. Knight,21
+Montgomery,11 Northwest,State Senate,22,Republican,Jeff Burkhart,40
+Montgomery,12 Ringgold,State Senate,22,Democratic,Juanita Charles,50
+Montgomery,12 Ringgold,State Senate,22,Republican,Betty M. Burchett,13
+Montgomery,12 Ringgold,State Senate,22,Republican,Bill Powers,39
+Montgomery,12 Ringgold,State Senate,22,Republican,Jason D. Knight,25
+Montgomery,12 Ringgold,State Senate,22,Republican,Jeff Burkhart,42
+Montgomery,13 Byrns Darden,State Senate,22,Democratic,Juanita Charles,44
+Montgomery,13 Byrns Darden,State Senate,22,Republican,Betty M. Burchett,19
+Montgomery,13 Byrns Darden,State Senate,22,Republican,Bill Powers,34
+Montgomery,13 Byrns Darden,State Senate,22,Republican,Jason D. Knight,10
+Montgomery,13 Byrns Darden,State Senate,22,Republican,Jeff Burkhart,45
+Montgomery,14 Glenellen,State Senate,22,Democratic,Juanita Charles,48
+Montgomery,14 Glenellen,State Senate,22,Republican,Betty M. Burchett,37
+Montgomery,14 Glenellen,State Senate,22,Republican,Bill Powers,80
+Montgomery,14 Glenellen,State Senate,22,Republican,Jason D. Knight,23
+Montgomery,14 Glenellen,State Senate,22,Republican,Jeff Burkhart,74
+Montgomery,15 Sango,State Senate,22,Democratic,Juanita Charles,51
+Montgomery,15 Sango,State Senate,22,Republican,Betty M. Burchett,133
+Montgomery,15 Sango,State Senate,22,Republican,Bill Powers,222
+Montgomery,15 Sango,State Senate,22,Republican,Jason D. Knight,44
+Montgomery,15 Sango,State Senate,22,Republican,Jeff Burkhart,153
+Montgomery,16 New Providence,State Senate,22,Democratic,Juanita Charles,43
+Montgomery,16 New Providence,State Senate,22,Republican,Betty M. Burchett,15
+Montgomery,16 New Providence,State Senate,22,Republican,Bill Powers,48
+Montgomery,16 New Providence,State Senate,22,Republican,Jason D. Knight,21
+Montgomery,16 New Providence,State Senate,22,Republican,Jeff Burkhart,44
+Montgomery,17 Grace,State Senate,22,Democratic,Juanita Charles,31
+Montgomery,17 Grace,State Senate,22,Republican,Betty M. Burchett,21
+Montgomery,17 Grace,State Senate,22,Republican,Bill Powers,39
+Montgomery,17 Grace,State Senate,22,Republican,Jason D. Knight,26
+Montgomery,17 Grace,State Senate,22,Republican,Jeff Burkhart,38
+Montgomery,18 Hazelwood,State Senate,22,Democratic,Juanita Charles,33
+Montgomery,18 Hazelwood,State Senate,22,Republican,Betty M. Burchett,13
+Montgomery,18 Hazelwood,State Senate,22,Republican,Bill Powers,23
+Montgomery,18 Hazelwood,State Senate,22,Republican,Jason D. Knight,43
+Montgomery,18 Hazelwood,State Senate,22,Republican,Jeff Burkhart,52
+Montgomery,19 Oakland,State Senate,22,Democratic,Juanita Charles,69
+Montgomery,19 Oakland,State Senate,22,Republican,Betty M. Burchett,73
+Montgomery,19 Oakland,State Senate,22,Republican,Bill Powers,144
+Montgomery,19 Oakland,State Senate,22,Republican,Jason D. Knight,51
+Montgomery,19 Oakland,State Senate,22,Republican,Jeff Burkhart,114
+Montgomery,1A St B ES,State Senate,22,Democratic,Juanita Charles,44
+Montgomery,1A St B ES,State Senate,22,Republican,Betty M. Burchett,27
+Montgomery,1A St B ES,State Senate,22,Republican,Bill Powers,90
+Montgomery,1A St B ES,State Senate,22,Republican,Jason D. Knight,19
+Montgomery,1A St B ES,State Senate,22,Republican,Jeff Burkhart,95
+Montgomery,1B Emmanuel,State Senate,22,Democratic,Juanita Charles,2
+Montgomery,1B Emmanuel,State Senate,22,Republican,Betty M. Burchett,4
+Montgomery,1B Emmanuel,State Senate,22,Republican,Bill Powers,5
+Montgomery,1B Emmanuel,State Senate,22,Republican,Jason D. Knight,4
+Montgomery,1B Emmanuel,State Senate,22,Republican,Jeff Burkhart,11
+Montgomery,20A Clarksville,State Senate,22,Democratic,Juanita Charles,34
+Montgomery,20A Clarksville,State Senate,22,Republican,Betty M. Burchett,108
+Montgomery,20A Clarksville,State Senate,22,Republican,Bill Powers,160
+Montgomery,20A Clarksville,State Senate,22,Republican,Jason D. Knight,20
+Montgomery,20A Clarksville,State Senate,22,Republican,Jeff Burkhart,100
+Montgomery,20B Barksdale,State Senate,22,Democratic,Juanita Charles,34
+Montgomery,20B Barksdale,State Senate,22,Republican,Betty M. Burchett,55
+Montgomery,20B Barksdale,State Senate,22,Republican,Bill Powers,74
+Montgomery,20B Barksdale,State Senate,22,Republican,Jason D. Knight,15
+Montgomery,20B Barksdale,State Senate,22,Republican,Jeff Burkhart,34
+Montgomery,21A Cumberland,State Senate,22,Democratic,Juanita Charles,32
+Montgomery,21A Cumberland,State Senate,22,Republican,Betty M. Burchett,27
+Montgomery,21A Cumberland,State Senate,22,Republican,Bill Powers,74
+Montgomery,21A Cumberland,State Senate,22,Republican,Jason D. Knight,9
+Montgomery,21A Cumberland,State Senate,22,Republican,Jeff Burkhart,32
+Montgomery,21B Hilldale,State Senate,22,Democratic,Juanita Charles,37
+Montgomery,21B Hilldale,State Senate,22,Republican,Betty M. Burchett,69
+Montgomery,21B Hilldale,State Senate,22,Republican,Bill Powers,238
+Montgomery,21B Hilldale,State Senate,22,Republican,Jason D. Knight,14
+Montgomery,21B Hilldale,State Senate,22,Republican,Jeff Burkhart,115
+Montgomery,2A St B MC,State Senate,22,Democratic,Juanita Charles,47
+Montgomery,2A St B MC,State Senate,22,Republican,Betty M. Burchett,110
+Montgomery,2A St B MC,State Senate,22,Republican,Bill Powers,276
+Montgomery,2A St B MC,State Senate,22,Republican,Jason D. Knight,25
+Montgomery,2A St B MC,State Senate,22,Republican,Jeff Burkhart,140
+Montgomery,2B St B CC,State Senate,22,Democratic,Juanita Charles,20
+Montgomery,2B St B CC,State Senate,22,Republican,Betty M. Burchett,43
+Montgomery,2B St B CC,State Senate,22,Republican,Bill Powers,101
+Montgomery,2B St B CC,State Senate,22,Republican,Jason D. Knight,9
+Montgomery,2B St B CC,State Senate,22,Republican,Jeff Burkhart,39
+Montgomery,3 East Montgomery,State Senate,22,Democratic,Juanita Charles,49
+Montgomery,3 East Montgomery,State Senate,22,Republican,Betty M. Burchett,132
+Montgomery,3 East Montgomery,State Senate,22,Republican,Bill Powers,265
+Montgomery,3 East Montgomery,State Senate,22,Republican,Jason D. Knight,68
+Montgomery,3 East Montgomery,State Senate,22,Republican,Jeff Burkhart,195
+Montgomery,4A MCMS,State Senate,22,Democratic,Juanita Charles,27
+Montgomery,4A MCMS,State Senate,22,Republican,Betty M. Burchett,54
+Montgomery,4A MCMS,State Senate,22,Republican,Bill Powers,123
+Montgomery,4A MCMS,State Senate,22,Republican,Jason D. Knight,37
+Montgomery,4A MCMS,State Senate,22,Republican,Jeff Burkhart,88
+Montgomery,4B CMCSS,State Senate,22,Democratic,Juanita Charles,24
+Montgomery,4B CMCSS,State Senate,22,Republican,Betty M. Burchett,26
+Montgomery,4B CMCSS,State Senate,22,Republican,Bill Powers,55
+Montgomery,4B CMCSS,State Senate,22,Republican,Jason D. Knight,12
+Montgomery,4B CMCSS,State Senate,22,Republican,Jeff Burkhart,69
+Montgomery,5A Smith,State Senate,22,Democratic,Juanita Charles,19
+Montgomery,5A Smith,State Senate,22,Republican,Betty M. Burchett,14
+Montgomery,5A Smith,State Senate,22,Republican,Bill Powers,31
+Montgomery,5A Smith,State Senate,22,Republican,Jason D. Knight,14
+Montgomery,5A Smith,State Senate,22,Republican,Jeff Burkhart,24
+Montgomery,5B Madison,State Senate,22,Democratic,Juanita Charles,27
+Montgomery,5B Madison,State Senate,22,Republican,Betty M. Burchett,11
+Montgomery,5B Madison,State Senate,22,Republican,Bill Powers,13
+Montgomery,5B Madison,State Senate,22,Republican,Jason D. Knight,2
+Montgomery,5B Madison,State Senate,22,Republican,Jeff Burkhart,7
+Montgomery,6A Cumberland,State Senate,22,Democratic,Juanita Charles,18
+Montgomery,6A Cumberland,State Senate,22,Republican,Betty M. Burchett,60
+Montgomery,6A Cumberland,State Senate,22,Republican,Bill Powers,111
+Montgomery,6A Cumberland,State Senate,22,Republican,Jason D. Knight,40
+Montgomery,6A Cumberland,State Senate,22,Republican,Jeff Burkhart,84
+Montgomery,6B Bethel,State Senate,22,Democratic,Juanita Charles,8
+Montgomery,6B Bethel,State Senate,22,Republican,Betty M. Burchett,26
+Montgomery,6B Bethel,State Senate,22,Republican,Bill Powers,26
+Montgomery,6B Bethel,State Senate,22,Republican,Jason D. Knight,14
+Montgomery,6B Bethel,State Senate,22,Republican,Jeff Burkhart,49
+Montgomery,7 Woodlawn,State Senate,22,Democratic,Juanita Charles,40
+Montgomery,7 Woodlawn,State Senate,22,Republican,Betty M. Burchett,42
+Montgomery,7 Woodlawn,State Senate,22,Republican,Bill Powers,92
+Montgomery,7 Woodlawn,State Senate,22,Republican,Jason D. Knight,88
+Montgomery,7 Woodlawn,State Senate,22,Republican,Jeff Burkhart,198
+Montgomery,8A Bethel,State Senate,22,Democratic,Juanita Charles,7
+Montgomery,8A Bethel,State Senate,22,Republican,Betty M. Burchett,1
+Montgomery,8A Bethel,State Senate,22,Republican,Bill Powers,10
+Montgomery,8A Bethel,State Senate,22,Republican,Jason D. Knight,1
+Montgomery,8A Bethel,State Senate,22,Republican,Jeff Burkhart,9
+Montgomery,8B Barkers Mill,State Senate,22,Democratic,Juanita Charles,20
+Montgomery,8B Barkers Mill,State Senate,22,Republican,Betty M. Burchett,6
+Montgomery,8B Barkers Mill,State Senate,22,Republican,Bill Powers,12
+Montgomery,8B Barkers Mill,State Senate,22,Republican,Jason D. Knight,12
+Montgomery,8B Barkers Mill,State Senate,22,Republican,Jeff Burkhart,14
+Montgomery,9 Outlaw,State Senate,22,Democratic,Juanita Charles,37
+Montgomery,9 Outlaw,State Senate,22,Republican,Betty M. Burchett,11
+Montgomery,9 Outlaw,State Senate,22,Republican,Bill Powers,22
+Montgomery,9 Outlaw,State Senate,22,Republican,Jason D. Knight,22
+Montgomery,9 Outlaw,State Senate,22,Republican,Jeff Burkhart,22
+Stewart,1-1 Indian Mound,State Senate,22,Democratic,Juanita Charles,7
+Stewart,1-1 Indian Mound,State Senate,22,Republican,Betty M. Burchett,3
+Stewart,1-1 Indian Mound,State Senate,22,Republican,Bill Powers,25
+Stewart,1-1 Indian Mound,State Senate,22,Republican,Jason D. Knight,8
+Stewart,1-1 Indian Mound,State Senate,22,Republican,Jeff Burkhart,39
+Stewart,2-1 Big Rock,State Senate,22,Democratic,Juanita Charles,10
+Stewart,2-1 Big Rock,State Senate,22,Republican,Betty M. Burchett,5
+Stewart,2-1 Big Rock,State Senate,22,Republican,Bill Powers,19
+Stewart,2-1 Big Rock,State Senate,22,Republican,Jason D. Knight,19
+Stewart,2-1 Big Rock,State Senate,22,Republican,Jeff Burkhart,52
+Stewart,3-1 Bumpus Mills,State Senate,22,Democratic,Juanita Charles,10
+Stewart,3-1 Bumpus Mills,State Senate,22,Republican,Betty M. Burchett,6
+Stewart,3-1 Bumpus Mills,State Senate,22,Republican,Bill Powers,22
+Stewart,3-1 Bumpus Mills,State Senate,22,Republican,Jason D. Knight,13
+Stewart,3-1 Bumpus Mills,State Senate,22,Republican,Jeff Burkhart,49
+Stewart,4-1 Church Street,State Senate,22,Democratic,Juanita Charles,12
+Stewart,4-1 Church Street,State Senate,22,Republican,Betty M. Burchett,13
+Stewart,4-1 Church Street,State Senate,22,Republican,Bill Powers,53
+Stewart,4-1 Church Street,State Senate,22,Republican,Jason D. Knight,11
+Stewart,4-1 Church Street,State Senate,22,Republican,Jeff Burkhart,43
+Stewart,5-1 Visitors Center,State Senate,22,Democratic,Juanita Charles,18
+Stewart,5-1 Visitors Center,State Senate,22,Republican,Betty M. Burchett,14
+Stewart,5-1 Visitors Center,State Senate,22,Republican,Bill Powers,40
+Stewart,5-1 Visitors Center,State Senate,22,Republican,Jason D. Knight,22
+Stewart,5-1 Visitors Center,State Senate,22,Republican,Jeff Burkhart,56
+Stewart,6-1 Public Library,State Senate,22,Democratic,Juanita Charles,31
+Stewart,6-1 Public Library,State Senate,22,Republican,Betty M. Burchett,16
+Stewart,6-1 Public Library,State Senate,22,Republican,Bill Powers,35
+Stewart,6-1 Public Library,State Senate,22,Republican,Jason D. Knight,16
+Stewart,6-1 Public Library,State Senate,22,Republican,Jeff Burkhart,48
+Stewart,7-1 Cumberland City,State Senate,22,Democratic,Juanita Charles,13
+Stewart,7-1 Cumberland City,State Senate,22,Republican,Betty M. Burchett,12
+Stewart,7-1 Cumberland City,State Senate,22,Republican,Bill Powers,21
+Stewart,7-1 Cumberland City,State Senate,22,Republican,Jason D. Knight,15
+Stewart,7-1 Cumberland City,State Senate,22,Republican,Jeff Burkhart,51

--- a/2019/20190312__tn__special__general__county.csv
+++ b/2019/20190312__tn__special__general__county.csv
@@ -1,0 +1,5 @@
+county,office,district,party,candidate,votes
+Shelby,State Senate,32,Democratic,Eric R. Coleman,1247
+Shelby,State Senate,32,Republican,Paul Rose,4936
+Tipton,State Senate,32,Democratic,Eric R. Coleman,499
+Tipton,State Senate,32,Republican,Paul Rose,4213

--- a/2019/20190312__tn__special__general__precinct.csv
+++ b/2019/20190312__tn__special__general__precinct.csv
@@ -1,0 +1,73 @@
+county,precinct,office,district,party,candidate,votes
+Shelby,Arlington 01,State Senate,32,Democratic,Eric R. Coleman,79
+Shelby,Arlington 01,State Senate,32,Republican,Paul Rose,306
+Shelby,Arlington 02,State Senate,32,Democratic,Eric R. Coleman,29
+Shelby,Arlington 02,State Senate,32,Republican,Paul Rose,84
+Shelby,Bartlett 03,State Senate,32,Democratic,Eric R. Coleman,24
+Shelby,Bartlett 03,State Senate,32,Republican,Paul Rose,197
+Shelby,Bartlett 04,State Senate,32,Democratic,Eric R. Coleman,45
+Shelby,Bartlett 04,State Senate,32,Republican,Paul Rose,185
+Shelby,Bartlett 05,State Senate,32,Democratic,Eric R. Coleman,45
+Shelby,Bartlett 05,State Senate,32,Republican,Paul Rose,142
+Shelby,Bartlett 06,State Senate,32,Democratic,Eric R. Coleman,29
+Shelby,Bartlett 06,State Senate,32,Republican,Paul Rose,129
+Shelby,Bartlett 08,State Senate,32,Democratic,Eric R. Coleman,47
+Shelby,Bartlett 08,State Senate,32,Republican,Paul Rose,295
+Shelby,Bartlett 09,State Senate,32,Democratic,Eric R. Coleman,44
+Shelby,Bartlett 09,State Senate,32,Republican,Paul Rose,254
+Shelby,Bartlett 11,State Senate,32,Democratic,Eric R. Coleman,26
+Shelby,Bartlett 11,State Senate,32,Republican,Paul Rose,165
+Shelby,Bartlett 13,State Senate,32,Democratic,Eric R. Coleman,98
+Shelby,Bartlett 13,State Senate,32,Republican,Paul Rose,144
+Shelby,Brunswick 01,State Senate,32,Democratic,Eric R. Coleman,35
+Shelby,Brunswick 01,State Senate,32,Republican,Paul Rose,143
+Shelby,Brunswick 02,State Senate,32,Democratic,Eric R. Coleman,67
+Shelby,Brunswick 02,State Senate,32,Republican,Paul Rose,176
+Shelby,Collierville 01,State Senate,32,Democratic,Eric R. Coleman,44
+Shelby,Collierville 01,State Senate,32,Republican,Paul Rose,271
+Shelby,Collierville 02,State Senate,32,Democratic,Eric R. Coleman,75
+Shelby,Collierville 02,State Senate,32,Republican,Paul Rose,235
+Shelby,Collierville 03,State Senate,32,Democratic,Eric R. Coleman,48
+Shelby,Collierville 03,State Senate,32,Republican,Paul Rose,293
+Shelby,Collierville 04,State Senate,32,Democratic,Eric R. Coleman,52
+Shelby,Collierville 04,State Senate,32,Republican,Paul Rose,292
+Shelby,Collierville 05,State Senate,32,Democratic,Eric R. Coleman,26
+Shelby,Collierville 05,State Senate,32,Republican,Paul Rose,153
+Shelby,Collierville 06,State Senate,32,Democratic,Eric R. Coleman,24
+Shelby,Collierville 06,State Senate,32,Republican,Paul Rose,183
+Shelby,Collierville 07,State Senate,32,Democratic,Eric R. Coleman,103
+Shelby,Collierville 07,State Senate,32,Republican,Paul Rose,82
+Shelby,Collierville 08,State Senate,32,Democratic,Eric R. Coleman,32
+Shelby,Collierville 08,State Senate,32,Republican,Paul Rose,124
+Shelby,Collierville 09,State Senate,32,Democratic,Eric R. Coleman,71
+Shelby,Collierville 09,State Senate,32,Republican,Paul Rose,238
+Shelby,Eads,State Senate,32,Democratic,Eric R. Coleman,24
+Shelby,Eads,State Senate,32,Republican,Paul Rose,94
+Shelby,Forest Hills 02,State Senate,32,Democratic,Eric R. Coleman,20
+Shelby,Forest Hills 02,State Senate,32,Republican,Paul Rose,24
+Shelby,Lakeland 01,State Senate,32,Democratic,Eric R. Coleman,66
+Shelby,Lakeland 01,State Senate,32,Republican,Paul Rose,358
+Shelby,Lakeland 02,State Senate,32,Democratic,Eric R. Coleman,24
+Shelby,Lakeland 02,State Senate,32,Republican,Paul Rose,105
+Shelby,Memphis 88-2,State Senate,32,Democratic,Eric R. Coleman,17
+Shelby,Memphis 88-2,State Senate,32,Republican,Paul Rose,14
+Shelby,Stewartville,State Senate,32,Democratic,Eric R. Coleman,53
+Shelby,Stewartville,State Senate,32,Republican,Paul Rose,250
+Tipton,1-1 NE Covington,State Senate,32,Democratic,Eric R. Coleman,68
+Tipton,1-1 NE Covington,State Senate,32,Republican,Paul Rose,378
+Tipton,2-3 SE Covington,State Senate,32,Democratic,Eric R. Coleman,68
+Tipton,2-3 SE Covington,State Senate,32,Republican,Paul Rose,801
+Tipton,3-6 Tipton West,State Senate,32,Democratic,Eric R. Coleman,22
+Tipton,3-6 Tipton West,State Senate,32,Republican,Paul Rose,696
+Tipton,4-11 Atoka,State Senate,32,Democratic,Eric R. Coleman,70
+Tipton,4-11 Atoka,State Senate,32,Republican,Paul Rose,477
+Tipton,5-12 Munford,State Senate,32,Democratic,Eric R. Coleman,53
+Tipton,5-12 Munford,State Senate,32,Republican,Paul Rose,475
+Tipton,6-14 SW Tipton,State Senate,32,Democratic,Eric R. Coleman,29
+Tipton,6-14 SW Tipton,State Senate,32,Republican,Paul Rose,352
+Tipton,7-19 Austin Peay,State Senate,32,Democratic,Eric R. Coleman,66
+Tipton,7-19 Austin Peay,State Senate,32,Republican,Paul Rose,437
+Tipton,8-21 Wilkinsville,State Senate,32,Democratic,Eric R. Coleman,80
+Tipton,8-21 Wilkinsville,State Senate,32,Republican,Paul Rose,223
+Tipton,9-22 Brighton,State Senate,32,Democratic,Eric R. Coleman,43
+Tipton,9-22 Brighton,State Senate,32,Republican,Paul Rose,374

--- a/2019/20190423__tn__special__general__county.csv
+++ b/2019/20190423__tn__special__general__county.csv
@@ -1,0 +1,13 @@
+county,office,district,party,candidate,votes
+Houston,State Senate,22,Democratic,Juanita Charles,161
+Houston,State Senate,22,Independent,David L. Cutting,1
+Houston,State Senate,22,Independent,Doyle Clark,43
+Houston,State Senate,22,Republican,Bill Powers,279
+Montgomery,State Senate,22,Democratic,Juanita Charles,4950
+Montgomery,State Senate,22,Independent,David L. Cutting,80
+Montgomery,State Senate,22,Independent,Doyle Clark,100
+Montgomery,State Senate,22,Republican,Bill Powers,5669
+Stewart,State Senate,22,Democratic,Juanita Charles,241
+Stewart,State Senate,22,Independent,David L. Cutting,3
+Stewart,State Senate,22,Independent,Doyle Clark,12
+Stewart,State Senate,22,Republican,Bill Powers,513

--- a/2019/20190423__tn__special__general__precinct.csv
+++ b/2019/20190423__tn__special__general__precinct.csv
@@ -1,0 +1,173 @@
+county,precinct,office,district,party,candidate,votes
+Houston,Arlington,State Senate,22,Democratic,Juanita Charles,23
+Houston,Arlington,State Senate,22,Independent,David L. Cutting,0
+Houston,Arlington,State Senate,22,Independent,Doyle Clark,7
+Houston,Arlington,State Senate,22,Republican,Bill Powers,44
+Houston,Erin,State Senate,22,Democratic,Juanita Charles,22
+Houston,Erin,State Senate,22,Independent,David L. Cutting,1
+Houston,Erin,State Senate,22,Independent,Doyle Clark,10
+Houston,Erin,State Senate,22,Republican,Bill Powers,37
+Houston,Erin Elementary,State Senate,22,Democratic,Juanita Charles,17
+Houston,Erin Elementary,State Senate,22,Independent,David L. Cutting,0
+Houston,Erin Elementary,State Senate,22,Independent,Doyle Clark,6
+Houston,Erin Elementary,State Senate,22,Republican,Bill Powers,38
+Houston,Griffins Chapel,State Senate,22,Democratic,Juanita Charles,22
+Houston,Griffins Chapel,State Senate,22,Independent,David L. Cutting,0
+Houston,Griffins Chapel,State Senate,22,Independent,Doyle Clark,10
+Houston,Griffins Chapel,State Senate,22,Republican,Bill Powers,50
+Houston,Houston Co Middle,State Senate,22,Democratic,Juanita Charles,32
+Houston,Houston Co Middle,State Senate,22,Independent,David L. Cutting,0
+Houston,Houston Co Middle,State Senate,22,Independent,Doyle Clark,5
+Houston,Houston Co Middle,State Senate,22,Republican,Bill Powers,32
+Houston,Stewart,State Senate,22,Democratic,Juanita Charles,18
+Houston,Stewart,State Senate,22,Independent,David L. Cutting,0
+Houston,Stewart,State Senate,22,Independent,Doyle Clark,2
+Houston,Stewart,State Senate,22,Republican,Bill Powers,41
+Houston,Tennessee Ridge,State Senate,22,Democratic,Juanita Charles,27
+Houston,Tennessee Ridge,State Senate,22,Independent,David L. Cutting,0
+Houston,Tennessee Ridge,State Senate,22,Independent,Doyle Clark,3
+Houston,Tennessee Ridge,State Senate,22,Republican,Bill Powers,37
+Montgomery,10 Minglewood,State Senate,22,Democratic,Juanita Charles,150
+Montgomery,10 Minglewood,State Senate,22,Independent,David L. Cutting,4
+Montgomery,10 Minglewood,State Senate,22,Independent,Doyle Clark,3
+Montgomery,10 Minglewood,State Senate,22,Republican,Bill Powers,123
+Montgomery,11 Northwest,State Senate,22,Democratic,Juanita Charles,211
+Montgomery,11 Northwest,State Senate,22,Independent,David L. Cutting,2
+Montgomery,11 Northwest,State Senate,22,Independent,Doyle Clark,3
+Montgomery,11 Northwest,State Senate,22,Republican,Bill Powers,107
+Montgomery,12 Ringgold,State Senate,22,Democratic,Juanita Charles,299
+Montgomery,12 Ringgold,State Senate,22,Independent,David L. Cutting,3
+Montgomery,12 Ringgold,State Senate,22,Independent,Doyle Clark,2
+Montgomery,12 Ringgold,State Senate,22,Republican,Bill Powers,127
+Montgomery,13 Byrns Darden,State Senate,22,Democratic,Juanita Charles,288
+Montgomery,13 Byrns Darden,State Senate,22,Independent,David L. Cutting,4
+Montgomery,13 Byrns Darden,State Senate,22,Independent,Doyle Clark,2
+Montgomery,13 Byrns Darden,State Senate,22,Republican,Bill Powers,93
+Montgomery,14 Glenellen,State Senate,22,Democratic,Juanita Charles,327
+Montgomery,14 Glenellen,State Senate,22,Independent,David L. Cutting,19
+Montgomery,14 Glenellen,State Senate,22,Independent,Doyle Clark,8
+Montgomery,14 Glenellen,State Senate,22,Republican,Bill Powers,180
+Montgomery,15 Sango,State Senate,22,Democratic,Juanita Charles,240
+Montgomery,15 Sango,State Senate,22,Independent,David L. Cutting,2
+Montgomery,15 Sango,State Senate,22,Independent,Doyle Clark,6
+Montgomery,15 Sango,State Senate,22,Republican,Bill Powers,459
+Montgomery,16 New Providence,State Senate,22,Democratic,Juanita Charles,195
+Montgomery,16 New Providence,State Senate,22,Independent,David L. Cutting,1
+Montgomery,16 New Providence,State Senate,22,Independent,Doyle Clark,4
+Montgomery,16 New Providence,State Senate,22,Republican,Bill Powers,128
+Montgomery,17 Grace,State Senate,22,Democratic,Juanita Charles,214
+Montgomery,17 Grace,State Senate,22,Independent,David L. Cutting,2
+Montgomery,17 Grace,State Senate,22,Independent,Doyle Clark,1
+Montgomery,17 Grace,State Senate,22,Republican,Bill Powers,134
+Montgomery,18 Hazelwood,State Senate,22,Democratic,Juanita Charles,276
+Montgomery,18 Hazelwood,State Senate,22,Independent,David L. Cutting,0
+Montgomery,18 Hazelwood,State Senate,22,Independent,Doyle Clark,2
+Montgomery,18 Hazelwood,State Senate,22,Republican,Bill Powers,141
+Montgomery,19 Oakland,State Senate,22,Democratic,Juanita Charles,388
+Montgomery,19 Oakland,State Senate,22,Independent,David L. Cutting,1
+Montgomery,19 Oakland,State Senate,22,Independent,Doyle Clark,8
+Montgomery,19 Oakland,State Senate,22,Republican,Bill Powers,386
+Montgomery,1A St B ES,State Senate,22,Democratic,Juanita Charles,197
+Montgomery,1A St B ES,State Senate,22,Independent,David L. Cutting,4
+Montgomery,1A St B ES,State Senate,22,Independent,Doyle Clark,5
+Montgomery,1A St B ES,State Senate,22,Republican,Bill Powers,212
+Montgomery,1B Emmanuel,State Senate,22,Democratic,Juanita Charles,17
+Montgomery,1B Emmanuel,State Senate,22,Independent,David L. Cutting,0
+Montgomery,1B Emmanuel,State Senate,22,Independent,Doyle Clark,2
+Montgomery,1B Emmanuel,State Senate,22,Republican,Bill Powers,24
+Montgomery,20A Clarksville,State Senate,22,Democratic,Juanita Charles,187
+Montgomery,20A Clarksville,State Senate,22,Independent,David L. Cutting,3
+Montgomery,20A Clarksville,State Senate,22,Independent,Doyle Clark,6
+Montgomery,20A Clarksville,State Senate,22,Republican,Bill Powers,337
+Montgomery,20B Barksdale,State Senate,22,Democratic,Juanita Charles,112
+Montgomery,20B Barksdale,State Senate,22,Independent,David L. Cutting,6
+Montgomery,20B Barksdale,State Senate,22,Independent,Doyle Clark,3
+Montgomery,20B Barksdale,State Senate,22,Republican,Bill Powers,153
+Montgomery,21A Cumberland,State Senate,22,Democratic,Juanita Charles,158
+Montgomery,21A Cumberland,State Senate,22,Independent,David L. Cutting,2
+Montgomery,21A Cumberland,State Senate,22,Independent,Doyle Clark,5
+Montgomery,21A Cumberland,State Senate,22,Republican,Bill Powers,114
+Montgomery,21B Hilldale,State Senate,22,Democratic,Juanita Charles,164
+Montgomery,21B Hilldale,State Senate,22,Independent,David L. Cutting,2
+Montgomery,21B Hilldale,State Senate,22,Independent,Doyle Clark,0
+Montgomery,21B Hilldale,State Senate,22,Republican,Bill Powers,381
+Montgomery,2A St B MC,State Senate,22,Democratic,Juanita Charles,219
+Montgomery,2A St B MC,State Senate,22,Independent,David L. Cutting,6
+Montgomery,2A St B MC,State Senate,22,Independent,Doyle Clark,1
+Montgomery,2A St B MC,State Senate,22,Republican,Bill Powers,479
+Montgomery,2B St B CC,State Senate,22,Democratic,Juanita Charles,93
+Montgomery,2B St B CC,State Senate,22,Independent,David L. Cutting,3
+Montgomery,2B St B CC,State Senate,22,Independent,Doyle Clark,3
+Montgomery,2B St B CC,State Senate,22,Republican,Bill Powers,187
+Montgomery,3 East Montgomery,State Senate,22,Democratic,Juanita Charles,224
+Montgomery,3 East Montgomery,State Senate,22,Independent,David L. Cutting,4
+Montgomery,3 East Montgomery,State Senate,22,Independent,Doyle Clark,8
+Montgomery,3 East Montgomery,State Senate,22,Republican,Bill Powers,591
+Montgomery,4A MCMS,State Senate,22,Democratic,Juanita Charles,108
+Montgomery,4A MCMS,State Senate,22,Independent,David L. Cutting,1
+Montgomery,4A MCMS,State Senate,22,Independent,Doyle Clark,2
+Montgomery,4A MCMS,State Senate,22,Republican,Bill Powers,244
+Montgomery,4B WR Event Center,State Senate,22,Democratic,Juanita Charles,103
+Montgomery,4B WR Event Center,State Senate,22,Independent,David L. Cutting,2
+Montgomery,4B WR Event Center,State Senate,22,Independent,Doyle Clark,0
+Montgomery,4B WR Event Center,State Senate,22,Republican,Bill Powers,120
+Montgomery,5A Smith,State Senate,22,Democratic,Juanita Charles,97
+Montgomery,5A Smith,State Senate,22,Independent,David L. Cutting,1
+Montgomery,5A Smith,State Senate,22,Independent,Doyle Clark,1
+Montgomery,5A Smith,State Senate,22,Republican,Bill Powers,75
+Montgomery,5B Madison,State Senate,22,Democratic,Juanita Charles,111
+Montgomery,5B Madison,State Senate,22,Independent,David L. Cutting,0
+Montgomery,5B Madison,State Senate,22,Independent,Doyle Clark,0
+Montgomery,5B Madison,State Senate,22,Republican,Bill Powers,27
+Montgomery,6A Cumberland,State Senate,22,Democratic,Juanita Charles,89
+Montgomery,6A Cumberland,State Senate,22,Independent,David L. Cutting,3
+Montgomery,6A Cumberland,State Senate,22,Independent,Doyle Clark,6
+Montgomery,6A Cumberland,State Senate,22,Republican,Bill Powers,250
+Montgomery,6B Bethel,State Senate,22,Democratic,Juanita Charles,25
+Montgomery,6B Bethel,State Senate,22,Independent,David L. Cutting,1
+Montgomery,6B Bethel,State Senate,22,Independent,Doyle Clark,7
+Montgomery,6B Bethel,State Senate,22,Republican,Bill Powers,92
+Montgomery,7 Woodlawn,State Senate,22,Democratic,Juanita Charles,115
+Montgomery,7 Woodlawn,State Senate,22,Independent,David L. Cutting,3
+Montgomery,7 Woodlawn,State Senate,22,Independent,Doyle Clark,9
+Montgomery,7 Woodlawn,State Senate,22,Republican,Bill Powers,346
+Montgomery,8A Bethel,State Senate,22,Democratic,Juanita Charles,48
+Montgomery,8A Bethel,State Senate,22,Independent,David L. Cutting,0
+Montgomery,8A Bethel,State Senate,22,Independent,Doyle Clark,1
+Montgomery,8A Bethel,State Senate,22,Republican,Bill Powers,29
+Montgomery,8B Barkers Mill,State Senate,22,Democratic,Juanita Charles,128
+Montgomery,8B Barkers Mill,State Senate,22,Independent,David L. Cutting,0
+Montgomery,8B Barkers Mill,State Senate,22,Independent,Doyle Clark,2
+Montgomery,8B Barkers Mill,State Senate,22,Republican,Bill Powers,53
+Montgomery,9 Outlaw,State Senate,22,Democratic,Juanita Charles,167
+Montgomery,9 Outlaw,State Senate,22,Independent,David L. Cutting,1
+Montgomery,9 Outlaw,State Senate,22,Independent,Doyle Clark,0
+Montgomery,9 Outlaw,State Senate,22,Republican,Bill Powers,77
+Stewart,1-1 Indian Mound,State Senate,22,Democratic,Juanita Charles,20
+Stewart,1-1 Indian Mound,State Senate,22,Independent,David L. Cutting,1
+Stewart,1-1 Indian Mound,State Senate,22,Independent,Doyle Clark,1
+Stewart,1-1 Indian Mound,State Senate,22,Republican,Bill Powers,60
+Stewart,2-1 Big Rock,State Senate,22,Democratic,Juanita Charles,21
+Stewart,2-1 Big Rock,State Senate,22,Independent,David L. Cutting,1
+Stewart,2-1 Big Rock,State Senate,22,Independent,Doyle Clark,3
+Stewart,2-1 Big Rock,State Senate,22,Republican,Bill Powers,71
+Stewart,3-1 Bumpus Mills,State Senate,22,Democratic,Juanita Charles,29
+Stewart,3-1 Bumpus Mills,State Senate,22,Independent,David L. Cutting,0
+Stewart,3-1 Bumpus Mills,State Senate,22,Independent,Doyle Clark,3
+Stewart,3-1 Bumpus Mills,State Senate,22,Republican,Bill Powers,80
+Stewart,4-1 Church Street,State Senate,22,Democratic,Juanita Charles,29
+Stewart,4-1 Church Street,State Senate,22,Independent,David L. Cutting,0
+Stewart,4-1 Church Street,State Senate,22,Independent,Doyle Clark,2
+Stewart,4-1 Church Street,State Senate,22,Republican,Bill Powers,80
+Stewart,5-1 Visitors Center,State Senate,22,Democratic,Juanita Charles,48
+Stewart,5-1 Visitors Center,State Senate,22,Independent,David L. Cutting,0
+Stewart,5-1 Visitors Center,State Senate,22,Independent,Doyle Clark,0
+Stewart,5-1 Visitors Center,State Senate,22,Republican,Bill Powers,72
+Stewart,6-1 Public Library,State Senate,22,Democratic,Juanita Charles,55
+Stewart,6-1 Public Library,State Senate,22,Independent,David L. Cutting,1
+Stewart,6-1 Public Library,State Senate,22,Independent,Doyle Clark,1
+Stewart,6-1 Public Library,State Senate,22,Republican,Bill Powers,82
+Stewart,7-1 Cumberland City,State Senate,22,Democratic,Juanita Charles,39
+Stewart,7-1 Cumberland City,State Senate,22,Independent,David L. Cutting,0
+Stewart,7-1 Cumberland City,State Senate,22,Independent,Doyle Clark,2
+Stewart,7-1 Cumberland City,State Senate,22,Republican,Bill Powers,68

--- a/2019/20191105__tn__special__primary__county.csv
+++ b/2019/20191105__tn__special__primary__county.csv
@@ -1,0 +1,16 @@
+county,office,district,party,candidate,votes
+Dyer,State House,77,Democratic,Michael Smith,277
+Dyer,State House,77,Republican,Bob Kirk,650
+Dyer,State House,77,Republican,Casey L Hood,345
+Dyer,State House,77,Republican,Rusty Grills,2655
+Dyer,State House,77,Republican,Vanedda Prince Webb,555
+Lake,State House,77,Democratic,Michael Smith,109
+Lake,State House,77,Republican,Bob Kirk,27
+Lake,State House,77,Republican,Casey L Hood,223
+Lake,State House,77,Republican,Rusty Grills,242
+Lake,State House,77,Republican,Vanedda Prince Webb,29
+Obion,State House,77,Democratic,Michael Smith,140
+Obion,State House,77,Republican,Bob Kirk,82
+Obion,State House,77,Republican,Casey L Hood,1350
+Obion,State House,77,Republican,Rusty Grills,1313
+Obion,State House,77,Republican,Vanedda Prince Webb,60

--- a/2019/20191105__tn__special__primary__precinct.csv
+++ b/2019/20191105__tn__special__primary__precinct.csv
@@ -1,0 +1,151 @@
+county,precinct,office,district,party,candidate,votes
+Dyer,A1- Bonicord,State House,77,Democratic,Michael Smith,14
+Dyer,A1- Bonicord,State House,77,Republican,Bob Kirk,29
+Dyer,A1- Bonicord,State House,77,Republican,Casey L Hood,23
+Dyer,A1- Bonicord,State House,77,Republican,Rusty Grills,134
+Dyer,A1- Bonicord,State House,77,Republican,Vanedda Prince Webb,26
+Dyer,A2- Fowlkes,State House,77,Democratic,Michael Smith,10
+Dyer,A2- Fowlkes,State House,77,Republican,Bob Kirk,20
+Dyer,A2- Fowlkes,State House,77,Republican,Casey L Hood,14
+Dyer,A2- Fowlkes,State House,77,Republican,Rusty Grills,127
+Dyer,A2- Fowlkes,State House,77,Republican,Vanedda Prince Webb,12
+Dyer,B- Newbern,State House,77,Democratic,Michael Smith,22
+Dyer,B- Newbern,State House,77,Republican,Bob Kirk,25
+Dyer,B- Newbern,State House,77,Republican,Casey L Hood,54
+Dyer,B- Newbern,State House,77,Republican,Rusty Grills,316
+Dyer,B- Newbern,State House,77,Republican,Vanedda Prince Webb,21
+Dyer,C1- Tatumville,State House,77,Democratic,Michael Smith,3
+Dyer,C1- Tatumville,State House,77,Republican,Bob Kirk,7
+Dyer,C1- Tatumville,State House,77,Republican,Casey L Hood,17
+Dyer,C1- Tatumville,State House,77,Republican,Rusty Grills,120
+Dyer,C1- Tatumville,State House,77,Republican,Vanedda Prince Webb,13
+Dyer,C2- Trimble,State House,77,Democratic,Michael Smith,18
+Dyer,C2- Trimble,State House,77,Republican,Bob Kirk,20
+Dyer,C2- Trimble,State House,77,Republican,Casey L Hood,41
+Dyer,C2- Trimble,State House,77,Republican,Rusty Grills,232
+Dyer,C2- Trimble,State House,77,Republican,Vanedda Prince Webb,23
+Dyer,C3- Roellen,State House,77,Democratic,Michael Smith,6
+Dyer,C3- Roellen,State House,77,Republican,Bob Kirk,10
+Dyer,C3- Roellen,State House,77,Republican,Casey L Hood,9
+Dyer,C3- Roellen,State House,77,Republican,Rusty Grills,84
+Dyer,C3- Roellen,State House,77,Republican,Vanedda Prince Webb,15
+Dyer,D1- Millsfield,State House,77,Democratic,Michael Smith,12
+Dyer,D1- Millsfield,State House,77,Republican,Bob Kirk,33
+Dyer,D1- Millsfield,State House,77,Republican,Casey L Hood,31
+Dyer,D1- Millsfield,State House,77,Republican,Rusty Grills,300
+Dyer,D1- Millsfield,State House,77,Republican,Vanedda Prince Webb,25
+Dyer,D2- Bogota,State House,77,Democratic,Michael Smith,6
+Dyer,D2- Bogota,State House,77,Republican,Bob Kirk,24
+Dyer,D2- Bogota,State House,77,Republican,Casey L Hood,29
+Dyer,D2- Bogota,State House,77,Republican,Rusty Grills,135
+Dyer,D2- Bogota,State House,77,Republican,Vanedda Prince Webb,47
+Dyer,E1- Finley,State House,77,Democratic,Michael Smith,10
+Dyer,E1- Finley,State House,77,Republican,Bob Kirk,24
+Dyer,E1- Finley,State House,77,Republican,Casey L Hood,13
+Dyer,E1- Finley,State House,77,Republican,Rusty Grills,129
+Dyer,E1- Finley,State House,77,Republican,Vanedda Prince Webb,22
+Dyer,E2- Lenox,State House,77,Democratic,Michael Smith,5
+Dyer,E2- Lenox,State House,77,Republican,Bob Kirk,47
+Dyer,E2- Lenox,State House,77,Republican,Casey L Hood,26
+Dyer,E2- Lenox,State House,77,Republican,Rusty Grills,162
+Dyer,E2- Lenox,State House,77,Republican,Vanedda Prince Webb,32
+Dyer,F- Dyer Co Central,State House,77,Democratic,Michael Smith,60
+Dyer,F- Dyer Co Central,State House,77,Republican,Bob Kirk,7
+Dyer,F- Dyer Co Central,State House,77,Republican,Casey L Hood,6
+Dyer,F- Dyer Co Central,State House,77,Republican,Rusty Grills,17
+Dyer,F- Dyer Co Central,State House,77,Republican,Vanedda Prince Webb,4
+Dyer,G- Courthouse,State House,77,Democratic,Michael Smith,18
+Dyer,G- Courthouse,State House,77,Republican,Bob Kirk,66
+Dyer,G- Courthouse,State House,77,Republican,Casey L Hood,24
+Dyer,G- Courthouse,State House,77,Republican,Rusty Grills,152
+Dyer,G- Courthouse,State House,77,Republican,Vanedda Prince Webb,61
+Dyer,H- E. Dyersburg,State House,77,Democratic,Michael Smith,26
+Dyer,H- E. Dyersburg,State House,77,Republican,Bob Kirk,61
+Dyer,H- E. Dyersburg,State House,77,Republican,Casey L Hood,16
+Dyer,H- E. Dyersburg,State House,77,Republican,Rusty Grills,181
+Dyer,H- E. Dyersburg,State House,77,Republican,Vanedda Prince Webb,44
+Dyer,I1- Community Center,State House,77,Democratic,Michael Smith,19
+Dyer,I1- Community Center,State House,77,Republican,Bob Kirk,22
+Dyer,I1- Community Center,State House,77,Republican,Casey L Hood,5
+Dyer,I1- Community Center,State House,77,Republican,Rusty Grills,141
+Dyer,I1- Community Center,State House,77,Republican,Vanedda Prince Webb,35
+Dyer,I2- Hurricane Hill,State House,77,Democratic,Michael Smith,7
+Dyer,I2- Hurricane Hill,State House,77,Republican,Bob Kirk,44
+Dyer,I2- Hurricane Hill,State House,77,Republican,Casey L Hood,14
+Dyer,I2- Hurricane Hill,State House,77,Republican,Rusty Grills,148
+Dyer,I2- Hurricane Hill,State House,77,Republican,Vanedda Prince Webb,10
+Dyer,J- North Dyersburg,State House,77,Democratic,Michael Smith,41
+Dyer,J- North Dyersburg,State House,77,Republican,Bob Kirk,211
+Dyer,J- North Dyersburg,State House,77,Republican,Casey L Hood,23
+Dyer,J- North Dyersburg,State House,77,Republican,Rusty Grills,277
+Dyer,J- North Dyersburg,State House,77,Republican,Vanedda Prince Webb,165
+Lake,1 Tiptonville SR Citizens,State House,77,Democratic,Michael Smith,3
+Lake,1 Tiptonville SR Citizens,State House,77,Republican,Bob Kirk,1
+Lake,1 Tiptonville SR Citizens,State House,77,Republican,Casey L Hood,16
+Lake,1 Tiptonville SR Citizens,State House,77,Republican,Rusty Grills,24
+Lake,1 Tiptonville SR Citizens,State House,77,Republican,Vanedda Prince Webb,0
+Lake,2 Courthouse,State House,77,Democratic,Michael Smith,69
+Lake,2 Courthouse,State House,77,Republican,Bob Kirk,15
+Lake,2 Courthouse,State House,77,Republican,Casey L Hood,101
+Lake,2 Courthouse,State House,77,Republican,Rusty Grills,108
+Lake,2 Courthouse,State House,77,Republican,Vanedda Prince Webb,12
+Lake,3 Lake Co Middle,State House,77,Democratic,Michael Smith,37
+Lake,3 Lake Co Middle,State House,77,Republican,Bob Kirk,11
+Lake,3 Lake Co Middle,State House,77,Republican,Casey L Hood,106
+Lake,3 Lake Co Middle,State House,77,Republican,Rusty Grills,110
+Lake,3 Lake Co Middle,State House,77,Republican,Vanedda Prince Webb,17
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Democratic,Michael Smith,0
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Republican,Bob Kirk,0
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Republican,Casey L Hood,7
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Republican,Rusty Grills,4
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Republican,Vanedda Prince Webb,0
+Obion,2-4 Woodland,State House,77,Democratic,Michael Smith,23
+Obion,2-4 Woodland,State House,77,Republican,Bob Kirk,5
+Obion,2-4 Woodland,State House,77,Republican,Casey L Hood,120
+Obion,2-4 Woodland,State House,77,Republican,Rusty Grills,146
+Obion,2-4 Woodland,State House,77,Republican,Vanedda Prince Webb,16
+Obion,3-2 Kenton,State House,77,Democratic,Michael Smith,13
+Obion,3-2 Kenton,State House,77,Republican,Bob Kirk,20
+Obion,3-2 Kenton,State House,77,Republican,Casey L Hood,63
+Obion,3-2 Kenton,State House,77,Republican,Rusty Grills,110
+Obion,3-2 Kenton,State House,77,Republican,Vanedda Prince Webb,11
+Obion,3-4 Rives,State House,77,Democratic,Michael Smith,16
+Obion,3-4 Rives,State House,77,Republican,Bob Kirk,13
+Obion,3-4 Rives,State House,77,Republican,Casey L Hood,127
+Obion,3-4 Rives,State House,77,Republican,Rusty Grills,203
+Obion,3-4 Rives,State House,77,Republican,Vanedda Prince Webb,7
+Obion,4-1 Fair Grounds,State House,77,Democratic,Michael Smith,1
+Obion,4-1 Fair Grounds,State House,77,Republican,Bob Kirk,0
+Obion,4-1 Fair Grounds,State House,77,Republican,Casey L Hood,5
+Obion,4-1 Fair Grounds,State House,77,Republican,Rusty Grills,3
+Obion,4-1 Fair Grounds,State House,77,Republican,Vanedda Prince Webb,0
+Obion,5-2 Cloverdale,State House,77,Democratic,Michael Smith,6
+Obion,5-2 Cloverdale,State House,77,Republican,Bob Kirk,2
+Obion,5-2 Cloverdale,State House,77,Republican,Casey L Hood,71
+Obion,5-2 Cloverdale,State House,77,Republican,Rusty Grills,87
+Obion,5-2 Cloverdale,State House,77,Republican,Vanedda Prince Webb,0
+Obion,5-4 Hornbeak,State House,77,Democratic,Michael Smith,9
+Obion,5-4 Hornbeak,State House,77,Republican,Bob Kirk,10
+Obion,5-4 Hornbeak,State House,77,Republican,Casey L Hood,147
+Obion,5-4 Hornbeak,State House,77,Republican,Rusty Grills,144
+Obion,5-4 Hornbeak,State House,77,Republican,Vanedda Prince Webb,3
+Obion,5-5 Samburg,State House,77,Democratic,Michael Smith,8
+Obion,5-5 Samburg,State House,77,Republican,Bob Kirk,3
+Obion,5-5 Samburg,State House,77,Republican,Casey L Hood,58
+Obion,5-5 Samburg,State House,77,Republican,Rusty Grills,78
+Obion,5-5 Samburg,State House,77,Republican,Vanedda Prince Webb,2
+Obion,6-1 Troy Sr Ctr,State House,77,Democratic,Michael Smith,18
+Obion,6-1 Troy Sr Ctr,State House,77,Republican,Bob Kirk,18
+Obion,6-1 Troy Sr Ctr,State House,77,Republican,Casey L Hood,330
+Obion,6-1 Troy Sr Ctr,State House,77,Republican,Rusty Grills,208
+Obion,6-1 Troy Sr Ctr,State House,77,Republican,Vanedda Prince Webb,8
+Obion,6-2 Obion Sr Ctr,State House,77,Democratic,Michael Smith,6
+Obion,6-2 Obion Sr Ctr,State House,77,Republican,Bob Kirk,1
+Obion,6-2 Obion Sr Ctr,State House,77,Republican,Casey L Hood,233
+Obion,6-2 Obion Sr Ctr,State House,77,Republican,Rusty Grills,64
+Obion,6-2 Obion Sr Ctr,State House,77,Republican,Vanedda Prince Webb,2
+Obion,7-2 Obion Co Library,State House,77,Democratic,Michael Smith,40
+Obion,7-2 Obion Co Library,State House,77,Republican,Bob Kirk,10
+Obion,7-2 Obion Co Library,State House,77,Republican,Casey L Hood,189
+Obion,7-2 Obion Co Library,State House,77,Republican,Rusty Grills,266
+Obion,7-2 Obion Co Library,State House,77,Republican,Vanedda Prince Webb,11

--- a/2019/20191219__tn__special__general__county.csv
+++ b/2019/20191219__tn__special__general__county.csv
@@ -1,0 +1,16 @@
+county,office,district,party,candidate,votes
+Dyer,State House,77,Democratic,Michael Smith,250
+Dyer,State House,77,Independent,Billy M Jones,6
+Dyer,State House,77,Independent,Max Smith,20
+Dyer,State House,77,Independent,Ronnie Henley,13
+Dyer,State House,77,Republican,Rusty Grills,2103
+Lake,State House,77,Democratic,Michael Smith,115
+Lake,State House,77,Independent,Billy M Jones,0
+Lake,State House,77,Independent,Max Smith,3
+Lake,State House,77,Independent,Ronnie Henley,2
+Lake,State House,77,Republican,Rusty Grills,231
+Obion,State House,77,Democratic,Michael Smith,139
+Obion,State House,77,Independent,Billy M Jones,9
+Obion,State House,77,Independent,Max Smith,16
+Obion,State House,77,Independent,Ronnie Henley,6
+Obion,State House,77,Republican,Rusty Grills,1010

--- a/2019/20191219__tn__special__general__precinct.csv
+++ b/2019/20191219__tn__special__general__precinct.csv
@@ -1,0 +1,151 @@
+county,precinct,office,district,party,candidate,votes
+Dyer,A1- Bonicord,State House,77,Democratic,Michael Smith,4
+Dyer,A1- Bonicord,State House,77,Independent,Billy M Jones,3
+Dyer,A1- Bonicord,State House,77,Independent,Max Smith,1
+Dyer,A1- Bonicord,State House,77,Independent,Ronnie Henley,1
+Dyer,A1- Bonicord,State House,77,Republican,Rusty Grills,110
+Dyer,A2- Fowlkes,State House,77,Democratic,Michael Smith,9
+Dyer,A2- Fowlkes,State House,77,Independent,Billy M Jones,0
+Dyer,A2- Fowlkes,State House,77,Independent,Max Smith,2
+Dyer,A2- Fowlkes,State House,77,Independent,Ronnie Henley,0
+Dyer,A2- Fowlkes,State House,77,Republican,Rusty Grills,105
+Dyer,B- Newbern,State House,77,Democratic,Michael Smith,15
+Dyer,B- Newbern,State House,77,Independent,Billy M Jones,0
+Dyer,B- Newbern,State House,77,Independent,Max Smith,2
+Dyer,B- Newbern,State House,77,Independent,Ronnie Henley,4
+Dyer,B- Newbern,State House,77,Republican,Rusty Grills,244
+Dyer,C1- Tatumville,State House,77,Democratic,Michael Smith,3
+Dyer,C1- Tatumville,State House,77,Independent,Billy M Jones,0
+Dyer,C1- Tatumville,State House,77,Independent,Max Smith,0
+Dyer,C1- Tatumville,State House,77,Independent,Ronnie Henley,0
+Dyer,C1- Tatumville,State House,77,Republican,Rusty Grills,95
+Dyer,C2- Trimble,State House,77,Democratic,Michael Smith,15
+Dyer,C2- Trimble,State House,77,Independent,Billy M Jones,0
+Dyer,C2- Trimble,State House,77,Independent,Max Smith,1
+Dyer,C2- Trimble,State House,77,Independent,Ronnie Henley,0
+Dyer,C2- Trimble,State House,77,Republican,Rusty Grills,171
+Dyer,C3- Roellen,State House,77,Democratic,Michael Smith,5
+Dyer,C3- Roellen,State House,77,Independent,Billy M Jones,0
+Dyer,C3- Roellen,State House,77,Independent,Max Smith,0
+Dyer,C3- Roellen,State House,77,Independent,Ronnie Henley,0
+Dyer,C3- Roellen,State House,77,Republican,Rusty Grills,55
+Dyer,D1- Millsfield,State House,77,Democratic,Michael Smith,7
+Dyer,D1- Millsfield,State House,77,Independent,Billy M Jones,0
+Dyer,D1- Millsfield,State House,77,Independent,Max Smith,0
+Dyer,D1- Millsfield,State House,77,Independent,Ronnie Henley,3
+Dyer,D1- Millsfield,State House,77,Republican,Rusty Grills,223
+Dyer,D2- Bogota,State House,77,Democratic,Michael Smith,21
+Dyer,D2- Bogota,State House,77,Independent,Billy M Jones,0
+Dyer,D2- Bogota,State House,77,Independent,Max Smith,2
+Dyer,D2- Bogota,State House,77,Independent,Ronnie Henley,1
+Dyer,D2- Bogota,State House,77,Republican,Rusty Grills,117
+Dyer,E1- Finley,State House,77,Democratic,Michael Smith,9
+Dyer,E1- Finley,State House,77,Independent,Billy M Jones,0
+Dyer,E1- Finley,State House,77,Independent,Max Smith,0
+Dyer,E1- Finley,State House,77,Independent,Ronnie Henley,0
+Dyer,E1- Finley,State House,77,Republican,Rusty Grills,100
+Dyer,E2- Lenox,State House,77,Democratic,Michael Smith,2
+Dyer,E2- Lenox,State House,77,Independent,Billy M Jones,1
+Dyer,E2- Lenox,State House,77,Independent,Max Smith,0
+Dyer,E2- Lenox,State House,77,Independent,Ronnie Henley,0
+Dyer,E2- Lenox,State House,77,Republican,Rusty Grills,128
+Dyer,F- Dyer Co Central,State House,77,Democratic,Michael Smith,50
+Dyer,F- Dyer Co Central,State House,77,Independent,Billy M Jones,1
+Dyer,F- Dyer Co Central,State House,77,Independent,Max Smith,2
+Dyer,F- Dyer Co Central,State House,77,Independent,Ronnie Henley,0
+Dyer,F- Dyer Co Central,State House,77,Republican,Rusty Grills,15
+Dyer,G- Courthouse,State House,77,Democratic,Michael Smith,21
+Dyer,G- Courthouse,State House,77,Independent,Billy M Jones,0
+Dyer,G- Courthouse,State House,77,Independent,Max Smith,0
+Dyer,G- Courthouse,State House,77,Independent,Ronnie Henley,2
+Dyer,G- Courthouse,State House,77,Republican,Rusty Grills,125
+Dyer,H- E. Dyersburg,State House,77,Democratic,Michael Smith,23
+Dyer,H- E. Dyersburg,State House,77,Independent,Billy M Jones,0
+Dyer,H- E. Dyersburg,State House,77,Independent,Max Smith,0
+Dyer,H- E. Dyersburg,State House,77,Independent,Ronnie Henley,0
+Dyer,H- E. Dyersburg,State House,77,Republican,Rusty Grills,138
+Dyer,I1- Community Center,State House,77,Democratic,Michael Smith,19
+Dyer,I1- Community Center,State House,77,Independent,Billy M Jones,0
+Dyer,I1- Community Center,State House,77,Independent,Max Smith,0
+Dyer,I1- Community Center,State House,77,Independent,Ronnie Henley,1
+Dyer,I1- Community Center,State House,77,Republican,Rusty Grills,92
+Dyer,I2- Hurricane Hill,State House,77,Democratic,Michael Smith,13
+Dyer,I2- Hurricane Hill,State House,77,Independent,Billy M Jones,0
+Dyer,I2- Hurricane Hill,State House,77,Independent,Max Smith,0
+Dyer,I2- Hurricane Hill,State House,77,Independent,Ronnie Henley,0
+Dyer,I2- Hurricane Hill,State House,77,Republican,Rusty Grills,108
+Dyer,J- North Dyersburg,State House,77,Democratic,Michael Smith,34
+Dyer,J- North Dyersburg,State House,77,Independent,Billy M Jones,1
+Dyer,J- North Dyersburg,State House,77,Independent,Max Smith,10
+Dyer,J- North Dyersburg,State House,77,Independent,Ronnie Henley,1
+Dyer,J- North Dyersburg,State House,77,Republican,Rusty Grills,277
+Lake,1 Tiptonville SR Citizens,State House,77,Democratic,Michael Smith,3
+Lake,1 Tiptonville SR Citizens,State House,77,Independent,Billy M Jones,0
+Lake,1 Tiptonville SR Citizens,State House,77,Independent,Max Smith,0
+Lake,1 Tiptonville SR Citizens,State House,77,Independent,Ronnie Henley,0
+Lake,1 Tiptonville SR Citizens,State House,77,Republican,Rusty Grills,18
+Lake,2 Courthouse,State House,77,Democratic,Michael Smith,73
+Lake,2 Courthouse,State House,77,Independent,Billy M Jones,0
+Lake,2 Courthouse,State House,77,Independent,Max Smith,1
+Lake,2 Courthouse,State House,77,Independent,Ronnie Henley,1
+Lake,2 Courthouse,State House,77,Republican,Rusty Grills,123
+Lake,3 Lake Co Middle,State House,77,Democratic,Michael Smith,39
+Lake,3 Lake Co Middle,State House,77,Independent,Billy M Jones,0
+Lake,3 Lake Co Middle,State House,77,Independent,Max Smith,2
+Lake,3 Lake Co Middle,State House,77,Independent,Ronnie Henley,1
+Lake,3 Lake Co Middle,State House,77,Republican,Rusty Grills,90
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Democratic,Michael Smith,1
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Independent,Billy M Jones,0
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Independent,Max Smith,0
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Independent,Ronnie Henley,0
+Obion,2-1 Eddie Cox Sr Ctr,State House,77,Republican,Rusty Grills,2
+Obion,2-4 Woodland,State House,77,Democratic,Michael Smith,14
+Obion,2-4 Woodland,State House,77,Independent,Billy M Jones,4
+Obion,2-4 Woodland,State House,77,Independent,Max Smith,0
+Obion,2-4 Woodland,State House,77,Independent,Ronnie Henley,0
+Obion,2-4 Woodland,State House,77,Republican,Rusty Grills,120
+Obion,3-2 Kenton,State House,77,Democratic,Michael Smith,13
+Obion,3-2 Kenton,State House,77,Independent,Billy M Jones,1
+Obion,3-2 Kenton,State House,77,Independent,Max Smith,4
+Obion,3-2 Kenton,State House,77,Independent,Ronnie Henley,1
+Obion,3-2 Kenton,State House,77,Republican,Rusty Grills,81
+Obion,3-4 Rives,State House,77,Democratic,Michael Smith,15
+Obion,3-4 Rives,State House,77,Independent,Billy M Jones,0
+Obion,3-4 Rives,State House,77,Independent,Max Smith,0
+Obion,3-4 Rives,State House,77,Independent,Ronnie Henley,1
+Obion,3-4 Rives,State House,77,Republican,Rusty Grills,155
+Obion,4-1 Fair Grounds,State House,77,Democratic,Michael Smith,0
+Obion,4-1 Fair Grounds,State House,77,Independent,Billy M Jones,0
+Obion,4-1 Fair Grounds,State House,77,Independent,Max Smith,0
+Obion,4-1 Fair Grounds,State House,77,Independent,Ronnie Henley,0
+Obion,4-1 Fair Grounds,State House,77,Republican,Rusty Grills,1
+Obion,5-2 Cloverdale,State House,77,Democratic,Michael Smith,3
+Obion,5-2 Cloverdale,State House,77,Independent,Billy M Jones,0
+Obion,5-2 Cloverdale,State House,77,Independent,Max Smith,0
+Obion,5-2 Cloverdale,State House,77,Independent,Ronnie Henley,0
+Obion,5-2 Cloverdale,State House,77,Republican,Rusty Grills,77
+Obion,5-4 Hornbeak,State House,77,Democratic,Michael Smith,11
+Obion,5-4 Hornbeak,State House,77,Independent,Billy M Jones,2
+Obion,5-4 Hornbeak,State House,77,Independent,Max Smith,0
+Obion,5-4 Hornbeak,State House,77,Independent,Ronnie Henley,1
+Obion,5-4 Hornbeak,State House,77,Republican,Rusty Grills,110
+Obion,5-5 Samburg,State House,77,Democratic,Michael Smith,7
+Obion,5-5 Samburg,State House,77,Independent,Billy M Jones,1
+Obion,5-5 Samburg,State House,77,Independent,Max Smith,0
+Obion,5-5 Samburg,State House,77,Independent,Ronnie Henley,0
+Obion,5-5 Samburg,State House,77,Republican,Rusty Grills,42
+Obion,6-1 Troy Sr Ctr,State House,77,Democratic,Michael Smith,17
+Obion,6-1 Troy Sr Ctr,State House,77,Independent,Billy M Jones,0
+Obion,6-1 Troy Sr Ctr,State House,77,Independent,Max Smith,2
+Obion,6-1 Troy Sr Ctr,State House,77,Independent,Ronnie Henley,2
+Obion,6-1 Troy Sr Ctr,State House,77,Republican,Rusty Grills,151
+Obion,6-2 Obion Sr Ctr,State House,77,Democratic,Michael Smith,8
+Obion,6-2 Obion Sr Ctr,State House,77,Independent,Billy M Jones,0
+Obion,6-2 Obion Sr Ctr,State House,77,Independent,Max Smith,6
+Obion,6-2 Obion Sr Ctr,State House,77,Independent,Ronnie Henley,0
+Obion,6-2 Obion Sr Ctr,State House,77,Republican,Rusty Grills,53
+Obion,7-2 Obion Co Library,State House,77,Democratic,Michael Smith,50
+Obion,7-2 Obion Co Library,State House,77,Independent,Billy M Jones,1
+Obion,7-2 Obion Co Library,State House,77,Independent,Max Smith,4
+Obion,7-2 Obion Co Library,State House,77,Independent,Ronnie Henley,1
+Obion,7-2 Obion Co Library,State House,77,Republican,Rusty Grills,218

--- a/cleaning/tn_2019_specials_parser.py
+++ b/cleaning/tn_2019_specials_parser.py
@@ -1,0 +1,336 @@
+"""
+Parser for the 2019 Tennessee special elections, producing OpenElections CSVs
+(county + precinct) for all six 2019 specials linked from
+https://sos.tn.gov/elections/results#2019:
+
+  20190124__tn__special__primary  -- Jan 24 Senate District 32 special primary
+                                      (Republican + Democratic primaries merged)
+  20190307__tn__special__primary  -- Mar 7  Senate District 22 special primary
+                                      (Republican + Democratic primaries merged)
+  20190312__tn__special__general  -- Mar 12 Senate District 32 special general
+  20190423__tn__special__general  -- Apr 23 Senate District 22 special general
+  20191105__tn__special__primary  -- Nov 5  House District 77 special primary
+                                      (Republican + Democratic primaries merged)
+  20191219__tn__special__general  -- Dec 19 House District 77 special general
+
+Sources (WebFetch 403s; use curl) are by-precinct PDFs on the pre-2025 bucket
+https://sos-tn-gov-files.tnsosfiles.com/  (the SoS results page links carry
+?<token> query strings but the plain URLs without tokens work). Each primary's
+Republican and Democratic results are published as SEPARATE PDFs and merged
+here with a `party` column; each general is a single PDF.
+
+Layout (the same "Layout B" multi-county format used by the 2023 Jun+ specials):
+  Banner:     State of Tennessee
+  Date:       <Month Day, Year>
+  Section:    Republican Primary | Democratic Primary | State General
+              (2021 used "Special State General Election"; accepted too)
+  Office:     Tennessee Senate District N (unexpired term)
+              Tennessee House of Representatives District N (unexpired term)
+  Candidates: N. Name                  (primaries; party from the section header)
+              N. Name - Party          (generals; party from the suffix)
+  Column hdr: 1  2  3  ... N          (present only when >1 candidate)
+  <County> County
+   Precincts:
+    <precinct name>  v1 v2 ... vN      (votes may contain commas, e.g. 1,512)
+   County Totals:   v1 v2 ... vN
+  ...
+   DISTRICT TOTALS  v1 v2 ... vN
+
+Conventions (standard OpenElections office names; matches the 2013/2015/2021/
+2023 legislative-special convention of a BARE district number -- the
+"(unexpired term)" suffix is for judicial/executive races, NOT legislative
+specials, so it is dropped here):
+  Tennessee Senate District N            -> office "State Senate",  district "N"
+  Tennessee House of Representatives N    -> office "State House",   district "N"
+Party: full names from the primary section header or each general candidate's
+` - Party` suffix (so generals carry `Independent`). Precinct names kept verbatim
+as printed (e.g. `Memphis 88-2`, `1-1 NE Covington`, `A1- Bonicord`) with
+internal whitespace collapsed so file_format passes. Votes are integers.
+
+County totals are derived by summing precinct votes per (county, candidate) and
+asserted against each precinct PDF's own `County Totals:` and `DISTRICT TOTALS`
+lines, then spot-checked against the separate by-county PDFs.
+
+Requires `requests` (in the Pipfile) and `pdftotext` (poppler).
+"""
+
+import csv
+import os
+import re
+import subprocess
+import tempfile
+from collections import defaultdict
+
+import requests
+
+BASE = "https://sos-tn-gov-files.tnsosfiles.com"
+
+OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "2019")
+
+COUNTY_HEADER = ["county", "office", "district", "party", "candidate", "votes"]
+PRECINCT_HEADER = ["county", "precinct", "office", "district", "party",
+                   "candidate", "votes"]
+
+SECTION_RE = re.compile(
+    r"^(Republican Primary|Democratic Primary|State General|"
+    r"Special State General Election)\s*$")
+OFFICE_SENATE_RE = re.compile(
+    r"^Tennessee Senate District (\d+)(?:\s*\(unexpired term\))?\s*$")
+OFFICE_HOUSE_RE = re.compile(
+    r"^Tennessee House of Representatives District (\d+)"
+    r"(?:\s*\(unexpired term\))?\s*$")
+CAND_RE = re.compile(r"^\s*(\d+)\.\s+(.+?)\s*$")
+COUNTY_RE = re.compile(r"^([A-Z][A-Za-z .]+) County\s*$")
+PARTY_SUFFIX_RE = re.compile(
+    r"^(.+?)\s+-\s+(Republican|Democratic|Independent|Libertarian|Green|"
+    r"Constitution)\s*$")
+VOTE_RE = re.compile(r"^\d[\d,]*$")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def clean(s):
+    return WHITESPACE_RE.sub(" ", str(s)).strip()
+
+
+def to_int(tok):
+    return int(tok.replace(",", ""))
+
+
+def split_candidate(raw, section):
+    """Return (name, party). Primaries take party from the section header;
+    generals take it from the candidate's ` - Party` suffix."""
+    if section == "Republican Primary":
+        return (raw.strip(), "Republican")
+    if section == "Democratic Primary":
+        return (raw.strip(), "Democratic")
+    m = PARTY_SUFFIX_RE.match(raw.strip())
+    if m:
+        return (m.group(1).strip(), m.group(2))
+    return (raw.strip(), "")
+
+
+def pdftotext_layout(pdf_bytes):
+    """Run `pdftotext -layout` on the given PDF bytes; return the text."""
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        f.write(pdf_bytes)
+        path = f.name
+    try:
+        out = subprocess.run(
+            ["pdftotext", "-layout", path, "-"],
+            check=True, capture_output=True, text=True)
+        return out.stdout
+    finally:
+        os.unlink(path)
+
+
+def parse_pdf(text):
+    """Parse one by-precinct PDF. Returns (office, district, candidates,
+    precinct_rows, county_totals) where candidates is [(name, party), ...],
+    precinct_rows is [[county, precinct, office, district, party, candidate,
+    votes], ...] and county_totals is {(county, name, party): votes} from the
+    PDF's own `County Totals:` lines (for cross-checking)."""
+    lines = text.splitlines()
+    section = None
+    office = None
+    district = None
+    cands_raw = []
+    # Header block: consume up to the first "<County> County" line.
+    start = 0
+    for idx, line in enumerate(lines):
+        s = line.strip()
+        if SECTION_RE.match(s):
+            section = s
+            continue
+        m = OFFICE_SENATE_RE.match(s)
+        if m:
+            office = "State Senate"
+            district = m.group(1)
+            continue
+        m = OFFICE_HOUSE_RE.match(s)
+        if m:
+            office = "State House"
+            district = m.group(1)
+            continue
+        if office and CAND_RE.match(line):
+            cands_raw.append(CAND_RE.match(line).group(2).strip())
+            continue
+        if COUNTY_RE.match(line):
+            start = idx
+            break
+    if office is None or section is None or not cands_raw:
+        raise ValueError(
+            f"header parse failed: office={office!r} section={section!r} "
+            f"cands={cands_raw!r}")
+    candidates = [split_candidate(c, section) for c in cands_raw]
+    n = len(candidates)
+
+    precinct_rows = []
+    county_totals = {}      # (county, name, party) -> votes from "County Totals:"
+    district_totals = {}    # (name, party) -> votes from "DISTRICT TOTALS"
+    current_county = None
+    in_precincts = False
+    for line in lines[start:]:
+        if not line.strip():
+            continue
+        m = COUNTY_RE.match(line)
+        if m:
+            current_county = m.group(1).strip()
+            in_precincts = False
+            continue
+        s = line.strip()
+        if s == "Precincts:":
+            in_precincts = True
+            continue
+        if s.startswith("County Totals:"):
+            nums = s[len("County Totals:"):].split()
+            if len(nums) != n:
+                raise ValueError(
+                    f"County Totals has {len(nums)} cols, expected {n}: {s!r}")
+            for k, (name, party) in enumerate(candidates):
+                county_totals[(current_county, name, party)] = to_int(nums[k])
+            in_precincts = False
+            continue
+        if s.startswith("DISTRICT TOTALS"):
+            nums = s[len("DISTRICT TOTALS"):].split()
+            if len(nums) == n:
+                for k, (name, party) in enumerate(candidates):
+                    district_totals[(name, party)] = to_int(nums[k])
+            in_precincts = False
+            continue
+        if in_precincts and current_county:
+            tokens = line.split()
+            if len(tokens) < n + 1:
+                continue
+            vote_tokens = tokens[-n:]
+            if not all(VOTE_RE.match(t) for t in vote_tokens):
+                continue
+            precinct = clean(" ".join(tokens[:-n]))
+            votes = [to_int(t) for t in vote_tokens]
+            for k, (name, party) in enumerate(candidates):
+                precinct_rows.append([current_county, precinct, office,
+                                      district, party, name, votes[k]])
+    return office, district, candidates, precinct_rows, county_totals
+
+
+def build(election):
+    """Build county + precinct rows for one election (which may combine
+    several PDFs, e.g. a primary's Rep+Dem PDFs). Returns (precinct_rows,
+    expected_county). `expected_county` maps (county, office, district, party,
+    candidate) -> votes from the PDFs' own County Totals lines."""
+    precinct_rows = []
+    expected = {}
+    for pdf_url in election["precincts"]:
+        resp = requests.get(pdf_url, headers={"User-Agent": "Mozilla/5.0"})
+        resp.raise_for_status()
+        text = pdftotext_layout(resp.content)
+        office, district, candidates, prows, ctotals = parse_pdf(text)
+        precinct_rows.extend(prows)
+        for (county, name, party), v in ctotals.items():
+            expected[(county, office, district, party, name)] = v
+    # Derive county totals by summing precincts.
+    derived = defaultdict(int)
+    for r in precinct_rows:
+        county, precinct, office, district, party, name, votes = r
+        derived[(county, office, district, party, name)] += votes
+    # Cross-check derived vs the PDFs' own County Totals lines.
+    mismatches = []
+    for k, v in derived.items():
+        if k in expected and expected[k] != v:
+            mismatches.append((k, v, expected[k]))
+    for k, v in expected.items():
+        if k not in derived:
+            mismatches.append((k, "MISSING", v))
+    if mismatches:
+        detail = "\n  ".join(
+            f"{k}: derived={dv} expected={ev}" for k, dv, ev in mismatches[:20])
+        raise AssertionError(f"county-total mismatch in {election['name']}:\n  "
+                            f"{detail}")
+    county_rows = [[k[0], k[1], k[2], k[3], k[4], v]
+                   for k, v in derived.items()]
+    return county_rows, precinct_rows, derived
+
+
+def sort_key_county(row):
+    return (row[0], row[2], row[3], row[1], row[4])
+
+
+def sort_key_precinct(row):
+    return (row[0], row[1], row[2], row[3], row[4], row[5])
+
+
+def write_csv(path, header, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(rows)
+    print(f"  Wrote {path} ({len(rows)} rows)")
+
+
+ELECTIONS = [
+    {
+        "name": "20190124__tn__special__primary",
+        "type": "primary",
+        "precincts": [
+            f"{BASE}/D32%20Republican%20Primary%20Precinct%20Totals.pdf",
+            f"{BASE}/D32%20Democratic%20Primary%20Precinct%20Totals.pdf",
+        ],
+    },
+    {
+        "name": "20190307__tn__special__primary",
+        "type": "primary",
+        "precincts": [
+            f"{BASE}/D22%20Republican%20Primary%20Precinct%20Totals.pdf",
+            f"{BASE}/D22%20Democratic%20Primary%20Precinct%20Totals.pdf",
+        ],
+    },
+    {
+        "name": "20190312__tn__special__general",
+        "type": "general",
+        "precincts": [
+            f"{BASE}/D32%20General%20Precinct%20Totals.pdf",
+        ],
+    },
+    {
+        "name": "20190423__tn__special__general",
+        "type": "general",
+        "precincts": [
+            f"{BASE}/D22%20General%20Precinct%20Totals.pdf",
+        ],
+    },
+    {
+        "name": "20191105__tn__special__primary",
+        "type": "primary",
+        "precincts": [
+            f"{BASE}/2019%20D77%20Republican%20Primary%20Precinct%20Totals.pdf",
+            f"{BASE}/2019%20D77%20Democratic%20Primary%20Precinct%20Totals.pdf",
+        ],
+    },
+    {
+        "name": "20191219__tn__special__general",
+        "type": "general",
+        "precincts": [
+            f"{BASE}/2019%20D77%20General%20Precinct%20Totals.pdf",
+        ],
+    },
+]
+
+
+def main():
+    out = os.path.abspath(OUT_DIR)
+    os.makedirs(out, exist_ok=True)
+    for election in ELECTIONS:
+        print(f"--- {election['name']} ({election['type']}) ---")
+        county_rows, precinct_rows, derived = build(election)
+        county_rows.sort(key=sort_key_county)
+        precinct_rows.sort(key=sort_key_precinct)
+        print(f"  county: {len(county_rows)} rows, precinct: "
+              f"{len(precinct_rows)} rows")
+        suffix = election["type"]  # "primary" or "general"
+        write_csv(os.path.join(out, f"{election['name']}__county.csv"),
+                  COUNTY_HEADER, county_rows)
+        write_csv(os.path.join(out, f"{election['name']}__precinct.csv"),
+                  PRECINCT_HEADER, precinct_rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds county- and precinct-level OpenElections CSVs for all six 2019 Tennessee special elections, sourced from the TN SoS results (`https://sos.tn.gov/elections/results#2019`):

- **`20190124__tn__special__primary`** (county + precinct) — Jan 24 Senate District 32 special primary. Republican + Democratic primaries published as separate SoS PDFs, merged with a `party` column.
- **`20190307__tn__special__primary`** (county + precinct) — Mar 7 Senate District 22 special primary (Rep + Dem merged).
- **`20190312__tn__special__general`** (county + precinct) — Mar 12 Senate District 32 special general.
- **`20190423__tn__special__general`** (county + precinct) — Apr 23 Senate District 22 special general.
- **`20191105__tn__special__primary`** (county + precinct) — Nov 5 House District 77 special primary (Rep + Dem merged).
- **`20191219__tn__special__general`** (county + precinct) — Dec 19 House District 77 special general.

## Conventions

Standard OpenElections office names, matching the repo's 2013/2015/2021/2023 legislative-special convention of a **bare district number** — the `(unexpired term)` suffix printed on the source is for judicial/executive races, not legislative specials, so it is dropped here:

- `Tennessee Senate District N` → `State Senate`, district `N`
- `Tennessee House of Representatives District N` → `State House`, district `N`

Party full names from the primary section header (`Republican Primary` / `Democratic Primary`) or each general candidate's ` - Party` suffix (so generals carry `Independent`). Precinct names kept verbatim as printed (e.g. `Memphis 88-2`, `1-1 NE Covington`, `A1- Bonicord`) with internal whitespace collapsed so `file_format` passes. Votes are integers.

## Sources

By-precinct PDFs on the pre-2025 bucket `https://sos-tn-gov-files.tnsosfiles.com/` (the SoS links carry `?<token>` query strings but the plain URLs work). All six use the multi-county "Layout B" format: banner, section header (`Republican Primary` / `Democratic Primary` / `State General`), `N. Name` (primaries) or `N. Name - Party` (generals) candidate lines, `<County> County` headers, a ` Precincts:` marker, `County Totals:` per county, and `DISTRICT TOTALS`. Single-candidate primaries (D32 Dem, D22 Dem, D77 Dem) omit the column-header line; the parser derives the candidate count from the `N. Name` lines.

- SD32: `D32 {Republican,Democratic} Primary Precinct Totals.pdf`, `D32 General Precinct Totals.pdf`
- SD22: `D22 {Republican,Democratic} Primary Precinct Totals.pdf`, `D22 General Precinct Totals.pdf`
- HD77: `2019 D77 {Republican,Democratic} Primary Precinct Totals.pdf`, `2019 D77 General Precinct Totals.pdf`

## Verification

- All four data tests pass locally on all twelve files: `file_format`, `missing_values`, `duplicate_entries`, `vote_breakdown_totals`.
- County totals derived by summing precinct votes and asserted against each precinct PDF's own `County Totals:` lines; the resulting district totals also match the separate by-county PDFs exactly:
  - Jan 24 D32 Rep: Chism 1,530 / McManus 1,157 / Rose 6,398 / Shafer 1,520
  - Jan 24 D32 Dem: Coleman 543
  - Mar 7 D22 Rep: Burchett 1,297 / Burkhart 2,513 / Knight 868 / Powers 2,782
  - Mar 7 D22 Dem: Charles 1,125
  - Mar 12 D32 gen: Rose (R) 9,149 / Coleman (D) 1,746
  - Apr 23 D22 gen: Powers (R) 6,461 / Charles (D) 5,352 / Clark (I) 155 / Cutting (I) 84
  - Nov 5 D77 Rep: Grills 4,210 / Hood 1,918 / Kirk 759 / Webb 644
  - Nov 5 D77 Dem: Smith 526
  - Dec 19 D77 gen: Grills (R) 3,344 / Smith (D) 504 / Henley (I) 21 / Jones (I) 15 / M. Smith (I) 39

Parser: `cleaning/tn_2019_specials_parser.py` (requires `requests` + `pdftotext`/poppler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)