### PR TITLE
Add 2017 TN special election results

### DIFF
--- a/2017/20170427__tn__special__primary__county.csv
+++ b/2017/20170427__tn__special__primary__county.csv
@@ -1,0 +1,9 @@
+county,office,district,party,candidate,votes
+Shelby,State House,95,Democratic,Julie Byrd Ashworth,364
+Shelby,State House,95,Republican,Billy Patton,753
+Shelby,State House,95,Republican,Curtis D. Loynachan,134
+Shelby,State House,95,Republican,Frank Uhlhorn,1017
+Shelby,State House,95,Republican,Gail Williams Horner,247
+Shelby,State House,95,Republican,Joseph Aaron Crone,58
+Shelby,State House,95,Republican,Kevin Vaughan,1067
+Shelby,State House,95,Republican,Missy Marshall,682

--- a/2017/20170427__tn__special__primary__precinct.csv
+++ b/2017/20170427__tn__special__primary__precinct.csv
@@ -1,0 +1,145 @@
+county,precinct,office,district,party,candidate,votes
+Shelby,Collierville 01,State House,95,Democratic,Julie Byrd Ashworth,15
+Shelby,Collierville 01,State House,95,Republican,Billy Patton,109
+Shelby,Collierville 01,State House,95,Republican,Curtis D. Loynachan,27
+Shelby,Collierville 01,State House,95,Republican,Frank Uhlhorn,9
+Shelby,Collierville 01,State House,95,Republican,Gail Williams Horner,53
+Shelby,Collierville 01,State House,95,Republican,Joseph Aaron Crone,4
+Shelby,Collierville 01,State House,95,Republican,Kevin Vaughan,148
+Shelby,Collierville 01,State House,95,Republican,Missy Marshall,62
+Shelby,Collierville 02,State House,95,Democratic,Julie Byrd Ashworth,34
+Shelby,Collierville 02,State House,95,Republican,Billy Patton,92
+Shelby,Collierville 02,State House,95,Republican,Curtis D. Loynachan,7
+Shelby,Collierville 02,State House,95,Republican,Frank Uhlhorn,23
+Shelby,Collierville 02,State House,95,Republican,Gail Williams Horner,18
+Shelby,Collierville 02,State House,95,Republican,Joseph Aaron Crone,1
+Shelby,Collierville 02,State House,95,Republican,Kevin Vaughan,91
+Shelby,Collierville 02,State House,95,Republican,Missy Marshall,48
+Shelby,Collierville 03,State House,95,Democratic,Julie Byrd Ashworth,22
+Shelby,Collierville 03,State House,95,Republican,Billy Patton,120
+Shelby,Collierville 03,State House,95,Republican,Curtis D. Loynachan,39
+Shelby,Collierville 03,State House,95,Republican,Frank Uhlhorn,10
+Shelby,Collierville 03,State House,95,Republican,Gail Williams Horner,26
+Shelby,Collierville 03,State House,95,Republican,Joseph Aaron Crone,2
+Shelby,Collierville 03,State House,95,Republican,Kevin Vaughan,111
+Shelby,Collierville 03,State House,95,Republican,Missy Marshall,56
+Shelby,Collierville 04,State House,95,Democratic,Julie Byrd Ashworth,44
+Shelby,Collierville 04,State House,95,Republican,Billy Patton,110
+Shelby,Collierville 04,State House,95,Republican,Curtis D. Loynachan,9
+Shelby,Collierville 04,State House,95,Republican,Frank Uhlhorn,32
+Shelby,Collierville 04,State House,95,Republican,Gail Williams Horner,38
+Shelby,Collierville 04,State House,95,Republican,Joseph Aaron Crone,1
+Shelby,Collierville 04,State House,95,Republican,Kevin Vaughan,148
+Shelby,Collierville 04,State House,95,Republican,Missy Marshall,102
+Shelby,Collierville 05,State House,95,Democratic,Julie Byrd Ashworth,14
+Shelby,Collierville 05,State House,95,Republican,Billy Patton,42
+Shelby,Collierville 05,State House,95,Republican,Curtis D. Loynachan,28
+Shelby,Collierville 05,State House,95,Republican,Frank Uhlhorn,6
+Shelby,Collierville 05,State House,95,Republican,Gail Williams Horner,16
+Shelby,Collierville 05,State House,95,Republican,Joseph Aaron Crone,5
+Shelby,Collierville 05,State House,95,Republican,Kevin Vaughan,122
+Shelby,Collierville 05,State House,95,Republican,Missy Marshall,44
+Shelby,Collierville 06,State House,95,Democratic,Julie Byrd Ashworth,18
+Shelby,Collierville 06,State House,95,Republican,Billy Patton,56
+Shelby,Collierville 06,State House,95,Republican,Curtis D. Loynachan,2
+Shelby,Collierville 06,State House,95,Republican,Frank Uhlhorn,49
+Shelby,Collierville 06,State House,95,Republican,Gail Williams Horner,7
+Shelby,Collierville 06,State House,95,Republican,Joseph Aaron Crone,7
+Shelby,Collierville 06,State House,95,Republican,Kevin Vaughan,71
+Shelby,Collierville 06,State House,95,Republican,Missy Marshall,58
+Shelby,Collierville 07,State House,95,Democratic,Julie Byrd Ashworth,60
+Shelby,Collierville 07,State House,95,Republican,Billy Patton,34
+Shelby,Collierville 07,State House,95,Republican,Curtis D. Loynachan,3
+Shelby,Collierville 07,State House,95,Republican,Frank Uhlhorn,15
+Shelby,Collierville 07,State House,95,Republican,Gail Williams Horner,13
+Shelby,Collierville 07,State House,95,Republican,Joseph Aaron Crone,0
+Shelby,Collierville 07,State House,95,Republican,Kevin Vaughan,22
+Shelby,Collierville 07,State House,95,Republican,Missy Marshall,23
+Shelby,Collierville 08,State House,95,Democratic,Julie Byrd Ashworth,7
+Shelby,Collierville 08,State House,95,Republican,Billy Patton,41
+Shelby,Collierville 08,State House,95,Republican,Curtis D. Loynachan,1
+Shelby,Collierville 08,State House,95,Republican,Frank Uhlhorn,13
+Shelby,Collierville 08,State House,95,Republican,Gail Williams Horner,7
+Shelby,Collierville 08,State House,95,Republican,Joseph Aaron Crone,2
+Shelby,Collierville 08,State House,95,Republican,Kevin Vaughan,51
+Shelby,Collierville 08,State House,95,Republican,Missy Marshall,72
+Shelby,Collierville 09,State House,95,Democratic,Julie Byrd Ashworth,32
+Shelby,Collierville 09,State House,95,Republican,Billy Patton,88
+Shelby,Collierville 09,State House,95,Republican,Curtis D. Loynachan,12
+Shelby,Collierville 09,State House,95,Republican,Frank Uhlhorn,22
+Shelby,Collierville 09,State House,95,Republican,Gail Williams Horner,20
+Shelby,Collierville 09,State House,95,Republican,Joseph Aaron Crone,3
+Shelby,Collierville 09,State House,95,Republican,Kevin Vaughan,98
+Shelby,Collierville 09,State House,95,Republican,Missy Marshall,76
+Shelby,Cordova 03,State House,95,Democratic,Julie Byrd Ashworth,0
+Shelby,Cordova 03,State House,95,Republican,Billy Patton,0
+Shelby,Cordova 03,State House,95,Republican,Curtis D. Loynachan,0
+Shelby,Cordova 03,State House,95,Republican,Frank Uhlhorn,2
+Shelby,Cordova 03,State House,95,Republican,Gail Williams Horner,0
+Shelby,Cordova 03,State House,95,Republican,Joseph Aaron Crone,0
+Shelby,Cordova 03,State House,95,Republican,Kevin Vaughan,0
+Shelby,Cordova 03,State House,95,Republican,Missy Marshall,0
+Shelby,Eads,State House,95,Democratic,Julie Byrd Ashworth,11
+Shelby,Eads,State House,95,Republican,Billy Patton,6
+Shelby,Eads,State House,95,Republican,Curtis D. Loynachan,3
+Shelby,Eads,State House,95,Republican,Frank Uhlhorn,15
+Shelby,Eads,State House,95,Republican,Gail Williams Horner,13
+Shelby,Eads,State House,95,Republican,Joseph Aaron Crone,1
+Shelby,Eads,State House,95,Republican,Kevin Vaughan,41
+Shelby,Eads,State House,95,Republican,Missy Marshall,13
+Shelby,Forest Hills 02,State House,95,Democratic,Julie Byrd Ashworth,5
+Shelby,Forest Hills 02,State House,95,Republican,Billy Patton,3
+Shelby,Forest Hills 02,State House,95,Republican,Curtis D. Loynachan,2
+Shelby,Forest Hills 02,State House,95,Republican,Frank Uhlhorn,3
+Shelby,Forest Hills 02,State House,95,Republican,Gail Williams Horner,3
+Shelby,Forest Hills 02,State House,95,Republican,Joseph Aaron Crone,0
+Shelby,Forest Hills 02,State House,95,Republican,Kevin Vaughan,3
+Shelby,Forest Hills 02,State House,95,Republican,Missy Marshall,5
+Shelby,Germantown 03,State House,95,Democratic,Julie Byrd Ashworth,2
+Shelby,Germantown 03,State House,95,Republican,Billy Patton,0
+Shelby,Germantown 03,State House,95,Republican,Curtis D. Loynachan,0
+Shelby,Germantown 03,State House,95,Republican,Frank Uhlhorn,18
+Shelby,Germantown 03,State House,95,Republican,Gail Williams Horner,0
+Shelby,Germantown 03,State House,95,Republican,Joseph Aaron Crone,0
+Shelby,Germantown 03,State House,95,Republican,Kevin Vaughan,2
+Shelby,Germantown 03,State House,95,Republican,Missy Marshall,3
+Shelby,Germantown 04,State House,95,Democratic,Julie Byrd Ashworth,39
+Shelby,Germantown 04,State House,95,Republican,Billy Patton,24
+Shelby,Germantown 04,State House,95,Republican,Curtis D. Loynachan,0
+Shelby,Germantown 04,State House,95,Republican,Frank Uhlhorn,274
+Shelby,Germantown 04,State House,95,Republican,Gail Williams Horner,12
+Shelby,Germantown 04,State House,95,Republican,Joseph Aaron Crone,1
+Shelby,Germantown 04,State House,95,Republican,Kevin Vaughan,44
+Shelby,Germantown 04,State House,95,Republican,Missy Marshall,48
+Shelby,Germantown 08,State House,95,Democratic,Julie Byrd Ashworth,17
+Shelby,Germantown 08,State House,95,Republican,Billy Patton,7
+Shelby,Germantown 08,State House,95,Republican,Curtis D. Loynachan,0
+Shelby,Germantown 08,State House,95,Republican,Frank Uhlhorn,174
+Shelby,Germantown 08,State House,95,Republican,Gail Williams Horner,10
+Shelby,Germantown 08,State House,95,Republican,Joseph Aaron Crone,8
+Shelby,Germantown 08,State House,95,Republican,Kevin Vaughan,22
+Shelby,Germantown 08,State House,95,Republican,Missy Marshall,19
+Shelby,Germantown 11,State House,95,Democratic,Julie Byrd Ashworth,27
+Shelby,Germantown 11,State House,95,Republican,Billy Patton,17
+Shelby,Germantown 11,State House,95,Republican,Curtis D. Loynachan,1
+Shelby,Germantown 11,State House,95,Republican,Frank Uhlhorn,230
+Shelby,Germantown 11,State House,95,Republican,Gail Williams Horner,9
+Shelby,Germantown 11,State House,95,Republican,Joseph Aaron Crone,13
+Shelby,Germantown 11,State House,95,Republican,Kevin Vaughan,73
+Shelby,Germantown 11,State House,95,Republican,Missy Marshall,31
+Shelby,Germantown 12,State House,95,Democratic,Julie Byrd Ashworth,9
+Shelby,Germantown 12,State House,95,Republican,Billy Patton,3
+Shelby,Germantown 12,State House,95,Republican,Curtis D. Loynachan,0
+Shelby,Germantown 12,State House,95,Republican,Frank Uhlhorn,115
+Shelby,Germantown 12,State House,95,Republican,Gail Williams Horner,0
+Shelby,Germantown 12,State House,95,Republican,Joseph Aaron Crone,0
+Shelby,Germantown 12,State House,95,Republican,Kevin Vaughan,18
+Shelby,Germantown 12,State House,95,Republican,Missy Marshall,16
+Shelby,Morning Sun 02,State House,95,Democratic,Julie Byrd Ashworth,8
+Shelby,Morning Sun 02,State House,95,Republican,Billy Patton,1
+Shelby,Morning Sun 02,State House,95,Republican,Curtis D. Loynachan,0
+Shelby,Morning Sun 02,State House,95,Republican,Frank Uhlhorn,7
+Shelby,Morning Sun 02,State House,95,Republican,Gail Williams Horner,2
+Shelby,Morning Sun 02,State House,95,Republican,Joseph Aaron Crone,10
+Shelby,Morning Sun 02,State House,95,Republican,Kevin Vaughan,2
+Shelby,Morning Sun 02,State House,95,Republican,Missy Marshall,6

--- a/2017/20170615__tn__special__general__county.csv
+++ b/2017/20170615__tn__special__general__county.csv
@@ -1,0 +1,5 @@
+county,office,district,party,candidate,votes
+Shelby,State House,95,Democratic,Julie Byrd Ashworth,1737
+Shelby,State House,95,Independent,Jim Tomasik,25
+Shelby,State House,95,Independent,Robert Schutt,144
+Shelby,State House,95,Republican,Kevin Vaughan,3099

--- a/2017/20170615__tn__special__general__precinct.csv
+++ b/2017/20170615__tn__special__general__precinct.csv
@@ -1,0 +1,73 @@
+county,precinct,office,district,party,candidate,votes
+Shelby,Collierville 01,State House,95,Democratic,Julie Byrd Ashworth,111
+Shelby,Collierville 01,State House,95,Independent,Jim Tomasik,0
+Shelby,Collierville 01,State House,95,Independent,Robert Schutt,5
+Shelby,Collierville 01,State House,95,Republican,Kevin Vaughan,348
+Shelby,Collierville 02,State House,95,Democratic,Julie Byrd Ashworth,159
+Shelby,Collierville 02,State House,95,Independent,Jim Tomasik,2
+Shelby,Collierville 02,State House,95,Independent,Robert Schutt,7
+Shelby,Collierville 02,State House,95,Republican,Kevin Vaughan,226
+Shelby,Collierville 03,State House,95,Democratic,Julie Byrd Ashworth,120
+Shelby,Collierville 03,State House,95,Independent,Jim Tomasik,2
+Shelby,Collierville 03,State House,95,Independent,Robert Schutt,3
+Shelby,Collierville 03,State House,95,Republican,Kevin Vaughan,322
+Shelby,Collierville 04,State House,95,Democratic,Julie Byrd Ashworth,123
+Shelby,Collierville 04,State House,95,Independent,Jim Tomasik,1
+Shelby,Collierville 04,State House,95,Independent,Robert Schutt,10
+Shelby,Collierville 04,State House,95,Republican,Kevin Vaughan,362
+Shelby,Collierville 05,State House,95,Democratic,Julie Byrd Ashworth,75
+Shelby,Collierville 05,State House,95,Independent,Jim Tomasik,0
+Shelby,Collierville 05,State House,95,Independent,Robert Schutt,3
+Shelby,Collierville 05,State House,95,Republican,Kevin Vaughan,223
+Shelby,Collierville 06,State House,95,Democratic,Julie Byrd Ashworth,74
+Shelby,Collierville 06,State House,95,Independent,Jim Tomasik,1
+Shelby,Collierville 06,State House,95,Independent,Robert Schutt,10
+Shelby,Collierville 06,State House,95,Republican,Kevin Vaughan,179
+Shelby,Collierville 07,State House,95,Democratic,Julie Byrd Ashworth,242
+Shelby,Collierville 07,State House,95,Independent,Jim Tomasik,3
+Shelby,Collierville 07,State House,95,Independent,Robert Schutt,6
+Shelby,Collierville 07,State House,95,Republican,Kevin Vaughan,93
+Shelby,Collierville 08,State House,95,Democratic,Julie Byrd Ashworth,55
+Shelby,Collierville 08,State House,95,Independent,Jim Tomasik,1
+Shelby,Collierville 08,State House,95,Independent,Robert Schutt,2
+Shelby,Collierville 08,State House,95,Republican,Kevin Vaughan,155
+Shelby,Collierville 09,State House,95,Democratic,Julie Byrd Ashworth,111
+Shelby,Collierville 09,State House,95,Independent,Jim Tomasik,1
+Shelby,Collierville 09,State House,95,Independent,Robert Schutt,4
+Shelby,Collierville 09,State House,95,Republican,Kevin Vaughan,277
+Shelby,Cordova 03,State House,95,Democratic,Julie Byrd Ashworth,0
+Shelby,Cordova 03,State House,95,Independent,Jim Tomasik,0
+Shelby,Cordova 03,State House,95,Independent,Robert Schutt,0
+Shelby,Cordova 03,State House,95,Republican,Kevin Vaughan,5
+Shelby,Eads,State House,95,Democratic,Julie Byrd Ashworth,36
+Shelby,Eads,State House,95,Independent,Jim Tomasik,3
+Shelby,Eads,State House,95,Independent,Robert Schutt,3
+Shelby,Eads,State House,95,Republican,Kevin Vaughan,104
+Shelby,Forest Hills 02,State House,95,Democratic,Julie Byrd Ashworth,76
+Shelby,Forest Hills 02,State House,95,Independent,Jim Tomasik,0
+Shelby,Forest Hills 02,State House,95,Independent,Robert Schutt,0
+Shelby,Forest Hills 02,State House,95,Republican,Kevin Vaughan,16
+Shelby,Germantown 03,State House,95,Democratic,Julie Byrd Ashworth,15
+Shelby,Germantown 03,State House,95,Independent,Jim Tomasik,1
+Shelby,Germantown 03,State House,95,Independent,Robert Schutt,0
+Shelby,Germantown 03,State House,95,Republican,Kevin Vaughan,11
+Shelby,Germantown 04,State House,95,Democratic,Julie Byrd Ashworth,204
+Shelby,Germantown 04,State House,95,Independent,Jim Tomasik,4
+Shelby,Germantown 04,State House,95,Independent,Robert Schutt,29
+Shelby,Germantown 04,State House,95,Republican,Kevin Vaughan,295
+Shelby,Germantown 08,State House,95,Democratic,Julie Byrd Ashworth,139
+Shelby,Germantown 08,State House,95,Independent,Jim Tomasik,2
+Shelby,Germantown 08,State House,95,Independent,Robert Schutt,9
+Shelby,Germantown 08,State House,95,Republican,Kevin Vaughan,155
+Shelby,Germantown 11,State House,95,Democratic,Julie Byrd Ashworth,122
+Shelby,Germantown 11,State House,95,Independent,Jim Tomasik,4
+Shelby,Germantown 11,State House,95,Independent,Robert Schutt,36
+Shelby,Germantown 11,State House,95,Republican,Kevin Vaughan,226
+Shelby,Germantown 12,State House,95,Democratic,Julie Byrd Ashworth,50
+Shelby,Germantown 12,State House,95,Independent,Jim Tomasik,0
+Shelby,Germantown 12,State House,95,Independent,Robert Schutt,10
+Shelby,Germantown 12,State House,95,Republican,Kevin Vaughan,83
+Shelby,Morning Sun 02,State House,95,Democratic,Julie Byrd Ashworth,25
+Shelby,Morning Sun 02,State House,95,Independent,Jim Tomasik,0
+Shelby,Morning Sun 02,State House,95,Independent,Robert Schutt,7
+Shelby,Morning Sun 02,State House,95,Republican,Kevin Vaughan,19

--- a/2017/20171107__tn__special__primary__county.csv
+++ b/2017/20171107__tn__special__primary__county.csv
@@ -1,0 +1,13 @@
+county,office,district,party,candidate,votes
+Cannon,State Senate,17,Democratic,Mary Alice Carfi,60
+Cannon,State Senate,17,Republican,Mark Pody,188
+Clay,State Senate,17,Democratic,Mary Alice Carfi,44
+Clay,State Senate,17,Republican,Mark Pody,93
+DeKalb,State Senate,17,Democratic,Mary Alice Carfi,111
+DeKalb,State Senate,17,Republican,Mark Pody,172
+Macon,State Senate,17,Democratic,Mary Alice Carfi,54
+Macon,State Senate,17,Republican,Mark Pody,168
+Smith,State Senate,17,Democratic,Mary Alice Carfi,187
+Smith,State Senate,17,Republican,Mark Pody,300
+Wilson,State Senate,17,Democratic,Mary Alice Carfi,827
+Wilson,State Senate,17,Republican,Mark Pody,1641

--- a/2017/20171107__tn__special__primary__precinct.csv
+++ b/2017/20171107__tn__special__primary__precinct.csv
@@ -1,0 +1,165 @@
+county,precinct,office,district,party,candidate,votes
+Cannon,1-1 Westside,State Senate,17,Democratic,Mary Alice Carfi,14
+Cannon,1-1 Westside,State Senate,17,Republican,Mark Pody,53
+Cannon,2-1 Auburntown,State Senate,17,Democratic,Mary Alice Carfi,6
+Cannon,2-1 Auburntown,State Senate,17,Republican,Mark Pody,13
+Cannon,2-2 Gassaway,State Senate,17,Democratic,Mary Alice Carfi,5
+Cannon,2-2 Gassaway,State Senate,17,Republican,Mark Pody,10
+Cannon,2-3 Pleasant Ridge,State Senate,17,Democratic,Mary Alice Carfi,3
+Cannon,2-3 Pleasant Ridge,State Senate,17,Republican,Mark Pody,14
+Cannon,2-4 Short Mountain,State Senate,17,Democratic,Mary Alice Carfi,3
+Cannon,2-4 Short Mountain,State Senate,17,Republican,Mark Pody,9
+Cannon,3-2 Woodland,State Senate,17,Democratic,Mary Alice Carfi,8
+Cannon,3-2 Woodland,State Senate,17,Republican,Mark Pody,25
+Cannon,4-1 Eastside,State Senate,17,Democratic,Mary Alice Carfi,7
+Cannon,4-1 Eastside,State Senate,17,Republican,Mark Pody,26
+Cannon,4-2 Short Mountain,State Senate,17,Democratic,Mary Alice Carfi,1
+Cannon,4-2 Short Mountain,State Senate,17,Republican,Mark Pody,12
+Cannon,5-1 Woodbury,State Senate,17,Democratic,Mary Alice Carfi,13
+Cannon,5-1 Woodbury,State Senate,17,Republican,Mark Pody,26
+Clay,1 Dentons Cross Road,State Senate,17,Democratic,Mary Alice Carfi,3
+Clay,1 Dentons Cross Road,State Senate,17,Republican,Mark Pody,14
+Clay,2 Hermitage Springs,State Senate,17,Democratic,Mary Alice Carfi,1
+Clay,2 Hermitage Springs,State Senate,17,Republican,Mark Pody,18
+Clay,3 Celina,State Senate,17,Democratic,Mary Alice Carfi,19
+Clay,3 Celina,State Senate,17,Republican,Mark Pody,15
+Clay,4-1 Maple Grove,State Senate,17,Democratic,Mary Alice Carfi,5
+Clay,4-1 Maple Grove,State Senate,17,Republican,Mark Pody,9
+Clay,4-2 Butlers Landing,State Senate,17,Democratic,Mary Alice Carfi,3
+Clay,4-2 Butlers Landing,State Senate,17,Republican,Mark Pody,15
+Clay,5-1 Beech Bethany,State Senate,17,Democratic,Mary Alice Carfi,3
+Clay,5-1 Beech Bethany,State Senate,17,Republican,Mark Pody,7
+Clay,5-2 Pea Ridge,State Senate,17,Democratic,Mary Alice Carfi,10
+Clay,5-2 Pea Ridge,State Senate,17,Republican,Mark Pody,15
+DeKalb,1-1 Alexandria,State Senate,17,Democratic,Mary Alice Carfi,10
+DeKalb,1-1 Alexandria,State Senate,17,Republican,Mark Pody,13
+DeKalb,1-2 Temperence Hall,State Senate,17,Democratic,Mary Alice Carfi,1
+DeKalb,1-2 Temperence Hall,State Senate,17,Republican,Mark Pody,11
+DeKalb,1-3 Edgar Evins Park,State Senate,17,Democratic,Mary Alice Carfi,0
+DeKalb,1-3 Edgar Evins Park,State Senate,17,Republican,Mark Pody,4
+DeKalb,2-1 Liberty,State Senate,17,Democratic,Mary Alice Carfi,5
+DeKalb,2-1 Liberty,State Senate,17,Republican,Mark Pody,18
+DeKalb,2-2 Dowelltown,State Senate,17,Democratic,Mary Alice Carfi,5
+DeKalb,2-2 Dowelltown,State Senate,17,Republican,Mark Pody,3
+DeKalb,2-3 Snows Hill,State Senate,17,Democratic,Mary Alice Carfi,8
+DeKalb,2-3 Snows Hill,State Senate,17,Republican,Mark Pody,14
+DeKalb,3-1 Church of God,State Senate,17,Democratic,Mary Alice Carfi,18
+DeKalb,3-1 Church of God,State Senate,17,Republican,Mark Pody,27
+DeKalb,4-2 Rock Castle,State Senate,17,Democratic,Mary Alice Carfi,1
+DeKalb,4-2 Rock Castle,State Senate,17,Republican,Mark Pody,7
+DeKalb,4-3 Courthouse,State Senate,17,Democratic,Mary Alice Carfi,8
+DeKalb,4-3 Courthouse,State Senate,17,Republican,Mark Pody,17
+DeKalb,5-1 Johnson Chapel,State Senate,17,Democratic,Mary Alice Carfi,2
+DeKalb,5-1 Johnson Chapel,State Senate,17,Republican,Mark Pody,9
+DeKalb,5-2 County Complex,State Senate,17,Democratic,Mary Alice Carfi,14
+DeKalb,5-2 County Complex,State Senate,17,Republican,Mark Pody,14
+DeKalb,6-1 Belk,State Senate,17,Democratic,Mary Alice Carfi,5
+DeKalb,6-1 Belk,State Senate,17,Republican,Mark Pody,9
+DeKalb,6-2 Keltonburg,State Senate,17,Democratic,Mary Alice Carfi,14
+DeKalb,6-2 Keltonburg,State Senate,17,Republican,Mark Pody,7
+DeKalb,6-3 Blue Springs,State Senate,17,Democratic,Mary Alice Carfi,3
+DeKalb,6-3 Blue Springs,State Senate,17,Republican,Mark Pody,5
+DeKalb,7-1 Church of Christ,State Senate,17,Democratic,Mary Alice Carfi,17
+DeKalb,7-1 Church of Christ,State Senate,17,Republican,Mark Pody,14
+Macon,Armory,State Senate,17,Democratic,Mary Alice Carfi,2
+Macon,Armory,State Senate,17,Republican,Mark Pody,15
+Macon,Central,State Senate,17,Democratic,Mary Alice Carfi,3
+Macon,Central,State Senate,17,Republican,Mark Pody,17
+Macon,County High School,State Senate,17,Democratic,Mary Alice Carfi,1
+Macon,County High School,State Senate,17,Republican,Mark Pody,17
+Macon,County Junior High,State Senate,17,Democratic,Mary Alice Carfi,9
+Macon,County Junior High,State Senate,17,Republican,Mark Pody,20
+Macon,Cross Roads,State Senate,17,Democratic,Mary Alice Carfi,2
+Macon,Cross Roads,State Senate,17,Republican,Mark Pody,14
+Macon,Lafayette,State Senate,17,Democratic,Mary Alice Carfi,3
+Macon,Lafayette,State Senate,17,Republican,Mark Pody,22
+Macon,Red Boiling Springs,State Senate,17,Democratic,Mary Alice Carfi,21
+Macon,Red Boiling Springs,State Senate,17,Republican,Mark Pody,18
+Macon,Welcome Center,State Senate,17,Democratic,Mary Alice Carfi,3
+Macon,Welcome Center,State Senate,17,Republican,Mark Pody,15
+Macon,Westside,State Senate,17,Democratic,Mary Alice Carfi,5
+Macon,Westside,State Senate,17,Republican,Mark Pody,7
+Macon,Willette,State Senate,17,Democratic,Mary Alice Carfi,5
+Macon,Willette,State Senate,17,Republican,Mark Pody,23
+Smith,01 Defeated,State Senate,17,Democratic,Mary Alice Carfi,26
+Smith,01 Defeated,State Senate,17,Republican,Mark Pody,57
+Smith,02 Tanglewood,State Senate,17,Democratic,Mary Alice Carfi,38
+Smith,02 Tanglewood,State Senate,17,Republican,Mark Pody,43
+Smith,03 New Middleton,State Senate,17,Democratic,Mary Alice Carfi,14
+Smith,03 New Middleton,State Senate,17,Republican,Mark Pody,23
+Smith,04 Rock City,State Senate,17,Democratic,Mary Alice Carfi,15
+Smith,04 Rock City,State Senate,17,Republican,Mark Pody,36
+Smith,05 Gordonsville,State Senate,17,Democratic,Mary Alice Carfi,31
+Smith,05 Gordonsville,State Senate,17,Republican,Mark Pody,42
+Smith,06 Carthage,State Senate,17,Democratic,Mary Alice Carfi,23
+Smith,06 Carthage,State Senate,17,Republican,Mark Pody,31
+Smith,07 South Carthage,State Senate,17,Democratic,Mary Alice Carfi,21
+Smith,07 South Carthage,State Senate,17,Republican,Mark Pody,43
+Smith,08 Elmwood,State Senate,17,Democratic,Mary Alice Carfi,19
+Smith,08 Elmwood,State Senate,17,Republican,Mark Pody,25
+Wilson,1-1,State Senate,17,Democratic,Mary Alice Carfi,16
+Wilson,1-1,State Senate,17,Republican,Mark Pody,47
+Wilson,10-1,State Senate,17,Democratic,Mary Alice Carfi,40
+Wilson,10-1,State Senate,17,Republican,Mark Pody,58
+Wilson,11-1,State Senate,17,Democratic,Mary Alice Carfi,70
+Wilson,11-1,State Senate,17,Republican,Mark Pody,97
+Wilson,12-1,State Senate,17,Democratic,Mary Alice Carfi,13
+Wilson,12-1,State Senate,17,Republican,Mark Pody,55
+Wilson,12-2,State Senate,17,Democratic,Mary Alice Carfi,9
+Wilson,12-2,State Senate,17,Republican,Mark Pody,29
+Wilson,13-1,State Senate,17,Democratic,Mary Alice Carfi,26
+Wilson,13-1,State Senate,17,Republican,Mark Pody,65
+Wilson,14-1,State Senate,17,Democratic,Mary Alice Carfi,29
+Wilson,14-1,State Senate,17,Republican,Mark Pody,46
+Wilson,15-1,State Senate,17,Democratic,Mary Alice Carfi,32
+Wilson,15-1,State Senate,17,Republican,Mark Pody,70
+Wilson,16-1,State Senate,17,Democratic,Mary Alice Carfi,28
+Wilson,16-1,State Senate,17,Republican,Mark Pody,41
+Wilson,17-1,State Senate,17,Democratic,Mary Alice Carfi,32
+Wilson,17-1,State Senate,17,Republican,Mark Pody,71
+Wilson,18-1,State Senate,17,Democratic,Mary Alice Carfi,52
+Wilson,18-1,State Senate,17,Republican,Mark Pody,78
+Wilson,19-1,State Senate,17,Democratic,Mary Alice Carfi,24
+Wilson,19-1,State Senate,17,Republican,Mark Pody,59
+Wilson,2-1,State Senate,17,Democratic,Mary Alice Carfi,15
+Wilson,2-1,State Senate,17,Republican,Mark Pody,44
+Wilson,20-1,State Senate,17,Democratic,Mary Alice Carfi,23
+Wilson,20-1,State Senate,17,Republican,Mark Pody,14
+Wilson,21-1,State Senate,17,Democratic,Mary Alice Carfi,21
+Wilson,21-1,State Senate,17,Republican,Mark Pody,22
+Wilson,21-2,State Senate,17,Democratic,Mary Alice Carfi,0
+Wilson,21-2,State Senate,17,Republican,Mark Pody,21
+Wilson,22-1,State Senate,17,Democratic,Mary Alice Carfi,34
+Wilson,22-1,State Senate,17,Republican,Mark Pody,36
+Wilson,23-1,State Senate,17,Democratic,Mary Alice Carfi,33
+Wilson,23-1,State Senate,17,Republican,Mark Pody,117
+Wilson,24-1,State Senate,17,Democratic,Mary Alice Carfi,38
+Wilson,24-1,State Senate,17,Republican,Mark Pody,65
+Wilson,25-1,State Senate,17,Democratic,Mary Alice Carfi,19
+Wilson,25-1,State Senate,17,Republican,Mark Pody,25
+Wilson,25-2,State Senate,17,Democratic,Mary Alice Carfi,15
+Wilson,25-2,State Senate,17,Republican,Mark Pody,32
+Wilson,3-1,State Senate,17,Democratic,Mary Alice Carfi,24
+Wilson,3-1,State Senate,17,Republican,Mark Pody,76
+Wilson,4-1,State Senate,17,Democratic,Mary Alice Carfi,19
+Wilson,4-1,State Senate,17,Republican,Mark Pody,38
+Wilson,4-2,State Senate,17,Democratic,Mary Alice Carfi,4
+Wilson,4-2,State Senate,17,Republican,Mark Pody,8
+Wilson,5-1,State Senate,17,Democratic,Mary Alice Carfi,27
+Wilson,5-1,State Senate,17,Republican,Mark Pody,72
+Wilson,6-1,State Senate,17,Democratic,Mary Alice Carfi,32
+Wilson,6-1,State Senate,17,Republican,Mark Pody,67
+Wilson,7-1,State Senate,17,Democratic,Mary Alice Carfi,6
+Wilson,7-1,State Senate,17,Republican,Mark Pody,28
+Wilson,7-2,State Senate,17,Democratic,Mary Alice Carfi,15
+Wilson,7-2,State Senate,17,Republican,Mark Pody,22
+Wilson,8-1,State Senate,17,Democratic,Mary Alice Carfi,31
+Wilson,8-1,State Senate,17,Republican,Mark Pody,59
+Wilson,9-1,State Senate,17,Democratic,Mary Alice Carfi,22
+Wilson,9-1,State Senate,17,Republican,Mark Pody,71
+Wilson,9-2,State Senate,17,Democratic,Mary Alice Carfi,5
+Wilson,9-2,State Senate,17,Republican,Mark Pody,23
+Wilson,Absentee,State Senate,17,Democratic,Mary Alice Carfi,73
+Wilson,Absentee,State Senate,17,Republican,Mark Pody,85
+Wilson,Provisional,State Senate,17,Democratic,Mary Alice Carfi,0
+Wilson,Provisional,State Senate,17,Republican,Mark Pody,0

--- a/2017/20171219__tn__special__general__county.csv
+++ b/2017/20171219__tn__special__general__county.csv
@@ -1,0 +1,13 @@
+county,office,district,party,candidate,votes
+Cannon,State Senate,17,Democratic,Mary Alice Carfi,353
+Cannon,State Senate,17,Republican,Mark Pody,467
+Clay,State Senate,17,Democratic,Mary Alice Carfi,218
+Clay,State Senate,17,Republican,Mark Pody,190
+DeKalb,State Senate,17,Democratic,Mary Alice Carfi,579
+DeKalb,State Senate,17,Republican,Mark Pody,548
+Macon,State Senate,17,Democratic,Mary Alice Carfi,238
+Macon,State Senate,17,Republican,Mark Pody,428
+Smith,State Senate,17,Democratic,Mary Alice Carfi,733
+Smith,State Senate,17,Republican,Mark Pody,716
+Wilson,State Senate,17,Democratic,Mary Alice Carfi,3567
+Wilson,State Senate,17,Republican,Mark Pody,3646

--- a/2017/20171219__tn__special__general__precinct.csv
+++ b/2017/20171219__tn__special__general__precinct.csv
@@ -1,0 +1,165 @@
+county,precinct,office,district,party,candidate,votes
+Cannon,1-1 Westside,State Senate,17,Democratic,Mary Alice Carfi,63
+Cannon,1-1 Westside,State Senate,17,Republican,Mark Pody,116
+Cannon,2-1 Auburntown,State Senate,17,Democratic,Mary Alice Carfi,22
+Cannon,2-1 Auburntown,State Senate,17,Republican,Mark Pody,34
+Cannon,2-2 Gassaway,State Senate,17,Democratic,Mary Alice Carfi,22
+Cannon,2-2 Gassaway,State Senate,17,Republican,Mark Pody,16
+Cannon,2-3 Pleasant Ridge,State Senate,17,Democratic,Mary Alice Carfi,34
+Cannon,2-3 Pleasant Ridge,State Senate,17,Republican,Mark Pody,43
+Cannon,2-4 Short Mountain,State Senate,17,Democratic,Mary Alice Carfi,31
+Cannon,2-4 Short Mountain,State Senate,17,Republican,Mark Pody,28
+Cannon,3-2 Woodland,State Senate,17,Democratic,Mary Alice Carfi,41
+Cannon,3-2 Woodland,State Senate,17,Republican,Mark Pody,76
+Cannon,4-1 Eastside,State Senate,17,Democratic,Mary Alice Carfi,45
+Cannon,4-1 Eastside,State Senate,17,Republican,Mark Pody,78
+Cannon,4-2 Short Mountain,State Senate,17,Democratic,Mary Alice Carfi,20
+Cannon,4-2 Short Mountain,State Senate,17,Republican,Mark Pody,17
+Cannon,5-1 Woodbury,State Senate,17,Democratic,Mary Alice Carfi,75
+Cannon,5-1 Woodbury,State Senate,17,Republican,Mark Pody,59
+Clay,1 Dentons Cross Road,State Senate,17,Democratic,Mary Alice Carfi,24
+Clay,1 Dentons Cross Road,State Senate,17,Republican,Mark Pody,45
+Clay,2 Hermitage Springs,State Senate,17,Democratic,Mary Alice Carfi,32
+Clay,2 Hermitage Springs,State Senate,17,Republican,Mark Pody,38
+Clay,3 Celina,State Senate,17,Democratic,Mary Alice Carfi,79
+Clay,3 Celina,State Senate,17,Republican,Mark Pody,35
+Clay,4-1 Maple Grove,State Senate,17,Democratic,Mary Alice Carfi,5
+Clay,4-1 Maple Grove,State Senate,17,Republican,Mark Pody,10
+Clay,4-2 Butlers Landing,State Senate,17,Democratic,Mary Alice Carfi,21
+Clay,4-2 Butlers Landing,State Senate,17,Republican,Mark Pody,26
+Clay,5-1 Beech Bethany,State Senate,17,Democratic,Mary Alice Carfi,23
+Clay,5-1 Beech Bethany,State Senate,17,Republican,Mark Pody,13
+Clay,5-2 Pea Ridge,State Senate,17,Democratic,Mary Alice Carfi,34
+Clay,5-2 Pea Ridge,State Senate,17,Republican,Mark Pody,23
+DeKalb,1-1 Alexandria,State Senate,17,Democratic,Mary Alice Carfi,55
+DeKalb,1-1 Alexandria,State Senate,17,Republican,Mark Pody,49
+DeKalb,1-2 Temperence Hall,State Senate,17,Democratic,Mary Alice Carfi,14
+DeKalb,1-2 Temperence Hall,State Senate,17,Republican,Mark Pody,19
+DeKalb,1-3 Edgar Evins Park,State Senate,17,Democratic,Mary Alice Carfi,1
+DeKalb,1-3 Edgar Evins Park,State Senate,17,Republican,Mark Pody,3
+DeKalb,2-1 Liberty,State Senate,17,Democratic,Mary Alice Carfi,19
+DeKalb,2-1 Liberty,State Senate,17,Republican,Mark Pody,52
+DeKalb,2-2 Dowelltown,State Senate,17,Democratic,Mary Alice Carfi,36
+DeKalb,2-2 Dowelltown,State Senate,17,Republican,Mark Pody,27
+DeKalb,2-3 Snows Hill,State Senate,17,Democratic,Mary Alice Carfi,45
+DeKalb,2-3 Snows Hill,State Senate,17,Republican,Mark Pody,32
+DeKalb,3-1 Church of God,State Senate,17,Democratic,Mary Alice Carfi,89
+DeKalb,3-1 Church of God,State Senate,17,Republican,Mark Pody,94
+DeKalb,4-2 Rock Castle,State Senate,17,Democratic,Mary Alice Carfi,8
+DeKalb,4-2 Rock Castle,State Senate,17,Republican,Mark Pody,14
+DeKalb,4-3 Courthouse,State Senate,17,Democratic,Mary Alice Carfi,91
+DeKalb,4-3 Courthouse,State Senate,17,Republican,Mark Pody,47
+DeKalb,5-1 Johnson Chapel,State Senate,17,Democratic,Mary Alice Carfi,11
+DeKalb,5-1 Johnson Chapel,State Senate,17,Republican,Mark Pody,28
+DeKalb,5-2 County Complex,State Senate,17,Democratic,Mary Alice Carfi,62
+DeKalb,5-2 County Complex,State Senate,17,Republican,Mark Pody,60
+DeKalb,6-1 Belk,State Senate,17,Democratic,Mary Alice Carfi,12
+DeKalb,6-1 Belk,State Senate,17,Republican,Mark Pody,27
+DeKalb,6-2 Keltonburg,State Senate,17,Democratic,Mary Alice Carfi,31
+DeKalb,6-2 Keltonburg,State Senate,17,Republican,Mark Pody,19
+DeKalb,6-3 Blue Springs,State Senate,17,Democratic,Mary Alice Carfi,15
+DeKalb,6-3 Blue Springs,State Senate,17,Republican,Mark Pody,31
+DeKalb,7-1 Church of Christ,State Senate,17,Democratic,Mary Alice Carfi,90
+DeKalb,7-1 Church of Christ,State Senate,17,Republican,Mark Pody,46
+Macon,Armory,State Senate,17,Democratic,Mary Alice Carfi,27
+Macon,Armory,State Senate,17,Republican,Mark Pody,54
+Macon,Central,State Senate,17,Democratic,Mary Alice Carfi,23
+Macon,Central,State Senate,17,Republican,Mark Pody,34
+Macon,County High School,State Senate,17,Democratic,Mary Alice Carfi,28
+Macon,County High School,State Senate,17,Republican,Mark Pody,35
+Macon,County Junior High,State Senate,17,Democratic,Mary Alice Carfi,21
+Macon,County Junior High,State Senate,17,Republican,Mark Pody,48
+Macon,Cross Roads,State Senate,17,Democratic,Mary Alice Carfi,16
+Macon,Cross Roads,State Senate,17,Republican,Mark Pody,30
+Macon,Lafayette,State Senate,17,Democratic,Mary Alice Carfi,13
+Macon,Lafayette,State Senate,17,Republican,Mark Pody,38
+Macon,Red Boiling Springs,State Senate,17,Democratic,Mary Alice Carfi,40
+Macon,Red Boiling Springs,State Senate,17,Republican,Mark Pody,31
+Macon,Welcome Center,State Senate,17,Democratic,Mary Alice Carfi,21
+Macon,Welcome Center,State Senate,17,Republican,Mark Pody,60
+Macon,Westside,State Senate,17,Democratic,Mary Alice Carfi,29
+Macon,Westside,State Senate,17,Republican,Mark Pody,24
+Macon,Willette,State Senate,17,Democratic,Mary Alice Carfi,20
+Macon,Willette,State Senate,17,Republican,Mark Pody,74
+Smith,01 Defeated,State Senate,17,Democratic,Mary Alice Carfi,76
+Smith,01 Defeated,State Senate,17,Republican,Mark Pody,122
+Smith,02 Tanglewood,State Senate,17,Democratic,Mary Alice Carfi,145
+Smith,02 Tanglewood,State Senate,17,Republican,Mark Pody,109
+Smith,03 New Middleton,State Senate,17,Democratic,Mary Alice Carfi,93
+Smith,03 New Middleton,State Senate,17,Republican,Mark Pody,106
+Smith,04 Rock City,State Senate,17,Democratic,Mary Alice Carfi,48
+Smith,04 Rock City,State Senate,17,Republican,Mark Pody,81
+Smith,05 Gordonsville,State Senate,17,Democratic,Mary Alice Carfi,105
+Smith,05 Gordonsville,State Senate,17,Republican,Mark Pody,98
+Smith,06 Carthage,State Senate,17,Democratic,Mary Alice Carfi,113
+Smith,06 Carthage,State Senate,17,Republican,Mark Pody,63
+Smith,07 South Carthage,State Senate,17,Democratic,Mary Alice Carfi,74
+Smith,07 South Carthage,State Senate,17,Republican,Mark Pody,76
+Smith,08 Elmwood,State Senate,17,Democratic,Mary Alice Carfi,79
+Smith,08 Elmwood,State Senate,17,Republican,Mark Pody,61
+Wilson,1-1,State Senate,17,Democratic,Mary Alice Carfi,199
+Wilson,1-1,State Senate,17,Republican,Mark Pody,99
+Wilson,10-1,State Senate,17,Democratic,Mary Alice Carfi,168
+Wilson,10-1,State Senate,17,Republican,Mark Pody,143
+Wilson,11-1,State Senate,17,Democratic,Mary Alice Carfi,306
+Wilson,11-1,State Senate,17,Republican,Mark Pody,166
+Wilson,12-1,State Senate,17,Democratic,Mary Alice Carfi,68
+Wilson,12-1,State Senate,17,Republican,Mark Pody,108
+Wilson,12-2,State Senate,17,Democratic,Mary Alice Carfi,55
+Wilson,12-2,State Senate,17,Republican,Mark Pody,92
+Wilson,13-1,State Senate,17,Democratic,Mary Alice Carfi,127
+Wilson,13-1,State Senate,17,Republican,Mark Pody,126
+Wilson,14-1,State Senate,17,Democratic,Mary Alice Carfi,135
+Wilson,14-1,State Senate,17,Republican,Mark Pody,104
+Wilson,15-1,State Senate,17,Democratic,Mary Alice Carfi,85
+Wilson,15-1,State Senate,17,Republican,Mark Pody,157
+Wilson,16-1,State Senate,17,Democratic,Mary Alice Carfi,128
+Wilson,16-1,State Senate,17,Republican,Mark Pody,77
+Wilson,17-1,State Senate,17,Democratic,Mary Alice Carfi,138
+Wilson,17-1,State Senate,17,Republican,Mark Pody,228
+Wilson,18-1,State Senate,17,Democratic,Mary Alice Carfi,200
+Wilson,18-1,State Senate,17,Republican,Mark Pody,149
+Wilson,19-1,State Senate,17,Democratic,Mary Alice Carfi,114
+Wilson,19-1,State Senate,17,Republican,Mark Pody,136
+Wilson,2-1,State Senate,17,Democratic,Mary Alice Carfi,129
+Wilson,2-1,State Senate,17,Republican,Mark Pody,87
+Wilson,20-1,State Senate,17,Democratic,Mary Alice Carfi,83
+Wilson,20-1,State Senate,17,Republican,Mark Pody,33
+Wilson,21-1,State Senate,17,Democratic,Mary Alice Carfi,52
+Wilson,21-1,State Senate,17,Republican,Mark Pody,38
+Wilson,21-2,State Senate,17,Democratic,Mary Alice Carfi,13
+Wilson,21-2,State Senate,17,Republican,Mark Pody,49
+Wilson,22-1,State Senate,17,Democratic,Mary Alice Carfi,128
+Wilson,22-1,State Senate,17,Republican,Mark Pody,106
+Wilson,23-1,State Senate,17,Democratic,Mary Alice Carfi,187
+Wilson,23-1,State Senate,17,Republican,Mark Pody,287
+Wilson,24-1,State Senate,17,Democratic,Mary Alice Carfi,136
+Wilson,24-1,State Senate,17,Republican,Mark Pody,116
+Wilson,25-1,State Senate,17,Democratic,Mary Alice Carfi,79
+Wilson,25-1,State Senate,17,Republican,Mark Pody,54
+Wilson,25-2,State Senate,17,Democratic,Mary Alice Carfi,70
+Wilson,25-2,State Senate,17,Republican,Mark Pody,126
+Wilson,3-1,State Senate,17,Democratic,Mary Alice Carfi,139
+Wilson,3-1,State Senate,17,Republican,Mark Pody,140
+Wilson,4-1,State Senate,17,Democratic,Mary Alice Carfi,87
+Wilson,4-1,State Senate,17,Republican,Mark Pody,108
+Wilson,4-2,State Senate,17,Democratic,Mary Alice Carfi,14
+Wilson,4-2,State Senate,17,Republican,Mark Pody,20
+Wilson,5-1,State Senate,17,Democratic,Mary Alice Carfi,141
+Wilson,5-1,State Senate,17,Republican,Mark Pody,205
+Wilson,6-1,State Senate,17,Democratic,Mary Alice Carfi,101
+Wilson,6-1,State Senate,17,Republican,Mark Pody,126
+Wilson,7-1,State Senate,17,Democratic,Mary Alice Carfi,38
+Wilson,7-1,State Senate,17,Republican,Mark Pody,76
+Wilson,7-2,State Senate,17,Democratic,Mary Alice Carfi,64
+Wilson,7-2,State Senate,17,Republican,Mark Pody,74
+Wilson,8-1,State Senate,17,Democratic,Mary Alice Carfi,188
+Wilson,8-1,State Senate,17,Republican,Mark Pody,148
+Wilson,9-1,State Senate,17,Democratic,Mary Alice Carfi,84
+Wilson,9-1,State Senate,17,Republican,Mark Pody,121
+Wilson,9-2,State Senate,17,Democratic,Mary Alice Carfi,21
+Wilson,9-2,State Senate,17,Republican,Mark Pody,56
+Wilson,Absentee,State Senate,17,Democratic,Mary Alice Carfi,84
+Wilson,Absentee,State Senate,17,Republican,Mark Pody,86
+Wilson,Provisional,State Senate,17,Democratic,Mary Alice Carfi,6
+Wilson,Provisional,State Senate,17,Republican,Mark Pody,5

--- a/cleaning/tn_2017_specials_parser.py
+++ b/cleaning/tn_2017_specials_parser.py
@@ -1,0 +1,369 @@
+"""
+Parser for the 2017 Tennessee special elections, producing OpenElections CSVs
+(county + precinct) for all four 2017 specials linked from
+https://sos.tn.gov/elections/results#2017:
+
+  20170427__tn__special__primary  -- Apr 27 House District 95 special primary
+                                      (Republican + Democratic primaries; both
+                                      are in ONE SoS PDF, merged with a party
+                                      column)
+  20170615__tn__special__general  -- Jun 15 House District 95 special general
+  20171107__tn__special__primary  -- Nov 7  Senate District 17 special primary
+                                      (Republican + Democratic primaries; both
+                                      are in ONE SoS PDF, merged with a party
+                                      column)
+  20171219__tn__special__general  -- Dec 19 Senate District 17 special general
+
+Sources are by-precinct PDFs on the OLDER s3 bucket
+https://sos-tn-gov-files.s3.amazonaws.com/ . For each special, the primary's
+Republican AND Democratic primaries are published together in a single PDF (as
+consecutive "Special Republican Primary" / "Special Democratic Primary" sections)
+and merged here with a `party` column; each general is a single PDF section.
+
+All four use the multi-county "Layout B" format (same as the 2018/2019/2023
+specials):
+  Banner:     State of Tennessee
+  Date:       <Month Day, Year>
+  Section:    Special Republican Primary | Special Democratic Primary |
+              Special State General
+  Office:     Tennessee Senate District N [(unexpired term)]
+              Tennessee House of Representatives District N [(unexpired term)]
+  Candidates: N. Name            (primaries; party from the section header)
+              N. Name - Party    (generals; party from the suffix)
+  Column hdr: 1 2 3 ... N        (present only when >1 candidate)
+  <County> County
+   Precincts:
+    <precinct name>  v1 v2 ... vN      (votes may contain commas, e.g. 1,512)
+   County Totals:   v1 v2 ... vN
+  ...
+   DISTRICT TOTALS  v1 v2 ... vN
+
+TWO wrinkles beyond the bare Layout B parser:
+  (1) A candidate list may be laid out in TWO COLUMNS (e.g. the HD95 Republican
+      primary lists candidates 1-5 on the left and 6-7 on the right of the same
+      lines). The parser finds every "N. Name" on a candidate line (not just the
+      first) and sorts the candidates by number so vote columns align.
+  (2) A race/section may span multiple pages, and a single county may be SPLIT
+      across a page break within a race. The parser is a state machine that
+      re-reads (office, candidates) on each repeated header and treats the
+      page-break footer ("<date> Page N of M") and next-page banner
+      ("State of Tennessee") as sentinels ending the in-progress precinct block,
+      so the date line (e.g. "November 7, 2017") is not mis-parsed as a precinct
+      row -- its "7," and "2017" tokens both look like votes.
+
+Conventions (standard OpenElections office names; integer votes; full party
+names; precinct names verbatim with internal whitespace collapsed):
+  "Tennessee Senate District N [(unexpired term)]"
+                              -> "State Senate", district "N" (bare)
+  "Tennessee House of Representatives District N [(unexpired term)]"
+                              -> "State House", district "N" (bare)
+Legislative specials use a BARE district number -- the "(unexpired term)"
+suffix is for judicial/executive races, not legislative ones, so it is stripped
+(matching the 2013/2015/2018/2019/2021/2023 special convention). Party from the
+primary section header or each general candidate's ` - Party` suffix (so
+generals carry `Independent`). "Absentee"/"Provisional" pseudo-precincts are
+kept verbatim.
+
+County totals are derived by summing precinct votes per (county, office,
+district, party, candidate) and asserted against each precinct PDF's own
+"County Totals:" lines, then verified against the separate by-county PDFs.
+
+Requires `requests` (in the Pipfile) and `pdftotext` (poppler).
+"""
+
+import csv
+import os
+import re
+import subprocess
+import tempfile
+from collections import defaultdict
+
+import requests
+
+BASE = "https://sos-tn-gov-files.s3.amazonaws.com"
+
+OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "2017")
+
+COUNTY_HEADER = ["county", "office", "district", "party", "candidate", "votes"]
+PRECINCT_HEADER = ["county", "precinct", "office", "district", "party",
+                   "candidate", "votes"]
+
+SECTION_RE = re.compile(
+    r"^(Special Republican Primary|Special Democratic Primary|"
+    r"Special State General Election|Special State General|"
+    r"Republican Primary|Democratic Primary|State General)\s*$")
+OFFICE_SENATE_RE = re.compile(
+    r"^Tennessee Senate District (\d+)(?:\s*\(unexpired term\))?\s*$")
+OFFICE_HOUSE_RE = re.compile(
+    r"^Tennessee House of Representatives District (\d+)"
+    r"(?:\s*\(unexpired term\))?\s*$")
+DISTRICT_RE = re.compile(
+    r"^(.+?)\s+District\s+(\d+(?:/\d+)?)\s*(\(unexpired term\))?\s*$")
+CAND_START_RE = re.compile(r"(\d+)\.\s+")
+COUNTY_RE = re.compile(r"^([A-Z][A-Za-z .]+) County\s*$")
+PARTY_SUFFIX_RE = re.compile(
+    r"^(.+?)\s+-\s+(Republican|Democratic|Independent|Libertarian|Green|"
+    r"Constitution)\s*$")
+VOTE_RE = re.compile(r"^\d[\d,]*$")
+ALLDIGITS_RE = re.compile(r"^\d+$")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def clean(s):
+    return WHITESPACE_RE.sub(" ", str(s)).strip()
+
+
+def to_int(tok):
+    return int(tok.replace(",", ""))
+
+
+def norm_office(raw):
+    s = raw.strip()
+    m = OFFICE_SENATE_RE.match(s)
+    if m:
+        return ("State Senate", m.group(1))
+    m = OFFICE_HOUSE_RE.match(s)
+    if m:
+        return ("State House", m.group(1))
+    m = DISTRICT_RE.match(s)
+    if m:
+        office = m.group(1).strip()
+        dist = m.group(2) + (" (unexpired term)" if m.group(3) else "")
+        return (office, dist)
+    return (s, "NA")
+
+
+def split_candidate(raw, section):
+    if section in ("Special Republican Primary", "Republican Primary"):
+        return (raw.strip(), "Republican")
+    if section in ("Special Democratic Primary", "Democratic Primary"):
+        return (raw.strip(), "Democratic")
+    m = PARTY_SUFFIX_RE.match(raw.strip())
+    if m:
+        return (m.group(1).strip(), m.group(2))
+    return (raw.strip(), "")
+
+
+def parse_candidate_entries(line):
+    """Return [(num, name), ...] for every 'N. Name' on the line. Handles
+    two-column candidate lists where two candidates share a line (e.g. the
+    HD95 Republican primary: '1. ...   6. ...'). Names are the text between one
+    candidate's 'N. ' and the next candidate's 'M. ' (or end of line)."""
+    matches = list(CAND_START_RE.finditer(line))
+    entries = []
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(line)
+        name = clean(line[start:end])
+        if name:
+            entries.append((int(m.group(1)), name))
+    return entries
+
+
+def pdftotext_layout(pdf_bytes):
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        f.write(pdf_bytes)
+        path = f.name
+    try:
+        out = subprocess.run(
+            ["pdftotext", "-layout", path, "-"],
+            check=True, capture_output=True, text=True)
+        return out.stdout
+    finally:
+        os.unlink(path)
+
+
+def parse_pdf(text):
+    """Parse a Layout B by-precinct PDF (possibly multi-section, multi-race,
+    multi-page, with two-column candidate lists). Returns (precinct_rows,
+    county_totals) where precinct_rows are [county, precinct, office, district,
+    party, candidate, votes] and county_totals maps (county, office, district,
+    party, candidate) -> votes from the PDFs' own "County Totals:" lines."""
+    precinct_rows = []
+    county_totals = {}
+    section = None
+    office = None
+    district = None
+    candidates = []          # list of (num, name, party)
+    expect_office = False
+    collecting_candidates = False
+    in_precincts = False
+    current_county = None
+    for line in text.splitlines():
+        s = line.strip()
+        # Page-break sentinels: footer + next-page banner end any in-progress
+        # precinct block so the date/banner lines aren't mis-parsed as precinct
+        # rows (e.g. "November 7, 2017" -> "November" w/ votes [7, 2017]).
+        if "Page " in s and " of " in s:
+            in_precincts = False
+            continue
+        if s == "State of Tennessee":
+            in_precincts = False
+            continue
+        m = SECTION_RE.match(s)
+        if m:
+            section = s
+            office = None
+            district = None
+            candidates = []
+            expect_office = True
+            collecting_candidates = False
+            in_precincts = False
+            current_county = None
+            continue
+        if expect_office:
+            if not s:
+                continue
+            office, district = norm_office(s)
+            expect_office = False
+            collecting_candidates = True
+            continue
+        if collecting_candidates:
+            if not s:
+                continue
+            entries = parse_candidate_entries(line)
+            if entries:
+                for num, name in entries:
+                    candidates.append((num,) + split_candidate(name, section))
+                continue
+            toks = s.split()
+            if toks and all(ALLDIGITS_RE.match(t) for t in toks):
+                continue  # column-header line
+            # First non-candidate, non-column-header line starts the body:
+            # finalize the ordered candidate list (sorted by candidate number
+            # so vote columns align) and process this line as a body line.
+            candidates.sort(key=lambda c: c[0])
+            nums = [c[0] for c in candidates]
+            if nums != list(range(1, len(candidates) + 1)):
+                raise ValueError(
+                    f"non-contiguous candidate numbers {nums} for "
+                    f"{office!r} {district!r}")
+            collecting_candidates = False
+            # fall through to body handling for this line
+        # body handling
+        if not s:
+            continue
+        cm = COUNTY_RE.match(line)
+        if cm:
+            current_county = cm.group(1).strip()
+            in_precincts = False
+            continue
+        if s == "Precincts:":
+            in_precincts = True
+            continue
+        if s.startswith("County Totals:"):
+            nums_str = s[len("County Totals:"):].split()
+            if len(nums_str) == len(candidates):
+                for k, (_num, name, party) in enumerate(candidates):
+                    county_totals[(current_county, office, district, party,
+                                   name)] = to_int(nums_str[k])
+            in_precincts = False
+            continue
+        if s.startswith("DISTRICT TOTALS"):
+            in_precincts = False
+            continue
+        if in_precincts and current_county and candidates:
+            n = len(candidates)
+            tokens = line.split()
+            if len(tokens) < n + 1:
+                continue
+            vote_tokens = tokens[-n:]
+            if not all(VOTE_RE.match(t) for t in vote_tokens):
+                continue
+            precinct = clean(" ".join(tokens[:-n]))
+            for k, (_num, name, party) in enumerate(candidates):
+                precinct_rows.append([current_county, precinct, office,
+                                      district, party, name,
+                                      to_int(vote_tokens[k])])
+    return precinct_rows, county_totals
+
+
+def build(election):
+    """Build county + precinct rows for one election (which may combine
+    several PDFs). Cross-checks derived county totals against the PDFs' own
+    County Totals lines."""
+    precinct_rows = []
+    expected = {}
+    for pdf_url in election["pdfs"]:
+        resp = requests.get(pdf_url, headers={"User-Agent": "Mozilla/5.0"})
+        resp.raise_for_status()
+        text = pdftotext_layout(resp.content)
+        prows, ctotals = parse_pdf(text)
+        precinct_rows.extend(prows)
+        for k, v in ctotals.items():
+            expected[k] = v
+    derived = defaultdict(int)
+    for r in precinct_rows:
+        county, precinct, office, district, party, name, votes = r
+        derived[(county, office, district, party, name)] += votes
+    mismatches = []
+    for k, v in derived.items():
+        if k in expected and expected[k] != v:
+            mismatches.append((k, v, expected[k]))
+    for k, v in expected.items():
+        if k not in derived:
+            mismatches.append((k, "MISSING", v))
+    if mismatches:
+        detail = "\n  ".join(
+            f"{k}: derived={dv} expected={ev}" for k, dv, ev in mismatches[:20])
+        raise AssertionError(f"county-total mismatch in {election['name']}:\n  "
+                            f"{detail}")
+    county_rows = [[k[0], k[1], k[2], k[3], k[4], v]
+                   for k, v in derived.items()]
+    return county_rows, precinct_rows, derived
+
+
+def sort_key_county(row):
+    return (row[0], row[2], row[3], row[1], row[4])
+
+
+def sort_key_precinct(row):
+    return (row[0], row[1], row[2], row[3], row[4], row[5])
+
+
+def write_csv(path, header, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(rows)
+    print(f"  Wrote {path} ({len(rows)} rows)")
+
+
+ELECTIONS = [
+    {
+        "name": "20170427__tn__special__primary",
+        "pdfs": [f"{BASE}/StateTNHouse95PrimaryPrecincts.pdf"],
+    },
+    {
+        "name": "20170615__tn__special__general",
+        "pdfs": [f"{BASE}/TNH95GeneralPrecincts.pdf"],
+    },
+    {
+        "name": "20171107__tn__special__primary",
+        "pdfs": [f"{BASE}/TN%20Senate%2017%20Primary%20Precincts.pdf"],
+    },
+    {
+        "name": "20171219__tn__special__general",
+        "pdfs": [f"{BASE}/TN%20Senate%2017%20General%20Precinct.pdf"],
+    },
+]
+
+
+def main():
+    out = os.path.abspath(OUT_DIR)
+    os.makedirs(out, exist_ok=True)
+    for election in ELECTIONS:
+        print(f"--- {election['name']} ---")
+        county_rows, precinct_rows, _ = build(election)
+        county_rows.sort(key=sort_key_county)
+        precinct_rows.sort(key=sort_key_precinct)
+        print(f"  county: {len(county_rows)} rows, precinct: "
+              f"{len(precinct_rows)} rows")
+        write_csv(os.path.join(out, f"{election['name']}__county.csv"),
+                  COUNTY_HEADER, county_rows)
+        write_csv(os.path.join(out, f"{election['name']}__precinct.csv"),
+                  PRECINCT_HEADER, precinct_rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds county- and precinct-level OpenElections CSVs for all four 2017 Tennessee special elections, sourced from the TN SoS results (`https://sos.tn.gov/elections/results#2017`):

- **`20170427__tn__special__primary`** (county + precinct) — Apr 27 House District 95 special primary (Republican + Democratic primaries, published together in one SoS PDF, merged here with a party column).
- **`20170615__tn__special__general`** (county + precinct) — Jun 15 House District 95 special general.
- **`20171107__tn__special__primary`** (county + precinct) — Nov 7 Senate District 17 special primary (Republican + Democratic primaries in one SoS PDF, merged).
- **`20171219__tn__special__general`** (county + precinct) — Dec 19 Senate District 17 special general.

## Conventions

Standard OpenElections office names; integer votes; full party names; precinct names verbatim with internal whitespace collapsed:

- `Tennessee Senate District N [(unexpired term)]` → `State Senate`, `N` (bare)
- `Tennessee House of Representatives District N [(unexpired term)]` → `State House`, `N` (bare)

Legislative offices use a **bare district number** — the `(unexpired term)` suffix is for judicial/executive races, not legislative ones, so it is stripped (matching the 2013/2015/2018/2019/2021/2023 special convention). So the HD95 specials use office `State House`, district `95`; the SD17 specials use office `State Senate`, district `17`. Party from the primary section header for primaries, from each general candidate's ` - Party` suffix for generals (so generals carry `Independent`). `Absentee`/`Provisional` pseudo-precincts kept verbatim.

## Sources

All four are by-precinct PDFs on the older `https://sos-tn-gov-files.s3.amazonaws.com/` bucket:

- Apr 27 HD95 primary — `StateTNHouse95PrimaryPrecincts.pdf`
- Jun 15 HD95 general — `TNH95GeneralPrecincts.pdf`
- Nov 7 SD17 primary — `TN%20Senate%2017%20Primary%20Precincts.pdf`
- Dec 19 SD17 general — `TN%20Senate%2017%20General%20Precinct.pdf`

The by-precinct PDFs use the multi-county "Layout B" format (banner, section header, `N. Name`/`N. Name - Party` candidates, `<County> County` headers, ` Precincts:` marker, `County Totals:` per county, `DISTRICT TOTALS`). For each special, the primary's Republican AND Democratic primaries are published together in a single PDF as consecutive `Special Republican Primary` / `Special Democratic Primary` sections and merged here with a party column; each general is a single `Special State General` section.

Two structural wrinkles the parser handles:
1. **Two-column candidate lists.** The HD95 Republican primary lists its 7 candidates in two columns (1–5 left, 6–7 right of the same lines). The parser finds every `N. Name` on a candidate line and sorts by candidate number so the vote columns align.
2. **Page-break date-line mis-parse.** A race may span multiple pages and a single county may be split across a page break within a race. The parser treats the page-break footer (`<date> Page N of M`) and next-page banner (`State of Tennessee`) as sentinels ending the in-progress precinct block, so the date line (e.g. `November 7, 2017`) is not mis-parsed as a precinct row — its `7,` and `2017` tokens both match the vote regex.

## Verification

- All four data tests pass locally on all eight files: `file_format`, `missing_values`, `duplicate_entries`, `vote_breakdown_totals`.
- County totals derived by summing precinct votes, asserted against each precinct PDF's own `County Totals:` lines, and verified against the separate by-county PDFs:
  - HD95 Rep primary: Crone 58 / Horner 247 / Loynachan 134 / Marshall 682 / Patton 753 / Uhlhorn 1,017 / Vaughan 1,067
  - HD95 Dem primary: Ashworth 364
  - HD95 general: Vaughan (R) 3,099 / Ashworth (D) 1,737 / Schutt (I) 144 / Tomasik (I) 25
  - SD17 Rep primary: Pody 2,562; Dem primary: Carfi 1,283
  - SD17 general: Pody (R) 5,995 / Carfi (D) 5,688

Parser: `cleaning/tn_2017_specials_parser.py` (requires `requests` + `pdftotext`/poppler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)